### PR TITLE
feat: implement bare-bones tags

### DIFF
--- a/docs/superpowers/plans/2026-06-16-seed-script-plan.md
+++ b/docs/superpowers/plans/2026-06-16-seed-script-plan.md
@@ -1,0 +1,199 @@
+# Seed Script Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-LEVEL: Inline execution in this session. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `scripts/seed.ts` を完成させ、ローカル DB に user / tags / bookmarks / bookmark_tags のダミーデータを流せるようにする。
+
+**Architecture:** Better Auth の `signUpEmail` API でユーザーを作り、残りのテーブルは `drizzle-seed` で生成する。実行前に `drizzle-seed/reset` で対象テーブルを空にする。
+
+**Tech Stack:** TypeScript, drizzle-orm, drizzle-seed, better-auth, libsql, tsx, dotenvx
+
+---
+
+## Task 1: 環境変数と実行スクリプトを整える
+
+**Files:**
+
+- Modify: `.env.development`
+- Modify: `package.json`
+
+- [ ] **Step 1: `.env.development` に `BETTER_AUTH_SECRET` を追加する**
+
+```text
+DATABASE_URL=http://127.0.0.1:8080
+BETTER_AUTH_SECRET=dev-secret-min-32-chars-for-local-only
+```
+
+- [ ] **Step 2: `package.json` に `db:seed` スクリプトを追加する**
+
+```json
+"db:seed": "pnpm dotenvx run -f .env.development -- pnpm tsx scripts/seed.ts"
+```
+
+---
+
+## Task 2: `scripts/seed.ts` を実装する
+
+**Files:**
+
+- Modify: `scripts/seed.ts`
+
+- [ ] **Step 1: 必要な import を追加する**
+
+```ts
+import { reset, seed } from 'drizzle-seed'
+
+import { auth, db } from '../auth'
+import * as authSchema from '../src/db/schema/auth-schema'
+import { bookmarkTagsTable } from '../src/db/schema/bookmark-tag'
+import { bookmarkTable } from '../src/db/schema/bookmark'
+import { tagsTable } from '../src/db/schema/tag'
+```
+
+- [ ] **Step 2: スキーマ定数とターゲットユーザーを定義する**
+
+```ts
+const fullSchema = {
+  ...authSchema,
+  bookmark: bookmarkTable,
+  bookmarkTags: bookmarkTagsTable,
+  tags: tagsTable
+}
+
+const TARGET = {
+  email: 'koralle@example.com',
+  name: 'koralle',
+  password: 'password'
+} as const
+
+const COUNTS = {
+  tags: 500,
+  bookmarks: 200,
+  bookmarkTags: 300
+} as const
+```
+
+- [ ] **Step 3: 一意な名前・URL リストを作るヘルパーを定義する**
+
+```ts
+const range = (length: number) => Array.from({ length }, (_, i) => i)
+
+const tagNames = range(COUNTS.tags).map((i) => `tag-${String(i + 1).padStart(3, '0')}`)
+const bookmarkUrls = range(COUNTS.bookmarks).map((i) => `https://example.com/bookmark/${i + 1}`)
+```
+
+- [ ] **Step 4: メイン処理を書く**
+
+```ts
+const main = async (): Promise<void> => {
+  console.log('Resetting database...')
+  await reset(db, fullSchema)
+
+  console.log('Creating user...')
+  const { user } = await auth.api.signUpEmail({
+    body: {
+      email: TARGET.email,
+      password: TARGET.password,
+      name: TARGET.name
+    }
+  })
+
+  if (!user) {
+    throw new Error('User creation failed')
+  }
+
+  console.log(`User created: ${user.id} (${user.email})`)
+
+  console.log('Seeding tags, bookmarks, and bookmark_tags...')
+  await seed(db, { tagsTable, bookmarkTable, bookmarkTagsTable }).refine((funcs) => ({
+    tagsTable: {
+      count: COUNTS.tags,
+      columns: {
+        userId: funcs.valuesFromArray({ values: [user.id] }),
+        name: funcs.valuesFromArray({ values: tagNames, isUnique: true })
+      }
+    },
+    bookmarkTable: {
+      count: COUNTS.bookmarks,
+      columns: {
+        id: funcs.uuid(),
+        userId: funcs.valuesFromArray({ values: [user.id] }),
+        url: funcs.valuesFromArray({ values: bookmarkUrls, isUnique: true }),
+        title: funcs.string({ isUnique: false })
+      }
+    },
+    bookmarkTagsTable: {
+      count: COUNTS.bookmarkTags
+    }
+  }))
+
+  console.log('Seed complete.')
+}
+
+main().catch((error) => {
+  console.error('Seed failed:', error)
+  process.exit(1)
+})
+```
+
+---
+
+## Task 3: 動作確認する
+
+**Files:**
+
+- N/A
+
+- [ ] **Step 1: ローカル DB サーバーが起動していることを確認する**
+
+```bash
+# 例: turso dev
+```
+
+- [ ] **Step 2: シードスクリプトを実行する**
+
+```bash
+pnpm run db:seed
+```
+
+- [ ] **Step 3: 期待される出力を確認する**
+
+```text
+Resetting database...
+Creating user...
+User created: <uuid> (koralle@example.com)
+Seeding tags, bookmarks, and bookmark_tags...
+Seed complete.
+```
+
+- [ ] **Step 4: エラーが出た場合は `bookmarkTagsTable` を直接 INSERT するフォールバックに切り替える**
+
+```ts
+const tagRows = await db.select({ id: tagsTable.id }).from(tagsTable).limit(COUNTS.bookmarkTags)
+const bookmarkRows = await db
+  .select({ id: bookmarkTable.id })
+  .from(bookmarkTable)
+  .limit(COUNTS.bookmarkTags)
+
+const bookmarkTagValues = tagRows.map((tag, i) => ({
+  bookmarkId: bookmarkRows[i % bookmarkRows.length].id,
+  tagId: tag.id
+}))
+
+await db.insert(bookmarkTagsTable).values(bookmarkTagValues)
+```
+
+---
+
+## Task 5: コミットする
+
+**Files:**
+
+- N/A
+
+- [ ] **Step 1: 変更をステージしてコミットする**
+
+```bash
+git add scripts/seed.ts package.json docs/superpowers/
+git commit -m "feat: add local DB seed script for user, tags, bookmarks and bookmark_tags"
+```

--- a/docs/superpowers/specs/2026-06-16-seed-script-design.md
+++ b/docs/superpowers/specs/2026-06-16-seed-script-design.md
@@ -1,0 +1,34 @@
+# Seed Script Design
+
+## Goal
+
+`scripts/seed.ts` を完成させ、ローカルの SQLite/libsql DB に開発用ダミーデータを流せるようにする。
+
+## Scope
+
+- 1 ユーザーの作成（`koralle@example.com` / `password` / `koralle`）
+- タグ 500 件
+- ブックマーク 200 件
+- ブックマークとタグの中間テーブル 300 件
+
+## Constraints
+
+- 実行のたびに既存データを削除して作り直す。
+- `user` テーブルに `password` カラムがないため、Better Auth の `auth.api.signUpEmail` を使ってアカウントも含めて作成する。
+- `drizzle-seed` を使ってタグ・ブックマーク・中間テーブルを生成する。
+
+## Data Flow
+
+1. `reset(db, fullSchema)` で `users`, `sessions`, `accounts`, `verifications`, `tags`, `bookmarks`, `bookmark_tags` を空にする。
+2. `auth.api.signUpEmail({ body: TARGET })` でユーザーを作成する。
+3. `seed(db, { tagsTable, bookmarkTable, bookmarkTagsTable })` を `refine` し、作成したユーザーの ID を `userId` に固定して生成する。
+
+## Environment
+
+- `.env.development` に `DATABASE_URL` と `BETTER_AUTH_SECRET` が必要。
+- `package.json` に `db:seed` スクリプトを追加する。
+
+## Risks
+
+- `drizzle-seed` は RC 版であり、リレーション生成が FK/unique 制約で失敗する可能性がある。
+- 失敗した場合は中間テーブルなどを直接 INSERT するフォールバックに切り替える。

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 local-db-build:
   @podman compose up -d
   @pnpm dotenvx run -f .env.development -- pnpm run migrate:dev
-  @pnpm dotenvx run -f .env.development -- pnpm tsx scripts/create-user.ts
+  @pnpm dotenvx run -f .env.development -- pnpm tsx scripts/seed.ts
 
 local-db-clean:
   @podman compose down --rmi all --volumes --remove-orphans

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'oxfmt'
 export default defineConfig({
   bracketSameLine: true,
   bracketSpacing: true,
-  ignorePatterns: ['pnpm-lock.yaml'],
+  ignorePatterns: ['pnpm-lock.yaml', 'src/routeTree.gen.ts'],
   jsxSingleQuote: true,
   semi: false,
   singleAttributePerLine: true,

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@typespec/rest": "catalog:typespec",
     "@vitejs/plugin-react": "catalog:build",
     "drizzle-kit": "catalog:database",
+    "drizzle-seed": "catalog:database",
     "lefthook": "catalog:githooks",
     "oxfmt": "catalog:format",
     "oxlint": "catalog:lint",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "vite build",
     "cf-typegen": "wrangler types",
+    "db:seed": "pnpm dotenvx run -f .env.development -- pnpm tsx scripts/seed.ts",
     "deploy": "pnpm run build && wrangler deploy",
     "dev": "pnpm vite dev --port 3000",
     "format": "oxfmt . --write",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ catalogs:
     drizzle-orm:
       specifier: 1.0.0-rc.4-273829f
       version: 1.0.0-rc.4-273829f
+    drizzle-seed:
+      specifier: 1.0.0-rc.4-ca0f029
+      version: 1.0.0-rc.4-ca0f029
   debug:
     '@tanstack/devtools-vite':
       specifier: 0.7.0
@@ -292,6 +295,9 @@ importers:
       drizzle-kit:
         specifier: catalog:database
         version: 1.0.0-rc.4-273829f
+      drizzle-seed:
+        specifier: catalog:database
+        version: 1.0.0-rc.4-ca0f029(drizzle-orm@1.0.0-rc.4-273829f(@libsql/client@0.17.3)(@tursodatabase/database-common@0.6.1)(@tursodatabase/database@0.6.1)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.3))
       lefthook:
         specifier: catalog:githooks
         version: 2.1.9
@@ -2569,6 +2575,11 @@ packages:
       zod:
         optional: true
 
+  drizzle-seed@1.0.0-rc.4-ca0f029:
+    resolution: {integrity: sha512-uK8LirYm/Tex7sFA6dHxrS+92luM7xhsrVkynsUH0J2uvezxREF9EEs62GNypEflkZ80Fvbwfj4ab7ovZq+Slw==}
+    peerDependencies:
+      drizzle-orm: '>=1.0.0-beta.2'
+
   eciesjs@0.4.18:
     resolution: {integrity: sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ==}
     engines: {bun: '>=1', deno: '>=2', node: '>=16'}
@@ -3035,6 +3046,9 @@ packages:
 
   promise-limit@2.7.0:
     resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
@@ -5199,6 +5213,11 @@ snapshots:
       valibot: 1.4.1(typescript@6.0.3)
       zod: 4.4.3
 
+  drizzle-seed@1.0.0-rc.4-ca0f029(drizzle-orm@1.0.0-rc.4-273829f(@libsql/client@0.17.3)(@tursodatabase/database-common@0.6.1)(@tursodatabase/database@0.6.1)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.3)):
+    dependencies:
+      drizzle-orm: 1.0.0-rc.4-273829f(@libsql/client@0.17.3)(@tursodatabase/database-common@0.6.1)(@tursodatabase/database@0.6.1)(valibot@1.4.1(typescript@6.0.3))(zod@4.4.3)
+      pure-rand: 6.1.0
+
   eciesjs@0.4.18:
     dependencies:
       '@ecies/ciphers': 0.2.6(@noble/ciphers@1.3.0)
@@ -5639,6 +5658,8 @@ snapshots:
   prettier@3.8.4: {}
 
   promise-limit@2.7.0: {}
+
+  pure-rand@6.1.0: {}
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,69 +8,69 @@ catalogMode: strict
 
 catalogs:
   authentication:
-    "@better-auth/drizzle-adapter": 1.6.16
+    '@better-auth/drizzle-adapter': 1.6.16
     better-auth: 1.6.16
   build:
-    "@cloudflare/vite-plugin": 1.40.2
-    "@vitejs/plugin-react": 6.0.2
-    "vite": 8.0.16
+    '@cloudflare/vite-plugin': 1.40.2
+    '@vitejs/plugin-react': 6.0.2
+    'vite': 8.0.16
   database:
-    "@libsql/client": 0.17.3
-    "@tursodatabase/database": 0.6.1
+    '@libsql/client': 0.17.3
+    '@tursodatabase/database': 0.6.1
     drizzle-orm: 1.0.0-rc.4-273829f
     drizzle-kit: 1.0.0-rc.4-273829f
     drizzle-seed: 1.0.0-rc.4-ca0f029
   debug:
-    "@tanstack/devtools-vite": 0.7.0
-    "@tanstack/react-devtools": 0.10.5
-    "@tanstack/react-query-devtools": 5.101.0
-    "@tanstack/react-router-devtools": 1.167.0
+    '@tanstack/devtools-vite': 0.7.0
+    '@tanstack/react-devtools': 0.10.5
+    '@tanstack/react-query-devtools': 5.101.0
+    '@tanstack/react-router-devtools': 1.167.0
   envvars:
-    "@dotenvx/dotenvx": 1.71.2
-    "@t3-oss/env-core": 0.13.11
+    '@dotenvx/dotenvx': 1.71.2
+    '@t3-oss/env-core': 0.13.11
   errors:
-    "@praha/error-factory": 1.4.1
-    "react-error-boundary": 6.1.2
+    '@praha/error-factory': 1.4.1
+    'react-error-boundary': 6.1.2
   form:
-    "@formisch/react": 0.5.0
+    '@formisch/react': 0.5.0
   format:
     oxfmt: 0.54.0
   framework:
-    "@tanstack/react-query": 5.101.0
-    "@tanstack/react-router": 1.170.15
-    "@tanstack/react-router-ssr-query": 1.167.1
-    "@tanstack/react-start": 1.168.25
-    "@tanstack/router-plugin": 1.168.18
+    '@tanstack/react-query': 5.101.0
+    '@tanstack/react-router': 1.170.15
+    '@tanstack/react-router-ssr-query': 1.167.1
+    '@tanstack/react-start': 1.168.25
+    '@tanstack/router-plugin': 1.168.18
   githooks:
     lefthook: 2.1.9
   lint:
     oxlint: 1.69.0
     oxlint-tsgolint: 0.23.0
   react:
-    "@types/react": 19.2.17
-    "@types/react-dom": 19.2.3
+    '@types/react': 19.2.17
+    '@types/react-dom': 19.2.3
     react: 19.2.7
     react-dom: 19.2.7
   runtime:
-    "@types/node": 25.9.3
+    '@types/node': 25.9.3
     wrangler: 4.100.0
   script:
     tsx: 4.22.4
   test:
-    "@cloudflare/vitest-pool-workers": 0.16.15
+    '@cloudflare/vitest-pool-workers': 0.16.15
     vitest: 4.1.8
   typescript:
-    "@tsconfig/strictest": 2.0.8
-    "@typescript/native-preview": 7.0.0-dev.20260611.2
+    '@tsconfig/strictest': 2.0.8
+    '@typescript/native-preview': 7.0.0-dev.20260611.2
     typescript: 6.0.3
   typespec:
-    "@typespec/compiler": 1.13.0
-    "@typespec/http": 1.13.0
-    "@typespec/openapi": 1.13.0
-    "@typespec/openapi3": 1.13.0
-    "@typespec/rest": 0.83.0
+    '@typespec/compiler': 1.13.0
+    '@typespec/http': 1.13.0
+    '@typespec/openapi': 1.13.0
+    '@typespec/openapi3': 1.13.0
+    '@typespec/rest': 0.83.0
   ui:
-    "@base-ui/react": 1.5.0
+    '@base-ui/react': 1.5.0
     lucide-react: 1.17.0
   validation:
     valibot: 1.4.1
@@ -78,19 +78,19 @@ catalogs:
 engineStrict: true
 
 minimumReleaseAgeExclude:
-  - "@better-auth/core@1.6.16"
-  - "@better-auth/drizzle-adapter@1.6.16"
-  - "@better-auth/kysely-adapter@1.6.16"
-  - "@better-auth/memory-adapter@1.6.16"
-  - "@better-auth/mongo-adapter@1.6.16"
-  - "@better-auth/prisma-adapter@1.6.16"
-  - "@better-auth/telemetry@1.6.16"
+  - '@better-auth/core@1.6.16'
+  - '@better-auth/drizzle-adapter@1.6.16'
+  - '@better-auth/kysely-adapter@1.6.16'
+  - '@better-auth/memory-adapter@1.6.16'
+  - '@better-auth/mongo-adapter@1.6.16'
+  - '@better-auth/prisma-adapter@1.6.16'
+  - '@better-auth/telemetry@1.6.16'
   - better-auth@1.6.16
 
 overrides:
-  "@babel/core>semver": 7.8.0
-  "@babel/helper-compilation-targets>semver": 7.8.0
-  "@tanstack/query-core": 5.100.11
+  '@babel/core>semver': 7.8.0
+  '@babel/helper-compilation-targets>semver': 7.8.0
+  '@tanstack/query-core': 5.100.11
   kysely: 0.28.17
   esbuild: 0.28.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,68 +8,69 @@ catalogMode: strict
 
 catalogs:
   authentication:
-    '@better-auth/drizzle-adapter': 1.6.16
+    "@better-auth/drizzle-adapter": 1.6.16
     better-auth: 1.6.16
   build:
-    '@cloudflare/vite-plugin': 1.40.2
-    '@vitejs/plugin-react': 6.0.2
-    'vite': 8.0.16
+    "@cloudflare/vite-plugin": 1.40.2
+    "@vitejs/plugin-react": 6.0.2
+    "vite": 8.0.16
   database:
-    '@libsql/client': 0.17.3
-    '@tursodatabase/database': 0.6.1
+    "@libsql/client": 0.17.3
+    "@tursodatabase/database": 0.6.1
     drizzle-orm: 1.0.0-rc.4-273829f
     drizzle-kit: 1.0.0-rc.4-273829f
+    drizzle-seed: 1.0.0-rc.4-ca0f029
   debug:
-    '@tanstack/devtools-vite': 0.7.0
-    '@tanstack/react-devtools': 0.10.5
-    '@tanstack/react-query-devtools': 5.101.0
-    '@tanstack/react-router-devtools': 1.167.0
+    "@tanstack/devtools-vite": 0.7.0
+    "@tanstack/react-devtools": 0.10.5
+    "@tanstack/react-query-devtools": 5.101.0
+    "@tanstack/react-router-devtools": 1.167.0
   envvars:
-    '@dotenvx/dotenvx': 1.71.2
-    '@t3-oss/env-core': 0.13.11
+    "@dotenvx/dotenvx": 1.71.2
+    "@t3-oss/env-core": 0.13.11
   errors:
-    '@praha/error-factory': 1.4.1
-    'react-error-boundary': 6.1.2
+    "@praha/error-factory": 1.4.1
+    "react-error-boundary": 6.1.2
   form:
-    '@formisch/react': 0.5.0
+    "@formisch/react": 0.5.0
   format:
     oxfmt: 0.54.0
   framework:
-    '@tanstack/react-query': 5.101.0
-    '@tanstack/react-router': 1.170.15
-    '@tanstack/react-router-ssr-query': 1.167.1
-    '@tanstack/react-start': 1.168.25
-    '@tanstack/router-plugin': 1.168.18
+    "@tanstack/react-query": 5.101.0
+    "@tanstack/react-router": 1.170.15
+    "@tanstack/react-router-ssr-query": 1.167.1
+    "@tanstack/react-start": 1.168.25
+    "@tanstack/router-plugin": 1.168.18
   githooks:
     lefthook: 2.1.9
   lint:
     oxlint: 1.69.0
     oxlint-tsgolint: 0.23.0
   react:
-    '@types/react': 19.2.17
-    '@types/react-dom': 19.2.3
+    "@types/react": 19.2.17
+    "@types/react-dom": 19.2.3
     react: 19.2.7
     react-dom: 19.2.7
   runtime:
-    '@types/node': 25.9.3
+    "@types/node": 25.9.3
     wrangler: 4.100.0
   script:
     tsx: 4.22.4
   test:
-    '@cloudflare/vitest-pool-workers': 0.16.15
+    "@cloudflare/vitest-pool-workers": 0.16.15
     vitest: 4.1.8
   typescript:
-    '@tsconfig/strictest': 2.0.8
-    '@typescript/native-preview': 7.0.0-dev.20260611.2
+    "@tsconfig/strictest": 2.0.8
+    "@typescript/native-preview": 7.0.0-dev.20260611.2
     typescript: 6.0.3
   typespec:
-    '@typespec/compiler': 1.13.0
-    '@typespec/http': 1.13.0
-    '@typespec/openapi': 1.13.0
-    '@typespec/openapi3': 1.13.0
-    '@typespec/rest': 0.83.0
+    "@typespec/compiler": 1.13.0
+    "@typespec/http": 1.13.0
+    "@typespec/openapi": 1.13.0
+    "@typespec/openapi3": 1.13.0
+    "@typespec/rest": 0.83.0
   ui:
-    '@base-ui/react': 1.5.0
+    "@base-ui/react": 1.5.0
     lucide-react: 1.17.0
   validation:
     valibot: 1.4.1
@@ -77,19 +78,19 @@ catalogs:
 engineStrict: true
 
 minimumReleaseAgeExclude:
-  - '@better-auth/core@1.6.16'
-  - '@better-auth/drizzle-adapter@1.6.16'
-  - '@better-auth/kysely-adapter@1.6.16'
-  - '@better-auth/memory-adapter@1.6.16'
-  - '@better-auth/mongo-adapter@1.6.16'
-  - '@better-auth/prisma-adapter@1.6.16'
-  - '@better-auth/telemetry@1.6.16'
+  - "@better-auth/core@1.6.16"
+  - "@better-auth/drizzle-adapter@1.6.16"
+  - "@better-auth/kysely-adapter@1.6.16"
+  - "@better-auth/memory-adapter@1.6.16"
+  - "@better-auth/mongo-adapter@1.6.16"
+  - "@better-auth/prisma-adapter@1.6.16"
+  - "@better-auth/telemetry@1.6.16"
   - better-auth@1.6.16
 
 overrides:
-  '@babel/core>semver': 7.8.0
-  '@babel/helper-compilation-targets>semver': 7.8.0
-  '@tanstack/query-core': 5.100.11
+  "@babel/core>semver": 7.8.0
+  "@babel/helper-compilation-targets>semver": 7.8.0
+  "@tanstack/query-core": 5.100.11
   kysely: 0.28.17
   esbuild: 0.28.1
 

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,88 @@
+import { reset, seed } from 'drizzle-seed'
+
+import { auth, db } from '../auth'
+import * as authSchema from '../src/db/schema/auth-schema'
+import { bookmarkTable } from '../src/db/schema/bookmark'
+import { bookmarkTagsTable } from '../src/db/schema/bookmark-tag'
+import { tagsTable } from '../src/db/schema/tag'
+
+const fullSchema = {
+  ...authSchema,
+  bookmark: bookmarkTable,
+  bookmarkTags: bookmarkTagsTable,
+  tags: tagsTable
+}
+
+const TARGET = {
+  email: 'koralle@example.com',
+  name: 'koralle',
+  password: 'password'
+} as const
+
+const COUNTS = {
+  tags: 500,
+  bookmarks: 200,
+  bookmarkTags: 300
+} as const
+
+const EXIT_FAILURE = 1
+
+const range = (length: number): number[] => Array.from({ length }, (_, index) => index)
+
+const tagNames = range(COUNTS.tags).map((index) => `tag-${String(index + 1).padStart(3, '0')}`)
+const bookmarkUrls = range(COUNTS.bookmarks).map(
+  (index) => `https://example.com/bookmark/${index + 1}`
+)
+
+const main = async (): Promise<void> => {
+  console.log('Resetting database...')
+  await reset(db, fullSchema)
+
+  console.log('Creating user...')
+  const { user } = await auth.api.signUpEmail({
+    body: {
+      email: TARGET.email,
+      password: TARGET.password,
+      name: TARGET.name
+    }
+  })
+
+  if (!user) {
+    throw new Error('User creation failed')
+  }
+
+  console.log(`User created: ${user.id} (${user.email})`)
+
+  console.log('Seeding tags, bookmarks, and bookmark_tags...')
+
+  await seed(db, { tagsTable, bookmarkTable, bookmarkTagsTable }).refine((funcs) => ({
+    tagsTable: {
+      count: COUNTS.tags,
+      columns: {
+        userId: funcs.valuesFromArray({ values: [user.id] }),
+        name: funcs.valuesFromArray({ values: tagNames, isUnique: true })
+      }
+    },
+    bookmarkTable: {
+      count: COUNTS.bookmarks,
+      columns: {
+        id: funcs.uuid(),
+        userId: funcs.valuesFromArray({ values: [user.id] }),
+        url: funcs.valuesFromArray({ values: bookmarkUrls, isUnique: true }),
+        title: funcs.string({ isUnique: false })
+      }
+    },
+    bookmarkTagsTable: {
+      count: COUNTS.bookmarkTags
+    }
+  }))
+
+  console.log('Seed complete.')
+}
+
+try {
+  await main()
+} catch (error) {
+  console.error('Seed failed:', error)
+  process.exit(EXIT_FAILURE)
+}

