### PR TITLE
feat: add betterleaks pre-push hook for secret detection

### DIFF
--- a/.betterleaks.toml
+++ b/.betterleaks.toml
@@ -10,5 +10,5 @@ paths = [
   '''(^|/)\.vinxi(?:/.*)?$''',
   '''(^|/)\.nitro(?:/.*)?$''',
   '''(^|/)tsp-output(?:/.*)?$''',
-  '''(^|/)(?:pnpm-lock|package-lock|yarn\.lock)\.json$''',
+  '''(^|/)(?:pnpm-lock|package-lock|yarn\.lock)\.json$'''
 ]

--- a/.betterleaks.toml
+++ b/.betterleaks.toml
@@ -1,0 +1,14 @@
+[extend]
+useDefault = true
+
+[allowlist]
+paths = [
+  '''(^|/)\.agents/skills(?:/.*)?$''',
+  '''(^|/)dist(?:/.*)?$''',
+  '''(^|/)\.wrangler(?:/.*)?$''',
+  '''(^|/)\.tanstack(?:/.*)?$''',
+  '''(^|/)\.vinxi(?:/.*)?$''',
+  '''(^|/)\.nitro(?:/.*)?$''',
+  '''(^|/)tsp-output(?:/.*)?$''',
+  '''(^|/)(?:pnpm-lock|package-lock|yarn\.lock)\.json$''',
+]

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,37 @@
+name: Security
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  osv-scanner:
+    permissions:
+      actions: read
+      security-events: write
+      contents: read
+
+    uses: 'google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@c51854704019a247608d928f370c98740469d4b5'
+
+  gitleaks:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install jdx/mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          mise_toml: |
+            [tools]
+            betterleaks = "1.5.0"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run betterleaks
+        run: |
+          betterleaks git . --no-banner -v

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -68,6 +68,11 @@ pre-commit:
             run: |
               pnpm run typecheck
 
+pre-push:
+  commands:
+    betterleaks:
+      run: betterleaks git . --no-banner -v
+
 post-checkout:
   commands:
     symlink-env-for-worktree:


### PR DESCRIPTION
Closes #56

## 概要

Lefthook の pre-push フックに [Betterleaks](https://github.com/betterleaks/betterleaks) を導入し、秘密情報の漏洩を防止します。

## 変更内容

- **betterleaks のインストール** (brew)
- **`.betterleaks.toml`** - デフォルト設定を拡張。ビルド成果物やサードパーティドキュメントをスキャン対象から除外
- **`lefthook.yaml`** - `pre-push` フックを追加。push 時に `betterleaks git . --no-banner -v` を実行