### PR TITLE
feat: add post-checkout hook for worktree env symlink

### DIFF
--- a/.issues/50/design.md
+++ b/.issues/50/design.md
@@ -1,0 +1,111 @@
+# post-checkout フックで .env 系ファイルの symlink を自動生成する
+
+## 目的
+
+`git worktree add` で新しい worktree を作成した際に、`.env` / `.env.development` が存在しないため手動コピーが必要になっている。
+これを post-checkout フックで自動的に symlink を貼ることで、worktree 作成直後から env ファイルが使える状態にする。
+
+## 要件
+
+- トリガー: `git worktree add` 実行時のみ（通常のブランチ切り替えでは発火させない）
+- 対象ファイル: `.env`, `.env.development`
+- symlink 元: メインリポジトリのルートにある実体ファイル
+- symlink 先: worktree のルートディレクトリ
+- 冪等性: 既に対象ファイルが存在する場合は何もしない
+- 実装: TypeScript + tsx（tsx は既存の devDependency）
+
+## 設計
+
+### 検出ロジック
+
+git worktree の判定には `git rev-parse --git-dir` と `git rev-parse --git-common-dir` の比較を用いる。
+
+- メインリポジトリ: `--git-dir` と `--git-common-dir` が同一パスを返す
+- worktree: `--git-dir` は `.git/worktrees/<name>`、`--git-common-dir` はメインの `.git` を返す
+
+### スクリプト: `scripts/symlink-env-for-worktree.ts`
+
+```typescript
+import { exec } from 'node:child_process'
+import { access, symlink } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { promisify } from 'node:util'
+
+const ENV_FILES = ['.env', '.env.development']
+
+const execAsync = promisify(exec)
+
+async function isGitWorktree(): Promise<boolean> {
+  const [gitDir, commonDir] = await Promise.all([
+    execAsync('git rev-parse --git-dir', { encoding: 'utf-8' }).then((r) => r.stdout.trim()),
+    execAsync('git rev-parse --git-common-dir', { encoding: 'utf-8' }).then((r) => r.stdout.trim())
+  ])
+  return gitDir !== commonDir
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function main(): Promise<void> {
+  if (!(await isGitWorktree())) {
+    console.log('Not a git worktree. Skipping.')
+    return
+  }
+
+  const commonDir = (
+    await execAsync('git rev-parse --git-common-dir', { encoding: 'utf-8' })
+  ).stdout.trim()
+  const mainRepoRoot = resolve(commonDir, '..')
+
+  for (const file of ENV_FILES) {
+    const source = resolve(mainRepoRoot, file)
+    const target = resolve(process.cwd(), file)
+
+    if (!(await exists(source))) {
+      console.warn(`Source ${source} not found. Skipping ${file}.`)
+      continue
+    }
+
+    if (await exists(target)) {
+      console.log(`${file} already exists. Skipping.`)
+      continue
+    }
+
+    await symlink(source, target)
+    console.log(`Symlinked ${target} -> ${source}`)
+  }
+}
+
+main()
+```
+
+### Lefthook 設定
+
+`lefthook.yaml` に `post-checkout` セクションを追加する。
+
+```yaml
+post-checkout:
+  scripts:
+    - name: Symlink env files for worktree
+      run: pnpm tsx scripts/symlink-env-for-worktree.ts
+```
+
+スクリプト内で worktree 検出を行うため、`lefthook.yaml` 側の分岐は不要。
+通常の checkout では `isGitWorktree()` が `false` を返して早期終了する。
+
+### エラーハンドリング
+
+- `git rev-parse` が git リポジトリ外で失敗した場合 → 例外が throw されスクリプトが終了する（post-checkout フックは git リポジトリ内でしか実行されないため問題ない）
+- 元ファイルが存在しない場合 → warn ログを出力してそのファイルをスキップ
+- symlink 作成失敗（権限不足など）→ 例外が throw される
+
+## 非機能要件
+
+- スクリプトは `pnpm tsx scripts/symlink-env-for-worktree.ts` で手動実行も可能
+- 出力は stdout/stderr にログを書き、Lefthook の実行ログで確認できる