--- a/src/components/error-fallback.tsx
+++ b/src/components/error-fallback.tsx
@@ -1,0 +1,9 @@
+import { FallbackProps, getErrorMessage } from 'react-error-boundary'
+
+export function ErrorFallback({ error }: FallbackProps) {
+  return (
+    <div role='alert'>
+      <p>{getErrorMessage(error)}</p>
+    </div>
+  )
+}

--- a/src/db/index.server.ts
+++ b/src/db/index.server.ts
@@ -1,3 +1,4 @@
+import { createServerOnlyFn } from '@tanstack/react-start'
 import { env } from 'cloudflare:workers'
 import { drizzle } from 'drizzle-orm/libsql'
 
@@ -17,3 +18,17 @@ export const db = drizzle({
     tags: tagsTable
   }
 })
+
+export const getDB = createServerOnlyFn(() =>
+  drizzle({
+    connection: {
+      url: env.DATABASE_URL
+    },
+    schema: {
+      ...authTables,
+      bookmark: bookmarkTable,
+      bookmarkTags: bookmarkTagsTable,
+      tags: tagsTable
+    }
+  })
+)

--- a/src/features/auth/auth-config.ts
+++ b/src/features/auth/auth-config.ts
@@ -2,7 +2,7 @@ import { drizzleAdapter } from '@better-auth/drizzle-adapter'
 import { betterAuth } from 'better-auth'
 import { admin } from 'better-auth/plugins'
 
-import { db } from '../../db'
+import { db } from '../../db/index.server'
 import * as schema from '../../db/schema/auth-schema'
 
 export const auth = betterAuth({

--- a/src/features/tags/tag-table.tsx
+++ b/src/features/tags/tag-table.tsx
@@ -1,0 +1,28 @@
+import { use } from 'react'
+
+import { TagSelectType } from '../../db/schema/tag'
+
+export function TagTable({ tagPromise }: { readonly tagPromise: Promise<TagSelectType[]> }) {
+  const tags = use(tagPromise)
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>id</th>
+          <th>名前</th>
+          <th>最終更新日</th>
+        </tr>
+      </thead>
+      <tbody>
+        {tags.map((tag) => (
+          <tr key={tag.id}>
+            <td>{tag.id}</td>
+            <td>{tag.name}</td>
+            <td>{tag.updatedAt.toString()}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/src/features/tags/tag.function.ts
+++ b/src/features/tags/tag.function.ts
@@ -1,0 +1,24 @@
+import { createServerFn } from '@tanstack/react-start'
+import { eq } from 'drizzle-orm'
+
+import { getDB } from '../../db/index.server'
+import { tagsTable } from '../../db/schema/tag'
+import { offsetPaginationQuerySchema } from '../../schemas/pagination'
+import { ensureSession } from '../auth/auth.function'
+
+export const fetchTags = createServerFn({ method: 'GET' })
+  .validator(offsetPaginationQuerySchema)
+  .handler(async (ctx) => {
+    const session = await ensureSession()
+
+    const { limit, offset } = ctx.data
+
+    const db = getDB()
+
+    return db
+      .select()
+      .from(tagsTable)
+      .where(eq(tagsTable.userId, session.user.id))
+      .limit(limit)
+      .offset(offset)
+  })

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,41 +9,41 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SignUpRouteImport } from './routes/sign-up'
 import { Route as ProtectedRouteImport } from './routes/_protected'
+import { Route as SignInIndexRouteImport } from './routes/sign-in/index'
 import { Route as ProtectedIndexRouteImport } from './routes/_protected/index'
 import { Route as ProtectedTagsIndexRouteImport } from './routes/_protected/tags/index'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
-import { Route as SignInIndexRouteImport } from './routes/sign-in/index'
-import { Route as SignUpRouteImport } from './routes/sign-up'
 
 const SignUpRoute = SignUpRouteImport.update({
   id: '/sign-up',
   path: '/sign-up',
-  getParentRoute: () => rootRouteImport
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ProtectedRoute = ProtectedRouteImport.update({
   id: '/_protected',
-  getParentRoute: () => rootRouteImport
+  getParentRoute: () => rootRouteImport,
 } as any)
 const SignInIndexRoute = SignInIndexRouteImport.update({
   id: '/sign-in/',
   path: '/sign-in/',
-  getParentRoute: () => rootRouteImport
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ProtectedIndexRoute = ProtectedIndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => ProtectedRoute
+  getParentRoute: () => ProtectedRoute,
 } as any)
 const ProtectedTagsIndexRoute = ProtectedTagsIndexRouteImport.update({
   id: '/tags/',
   path: '/tags/',
-  getParentRoute: () => ProtectedRoute
+  getParentRoute: () => ProtectedRoute,
 } as any)
 const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
   id: '/api/auth/$',
   path: '/api/auth/$',
-  getParentRoute: () => rootRouteImport
+  getParentRoute: () => rootRouteImport,
 } as any)
 
 export interface FileRoutesByFullPath {
@@ -145,24 +145,25 @@ interface ProtectedRouteChildren {
 
 const ProtectedRouteChildren: ProtectedRouteChildren = {
   ProtectedIndexRoute: ProtectedIndexRoute,
-  ProtectedTagsIndexRoute: ProtectedTagsIndexRoute
+  ProtectedTagsIndexRoute: ProtectedTagsIndexRoute,
 }
 
-const ProtectedRouteWithChildren = ProtectedRoute._addFileChildren(ProtectedRouteChildren)
+const ProtectedRouteWithChildren = ProtectedRoute._addFileChildren(
+  ProtectedRouteChildren,
+)
 
 const rootRouteChildren: RootRouteChildren = {
   ProtectedRoute: ProtectedRouteWithChildren,
   SignUpRoute: SignUpRoute,
   SignInIndexRoute: SignInIndexRoute,
-  ApiAuthSplatRoute: ApiAuthSplatRoute
+  ApiAuthSplatRoute: ApiAuthSplatRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
 
-import type { createStart } from '@tanstack/react-start'
-
 import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
     ssr: true

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,41 +9,41 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as SignUpRouteImport } from './routes/sign-up'
 import { Route as ProtectedRouteImport } from './routes/_protected'
-import { Route as SignInIndexRouteImport } from './routes/sign-in/index'
 import { Route as ProtectedIndexRouteImport } from './routes/_protected/index'
 import { Route as ProtectedTagsIndexRouteImport } from './routes/_protected/tags/index'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
+import { Route as SignInIndexRouteImport } from './routes/sign-in/index'
+import { Route as SignUpRouteImport } from './routes/sign-up'
 
 const SignUpRoute = SignUpRouteImport.update({
   id: '/sign-up',
   path: '/sign-up',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRouteImport
 } as any)
 const ProtectedRoute = ProtectedRouteImport.update({
   id: '/_protected',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRouteImport
 } as any)
 const SignInIndexRoute = SignInIndexRouteImport.update({
   id: '/sign-in/',
   path: '/sign-in/',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRouteImport
 } as any)
 const ProtectedIndexRoute = ProtectedIndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => ProtectedRoute,
+  getParentRoute: () => ProtectedRoute
 } as any)
 const ProtectedTagsIndexRoute = ProtectedTagsIndexRouteImport.update({
   id: '/tags/',
   path: '/tags/',
-  getParentRoute: () => ProtectedRoute,
+  getParentRoute: () => ProtectedRoute
 } as any)
 const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
   id: '/api/auth/$',
   path: '/api/auth/$',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRouteImport
 } as any)
 
 export interface FileRoutesByFullPath {
@@ -145,25 +145,24 @@ interface ProtectedRouteChildren {
 
 const ProtectedRouteChildren: ProtectedRouteChildren = {
   ProtectedIndexRoute: ProtectedIndexRoute,
-  ProtectedTagsIndexRoute: ProtectedTagsIndexRoute,
+  ProtectedTagsIndexRoute: ProtectedTagsIndexRoute
 }
 
-const ProtectedRouteWithChildren = ProtectedRoute._addFileChildren(
-  ProtectedRouteChildren,
-)
+const ProtectedRouteWithChildren = ProtectedRoute._addFileChildren(ProtectedRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
   ProtectedRoute: ProtectedRouteWithChildren,
   SignUpRoute: SignUpRoute,
   SignInIndexRoute: SignInIndexRoute,
-  ApiAuthSplatRoute: ApiAuthSplatRoute,
+  ApiAuthSplatRoute: ApiAuthSplatRoute
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
 
-import type { getRouter } from './router.tsx'
 import type { createStart } from '@tanstack/react-start'
+
+import type { getRouter } from './router.tsx'
 declare module '@tanstack/react-start' {
   interface Register {
     ssr: true

--- a/src/routes/_protected/tags/index.tsx
+++ b/src/routes/_protected/tags/index.tsx
@@ -1,9 +1,50 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, ErrorComponent, ErrorComponentProps } from '@tanstack/react-router'
+import { Suspense } from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
+import * as v from 'valibot'
 
-export const Route = createFileRoute('/_protected/tags/')({
-  component: RouteComponent
+import { ErrorFallback } from '../../../components/error-fallback'
+import { ensureSession } from '../../../features/auth/auth.function'
+import { TagTable } from '../../../features/tags/tag-table'
+import { fetchTags } from '../../../features/tags/tag.function'
+import { offsetPaginationQuerySchema } from '../../../schemas/pagination'
+
+const tagsSearchSchema = v.object({
+  ...offsetPaginationQuerySchema.entries
 })
 
+export const Route = createFileRoute('/_protected/tags/')({
+  validateSearch: (search) => v.parseAsync(tagsSearchSchema, search),
+  loader: async ({ location }) => {
+    const { user } = await ensureSession()
+    const search = await v.parseAsync(tagsSearchSchema, location.search)
+
+    const tagsPromise = fetchTags({ data: { limit: search.limit, offset: search.offset } })
+
+    return {
+      user,
+      tagsPromise
+    }
+  },
+  component: RouteComponent,
+  errorComponent: TagPageFallbackComponent
+})
+
+function TagPageFallbackComponent({ error }: ErrorComponentProps) {
+  return <ErrorComponent error={error} />
+}
+
 function RouteComponent() {
-  return <div>Hello Tag!</div>
+  const { user, tagsPromise } = Route.useLoaderData()
+
+  return (
+    <>
+      <h1>{user.name}のタグ一覧</h1>
+      <ErrorBoundary FallbackComponent={ErrorFallback}>
+        <Suspense fallback={<p>Loading...</p>}>
+          <TagTable tagPromise={tagsPromise} />
+        </Suspense>
+      </ErrorBoundary>
+    </>
+  )
 }

--- a/src/routes/_protected/tags/index.tsx
+++ b/src/routes/_protected/tags/index.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_protected/tags/')({
+  component: RouteComponent
+})
+
+function RouteComponent() {
+  return <div>Hello Tag!</div>
+}

--- a/src/schemas/pagination.ts
+++ b/src/schemas/pagination.ts
@@ -1,0 +1,15 @@
+import * as v from 'valibot'
+
+const numericQueryParam = v.pipe(
+  v.union([v.string(), v.number()]),
+  v.toNumber(),
+  v.integer(),
+  v.minValue(0)
+)
+
+export const offsetPaginationQuerySchema = v.object({
+  limit: v.pipe(v.optional(numericQueryParam, 50), v.brand('limit')),
+  offset: v.pipe(v.optional(numericQueryParam, 0), v.brand('offset'))
+})
+
+export type OffsetPaginationQuery = v.InferOutput<typeof offsetPaginationQuerySchema>


### PR DESCRIPTION
## 変更概要

タグ機能のベース実装を行いました。

## 主な変更

- **feat(tags):** タグ一覧ページの実装（サーバー関数 + ページネーションスキーマ）
- **refactor(db):** db/index.ts → db/index.server.ts へのリネームと getDB ラッパー追加
- **feat:** ローカルDBシードスクリプトの追加
- **chore(deps):** drizzle-seed の追加

## 確認事項

- [ ] `pnpm run build` が通ること
- [ ] `pnpm run test` が通ること
- [ ] タグ一覧ページが正しく表示されること