--- a/.issues/50/plan.md
+++ b/.issues/50/plan.md
@@ -1,0 +1,118 @@
+# post-checkout フックで .env 系ファイルの symlink を自動生成する 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `git worktree add` 実行時に `.env` と `.env.development` をメインリポジトリから worktree へ自動 symlink する
+
+**Architecture:** TypeScript スクリプト (`scripts/symlink-env-for-worktree.ts`) を Lefthook の `post-checkout` フックから呼び出す。worktree 判定は `git rev-parse --git-dir` ≠ `git rev-parse --git-common-dir` で行う
+
+**Tech Stack:** Node.js (child_process, fs/promises), tsx, Lefthook
+
+---
+
+### Task 1: スクリプト作成 `scripts/symlink-env-for-worktree.ts`
+
+**Files:**
+
+- Create: `scripts/symlink-env-for-worktree.ts`
+
+- [ ] **Step 1: スクリプトを書く**
+
+```typescript
+import { exec } from 'node:child_process'
+import { access, symlink } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { promisify } from 'node:util'
+
+const ENV_FILES = ['.env', '.env.development']
+
+const execAsync = promisify(exec)
+
+async function isGitWorktree(): Promise<boolean> {
+  const [gitDir, commonDir] = await Promise.all([
+    execAsync('git rev-parse --git-dir', { encoding: 'utf-8' }).then((r) => r.stdout.trim()),
+    execAsync('git rev-parse --git-common-dir', { encoding: 'utf-8' }).then((r) => r.stdout.trim())
+  ])
+  return gitDir !== commonDir
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function main(): Promise<void> {
+  if (!(await isGitWorktree())) {
+    console.log('Not a git worktree. Skipping.')
+    return
+  }
+
+  const commonDir = (
+    await execAsync('git rev-parse --git-common-dir', { encoding: 'utf-8' })
+  ).stdout.trim()
+  const mainRepoRoot = resolve(commonDir, '..')
+
+  for (const file of ENV_FILES) {
+    const source = resolve(mainRepoRoot, file)
+    const target = resolve(process.cwd(), file)
+
+    if (!(await exists(source))) {
+      console.warn(`Source ${source} not found. Skipping ${file}.`)
+      continue
+    }
+
+    if (await exists(target)) {
+      console.log(`${file} already exists. Skipping.`)
+      continue
+    }
+
+    await symlink(source, target)
+    console.log(`Symlinked ${target} -> ${source}`)
+  }
+}
+
+main()
+```
+
+- [ ] **Step 2: 手動実行で動作確認（worktree ではないので早期終了する）**
+
+Run: `pnpm tsx scripts/symlink-env-for-worktree.ts`
+Expected output: `Not a git worktree. Skipping.`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/symlink-env-for-worktree.ts
+git commit -m "feat: add worktree env symlink script"
+```
+
+### Task 2: Lefthook に post-checkout フックを追加
+
+**Files:**
+
+- Modify: `lefthook.yaml`
+
+- [ ] **Step 1: lefthook.yaml の末尾に post-checkout セクションを追加**
+
+```yaml
+post-checkout:
+  scripts:
+    - name: Symlink env files for worktree
+      run: pnpm tsx scripts/symlink-env-for-worktree.ts
+```
+
+- [ ] **Step 2: 構文チェック**
+
+Run: `pnpm lefthook validate`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lefthook.yaml
+git commit -m "feat: add post-checkout hook for worktree env symlink"
+```

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -26,6 +26,14 @@ pre-commit:
               pnpm oxfmt {staged_files} --write
             stage_fixed: true
 
+          - name: Format with Oxfmt (scripts)
+            root: scripts
+            glob:
+              - '**/*.ts'
+            run: |
+              pnpm oxfmt {staged_files} --write
+            stage_fixed: true
+
           - name: Format with Oxfmt (.agents)
             root: .agents
             glob:

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -59,3 +59,8 @@ pre-commit:
               - '**/*.{ts,tsx}'
             run: |
               pnpm run typecheck
+
+post-checkout:
+  commands:
+    symlink-env-for-worktree:
+      run: pnpm tsx scripts/symlink-env-for-worktree.ts

--- a/scripts/symlink-env-for-worktree.ts
+++ b/scripts/symlink-env-for-worktree.ts
@@ -1,0 +1,64 @@
+import { exec } from "node:child_process"
+import { access, symlink } from "node:fs/promises"
+import { resolve } from "node:path"
+import { promisify } from "node:util"
+
+const ENV_FILES = [".env", ".env.development"] as const
+
+const EXIT_FAILURE = 1
+
+const execAsync = promisify(exec)
+
+async function isGitWorktree(): Promise<boolean> {
+  const [gitDir, commonDir] = await Promise.all([
+    execAsync("git rev-parse --git-dir", { encoding: "utf-8" }).then(r => r.stdout.trim()),
+    execAsync("git rev-parse --git-common-dir", { encoding: "utf-8" }).then(r => r.stdout.trim()),
+  ])
+  return gitDir !== commonDir
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function main(): Promise<void> {
+  if (!(await isGitWorktree())) {
+    console.log("Not a git worktree. Skipping.")
+    return
+  }
+
+  const commonDir = (
+    await execAsync("git rev-parse --git-common-dir", { encoding: "utf-8" })
+  ).stdout.trim()
+  const mainRepoRoot = resolve(commonDir, "..")
+
+  for (const file of ENV_FILES) {
+    const source = resolve(mainRepoRoot, file)
+    const target = resolve(process.cwd(), file)
+
+    if (!(await exists(source))) {
+      console.warn(`Source ${source} not found. Skipping ${file}.`)
+      continue
+    }
+
+    if (await exists(target)) {
+      console.log(`${file} already exists. Skipping.`)
+      continue
+    }
+
+    await symlink(source, target)
+    console.log(`Symlinked ${target} -> ${source}`)
+  }
+}
+
+try {
+  await main()
+} catch (error) {
+  console.error("Failed to symlink env files:", error)
+  process.exit(EXIT_FAILURE)
+}

--- a/scripts/symlink-env-for-worktree.ts
+++ b/scripts/symlink-env-for-worktree.ts
@@ -1,9 +1,9 @@
-import { exec } from "node:child_process"
-import { access, symlink } from "node:fs/promises"
-import { resolve } from "node:path"
-import { promisify } from "node:util"
+import { exec } from 'node:child_process'
+import { access, symlink } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { promisify } from 'node:util'
 
-const ENV_FILES = [".env", ".env.development"] as const
+const ENV_FILES = ['.env', '.env.development'] as const
 
 const EXIT_FAILURE = 1
 
@@ -11,8 +11,8 @@ const execAsync = promisify(exec)
 
 async function isGitWorktree(): Promise<boolean> {
   const [gitDir, commonDir] = await Promise.all([
-    execAsync("git rev-parse --git-dir", { encoding: "utf-8" }).then(r => r.stdout.trim()),
-    execAsync("git rev-parse --git-common-dir", { encoding: "utf-8" }).then(r => r.stdout.trim()),
+    execAsync('git rev-parse --git-dir', { encoding: 'utf-8' }).then((r) => r.stdout.trim()),
+    execAsync('git rev-parse --git-common-dir', { encoding: 'utf-8' }).then((r) => r.stdout.trim())
   ])
   return gitDir !== commonDir
 }
@@ -28,14 +28,14 @@ async function exists(filePath: string): Promise<boolean> {
 
 async function main(): Promise<void> {
   if (!(await isGitWorktree())) {
-    console.log("Not a git worktree. Skipping.")
+    console.log('Not a git worktree. Skipping.')
     return
   }
 
   const commonDir = (
-    await execAsync("git rev-parse --git-common-dir", { encoding: "utf-8" })
+    await execAsync('git rev-parse --git-common-dir', { encoding: 'utf-8' })
   ).stdout.trim()
-  const mainRepoRoot = resolve(commonDir, "..")
+  const mainRepoRoot = resolve(commonDir, '..')
 
   for (const file of ENV_FILES) {
     const source = resolve(mainRepoRoot, file)
@@ -59,6 +59,6 @@ async function main(): Promise<void> {
 try {
   await main()
 } catch (error) {
-  console.error("Failed to symlink env files:", error)
+  console.error('Failed to symlink env files:', error)
   process.exit(EXIT_FAILURE)
 }


### PR DESCRIPTION
## Summary
- post-checkout フックにより git worktree 作成時に .env / .env.development を自動 symlink
- 検出は `git rev-parse --git-dir` ≠ `--git-common-dir` で厳密に判定
- 既にファイルが存在する場合はスキップ（冪等）

## Test Plan
- [x] `pnpm tsx scripts/symlink-env-for-worktree.ts` が main repo で "Not a git worktree. Skipping." を出力することを確認
- [x] `pnpm lefthook validate` がパスすることを確認
- [x] `pnpm run test` がパスすることを確認

Closes #50