### PR TITLE
feat: implement bookmark creation form and addBookmark server function

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react": "catalog:react",
     "react-dom": "catalog:react",
     "react-error-boundary": "catalog:errors",
+    "uuidv7": "catalog:uuid",
     "valibot": "catalog:validation"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,10 @@ catalogs:
     lucide-react:
       specifier: 1.21.0
       version: 1.21.0
+  uuid:
+    uuidv7:
+      specifier: 1.2.1
+      version: 1.2.1
   validation:
     valibot:
       specifier: 1.4.1
@@ -246,6 +250,9 @@ importers:
       react-error-boundary:
         specifier: catalog:errors
         version: 6.1.2(react@19.2.7)
+      uuidv7:
+        specifier: catalog:uuid
+        version: 1.2.1
       valibot:
         specifier: catalog:validation
         version: 1.4.1(typescript@6.0.3)
@@ -3358,6 +3365,10 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  uuidv7@1.2.1:
+    resolution: {integrity: sha512-4kPkK3/XTQW9Hbm4CaqfICn+kY9LJtDVEOfgsRRra/+n2Ofg4NqzRFceAkxvQ/Ud/6BpHOPzj8cirqM7TzTN5Q==}
+    hasBin: true
+
   valibot@1.4.1:
     resolution: {integrity: sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==}
     peerDependencies:
@@ -6038,6 +6049,8 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:
       react: 19.2.7
+
+  uuidv7@1.2.1: {}
 
   valibot@1.4.1(typescript@6.0.3):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,90 +8,92 @@ catalogMode: strict
 
 catalogs:
   authentication:
-    '@better-auth/drizzle-adapter': 1.6.19
+    "@better-auth/drizzle-adapter": 1.6.19
     better-auth: 1.6.19
   build:
-    '@cloudflare/vite-plugin': 1.42.0
-    '@vitejs/plugin-react': 6.0.2
-    'vite': 8.0.16
+    "@cloudflare/vite-plugin": 1.42.0
+    "@vitejs/plugin-react": 6.0.2
+    "vite": 8.0.16
   database:
-    '@libsql/client': 0.17.4
-    '@tursodatabase/database': 0.6.1
+    "@libsql/client": 0.17.4
+    "@tursodatabase/database": 0.6.1
     drizzle-orm: 1.0.0-rc.4-273829f
     drizzle-kit: 1.0.0-rc.4-273829f
     drizzle-seed: 1.0.0-rc.4-273829f
   debug:
-    '@tanstack/devtools-vite': 0.7.0
-    '@tanstack/react-devtools': 0.10.5
-    '@tanstack/react-query-devtools': 5.101.0
-    '@tanstack/react-router-devtools': 1.167.0
+    "@tanstack/devtools-vite": 0.7.0
+    "@tanstack/react-devtools": 0.10.5
+    "@tanstack/react-query-devtools": 5.101.0
+    "@tanstack/react-router-devtools": 1.167.0
   envvars:
-    '@dotenvx/dotenvx': 1.73.1
-    '@t3-oss/env-core': 0.13.11
+    "@dotenvx/dotenvx": 1.73.1
+    "@t3-oss/env-core": 0.13.11
   errors:
-    '@praha/error-factory': 1.4.1
-    'react-error-boundary': 6.1.2
+    "@praha/error-factory": 1.4.1
+    "react-error-boundary": 6.1.2
   form:
-    '@formisch/react': 0.6.0
+    "@formisch/react": 0.6.0
   format:
     oxfmt: 0.55.0
   framework:
-    '@tanstack/react-query': 5.101.0
-    '@tanstack/react-router': 1.170.16
-    '@tanstack/react-router-ssr-query': 1.167.1
-    '@tanstack/react-start': 1.168.26
-    '@tanstack/router-plugin': 1.168.18
+    "@tanstack/react-query": 5.101.0
+    "@tanstack/react-router": 1.170.16
+    "@tanstack/react-router-ssr-query": 1.167.1
+    "@tanstack/react-start": 1.168.26
+    "@tanstack/router-plugin": 1.168.18
   githooks:
     lefthook: 2.1.9
   lint:
     oxlint: 1.70.0
     oxlint-tsgolint: 0.23.0
   react:
-    '@types/react': 19.2.17
-    '@types/react-dom': 19.2.3
+    "@types/react": 19.2.17
+    "@types/react-dom": 19.2.3
     react: 19.2.7
     react-dom: 19.2.7
   runtime:
-    '@types/node': 25.9.3
+    "@types/node": 25.9.3
     wrangler: 4.102.0
   script:
     tsx: 4.22.4
   test:
-    '@cloudflare/vitest-pool-workers': 0.16.17
+    "@cloudflare/vitest-pool-workers": 0.16.17
     vitest: 4.1.9
   typescript:
-    '@tsconfig/strictest': 2.0.8
-    '@typescript/native-preview': 7.0.0-dev.20260618.1
+    "@tsconfig/strictest": 2.0.8
+    "@typescript/native-preview": 7.0.0-dev.20260618.1
     typescript: 6.0.3
   typespec:
-    '@typespec/compiler': 1.13.0
-    '@typespec/http': 1.13.0
-    '@typespec/openapi': 1.13.0
-    '@typespec/openapi3': 1.13.0
-    '@typespec/rest': 0.83.0
+    "@typespec/compiler": 1.13.0
+    "@typespec/http": 1.13.0
+    "@typespec/openapi": 1.13.0
+    "@typespec/openapi3": 1.13.0
+    "@typespec/rest": 0.83.0
   ui:
-    '@base-ui/react': 1.6.0
+    "@base-ui/react": 1.6.0
     kiso.css: 1.2.4
     lucide-react: 1.21.0
+  uuid:
+    uuidv7: 1.2.1
   validation:
     valibot: 1.4.1
 
 engineStrict: true
 
 minimumReleaseAgeExclude:
-  - '@better-auth/core@1.6.16'
-  - '@better-auth/drizzle-adapter@1.6.16'
-  - '@better-auth/kysely-adapter@1.6.16'
-  - '@better-auth/memory-adapter@1.6.16'
-  - '@better-auth/mongo-adapter@1.6.16'
-  - '@better-auth/prisma-adapter@1.6.16'
-  - '@better-auth/telemetry@1.6.16'
+  - "@better-auth/core@1.6.16"
+  - "@better-auth/drizzle-adapter@1.6.16"
+  - "@better-auth/kysely-adapter@1.6.16"
+  - "@better-auth/memory-adapter@1.6.16"
+  - "@better-auth/mongo-adapter@1.6.16"
+  - "@better-auth/prisma-adapter@1.6.16"
+  - "@better-auth/telemetry@1.6.16"
   - better-auth@1.6.16
 
 overrides:
-  '@babel/core>semver': 7.8.0
-  '@babel/helper-compilation-targets>semver': 7.8.0
-  '@tanstack/query-core': 5.100.11
+  "@babel/core>semver": 7.8.0
+  "@babel/helper-compilation-targets>semver": 7.8.0
+  "@tanstack/query-core": 5.100.11
   kysely: 0.28.17
   esbuild: 0.28.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,69 +8,69 @@ catalogMode: strict
 
 catalogs:
   authentication:
-    "@better-auth/drizzle-adapter": 1.6.19
+    '@better-auth/drizzle-adapter': 1.6.19
     better-auth: 1.6.19
   build:
-    "@cloudflare/vite-plugin": 1.42.0
-    "@vitejs/plugin-react": 6.0.2
-    "vite": 8.0.16
+    '@cloudflare/vite-plugin': 1.42.0
+    '@vitejs/plugin-react': 6.0.2
+    'vite': 8.0.16
   database:
-    "@libsql/client": 0.17.4
-    "@tursodatabase/database": 0.6.1
+    '@libsql/client': 0.17.4
+    '@tursodatabase/database': 0.6.1
     drizzle-orm: 1.0.0-rc.4-273829f
     drizzle-kit: 1.0.0-rc.4-273829f
     drizzle-seed: 1.0.0-rc.4-273829f
   debug:
-    "@tanstack/devtools-vite": 0.7.0
-    "@tanstack/react-devtools": 0.10.5
-    "@tanstack/react-query-devtools": 5.101.0
-    "@tanstack/react-router-devtools": 1.167.0
+    '@tanstack/devtools-vite': 0.7.0
+    '@tanstack/react-devtools': 0.10.5
+    '@tanstack/react-query-devtools': 5.101.0
+    '@tanstack/react-router-devtools': 1.167.0
   envvars:
-    "@dotenvx/dotenvx": 1.73.1
-    "@t3-oss/env-core": 0.13.11
+    '@dotenvx/dotenvx': 1.73.1
+    '@t3-oss/env-core': 0.13.11
   errors:
-    "@praha/error-factory": 1.4.1
-    "react-error-boundary": 6.1.2
+    '@praha/error-factory': 1.4.1
+    'react-error-boundary': 6.1.2
   form:
-    "@formisch/react": 0.6.0
+    '@formisch/react': 0.6.0
   format:
     oxfmt: 0.55.0
   framework:
-    "@tanstack/react-query": 5.101.0
-    "@tanstack/react-router": 1.170.16
-    "@tanstack/react-router-ssr-query": 1.167.1
-    "@tanstack/react-start": 1.168.26
-    "@tanstack/router-plugin": 1.168.18
+    '@tanstack/react-query': 5.101.0
+    '@tanstack/react-router': 1.170.16
+    '@tanstack/react-router-ssr-query': 1.167.1
+    '@tanstack/react-start': 1.168.26
+    '@tanstack/router-plugin': 1.168.18
   githooks:
     lefthook: 2.1.9
   lint:
     oxlint: 1.70.0
     oxlint-tsgolint: 0.23.0
   react:
-    "@types/react": 19.2.17
-    "@types/react-dom": 19.2.3
+    '@types/react': 19.2.17
+    '@types/react-dom': 19.2.3
     react: 19.2.7
     react-dom: 19.2.7
   runtime:
-    "@types/node": 25.9.3
+    '@types/node': 25.9.3
     wrangler: 4.102.0
   script:
     tsx: 4.22.4
   test:
-    "@cloudflare/vitest-pool-workers": 0.16.17
+    '@cloudflare/vitest-pool-workers': 0.16.17
     vitest: 4.1.9
   typescript:
-    "@tsconfig/strictest": 2.0.8
-    "@typescript/native-preview": 7.0.0-dev.20260618.1
+    '@tsconfig/strictest': 2.0.8
+    '@typescript/native-preview': 7.0.0-dev.20260618.1
     typescript: 6.0.3
   typespec:
-    "@typespec/compiler": 1.13.0
-    "@typespec/http": 1.13.0
-    "@typespec/openapi": 1.13.0
-    "@typespec/openapi3": 1.13.0
-    "@typespec/rest": 0.83.0
+    '@typespec/compiler': 1.13.0
+    '@typespec/http': 1.13.0
+    '@typespec/openapi': 1.13.0
+    '@typespec/openapi3': 1.13.0
+    '@typespec/rest': 0.83.0
   ui:
-    "@base-ui/react": 1.6.0
+    '@base-ui/react': 1.6.0
     kiso.css: 1.2.4
     lucide-react: 1.21.0
   uuid:
@@ -81,19 +81,19 @@ catalogs:
 engineStrict: true
 
 minimumReleaseAgeExclude:
-  - "@better-auth/core@1.6.16"
-  - "@better-auth/drizzle-adapter@1.6.16"
-  - "@better-auth/kysely-adapter@1.6.16"
-  - "@better-auth/memory-adapter@1.6.16"
-  - "@better-auth/mongo-adapter@1.6.16"
-  - "@better-auth/prisma-adapter@1.6.16"
-  - "@better-auth/telemetry@1.6.16"
+  - '@better-auth/core@1.6.16'
+  - '@better-auth/drizzle-adapter@1.6.16'
+  - '@better-auth/kysely-adapter@1.6.16'
+  - '@better-auth/memory-adapter@1.6.16'
+  - '@better-auth/mongo-adapter@1.6.16'
+  - '@better-auth/prisma-adapter@1.6.16'
+  - '@better-auth/telemetry@1.6.16'
   - better-auth@1.6.16
 
 overrides:
-  "@babel/core>semver": 7.8.0
-  "@babel/helper-compilation-targets>semver": 7.8.0
-  "@tanstack/query-core": 5.100.11
+  '@babel/core>semver': 7.8.0
+  '@babel/helper-compilation-targets>semver': 7.8.0
+  '@tanstack/query-core': 5.100.11
   kysely: 0.28.17
   esbuild: 0.28.1
 

--- a/src/features/bookmarks/bookmark.function.ts
+++ b/src/features/bookmarks/bookmark.function.ts
@@ -1,10 +1,14 @@
 import { createServerFn } from '@tanstack/react-start'
 import { eq } from 'drizzle-orm'
+import { uuidv7 } from 'uuidv7'
+import * as v from 'valibot'
 
 import { getDB } from '../../db/index.server'
-import { bookmarkTable } from '../../db/schema/bookmark'
+import { bookmarkTable, bookmarkInsertSchema } from '../../db/schema/bookmark'
 import { offsetPaginationQuerySchema } from '../../schemas/pagination'
 import { ensureSession } from '../auth/auth.function'
+
+const addBookmarkInputSchema = v.pick(bookmarkInsertSchema, ['url', 'title', 'note'])
 
 export const fetchBookmarks = createServerFn({ method: 'GET' })
   .validator(offsetPaginationQuerySchema)
@@ -21,4 +25,18 @@ export const fetchBookmarks = createServerFn({ method: 'GET' })
       .where(eq(bookmarkTable.userId, session.user.id))
       .limit(limit)
       .offset(offset)
+  })
+
+export const addBookmark = createServerFn({ method: 'POST' })
+  .validator(addBookmarkInputSchema)
+  .handler(async (ctx) => {
+    const session = await ensureSession()
+    const db = getDB()
+
+    const id = uuidv7()
+    const { url, title, note } = ctx.data
+
+    await db.insert(bookmarkTable).values({ id, url, title, note, userId: session.user.id })
+
+    return { id }
   })

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -36,4 +36,8 @@ declare module '@tanstack/react-router' {
   interface Register {
     router: ReturnType<typeof getRouter>
   }
+
+  interface HistoryState {
+    newBookmarkCreated: boolean
+  }
 }

--- a/src/routes/_protected/bookmarks/$id/index.tsx
+++ b/src/routes/_protected/bookmarks/$id/index.tsx
@@ -1,22 +1,37 @@
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute, Link, useRouterState } from '@tanstack/react-router'
+import * as v from 'valibot'
+
+const bookmarkDetailSearchSchema = v.object({
+  created: v.optional(v.boolean())
+})
 
 export const Route = createFileRoute('/_protected/bookmarks/$id/')({
+  validateSearch: bookmarkDetailSearchSchema,
   component: RouteComponent
 })
 
 function RouteComponent() {
   const { id } = Route.useParams()
 
+  const { newBookmarkCreated } = useRouterState({
+    select: (s) => s.location.state
+  })
+
   return (
     <div>
+      {newBookmarkCreated && <div role='alert'>ブックマークを登録しました</div>}
+
       <h1>ブックマーク詳細</h1>
+
       <p>ID: {id}</p>
+
       <nav>
         <Link
           to='/bookmarks/$id/edit'
           params={{ id }}>
           編集
         </Link>
+
         <Link
           to='/'
           search={{ tagMode: 'and', sort: 'newest' }}>

--- a/src/routes/_protected/bookmarks/new/index.tsx
+++ b/src/routes/_protected/bookmarks/new/index.tsx
@@ -1,33 +1,117 @@
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { Input } from '@base-ui/react'
+import { Field, getInput, useForm } from '@formisch/react'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { useActionState } from 'react'
+import * as v from 'valibot'
+
+import { addBookmark } from '../../../../features/bookmarks/bookmark.function'
 
 export const Route = createFileRoute('/_protected/bookmarks/new/')({
   component: RouteComponent
 })
 
 function RouteComponent() {
+  const navigate = useNavigate()
+
+  async function submitAction({ url, title }: { url: string; title: string }) {
+    const { id } = await addBookmark({ data: { url, title } })
+
+    await navigate({
+      to: '/bookmarks/$id',
+      params: { id },
+      state: { newBookmarkCreated: true }
+    })
+  }
+
   return (
     <div>
       <h1>ブックマーク新規作成</h1>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault()
-        }}>
-        <label>
-          URL
-          <input
-            type='url'
-            name='url'
-            aria-label='URL'
-            required
-          />
-        </label>
-        <button type='submit'>保存</button>
-      </form>
+
+      <RegisterNewBookmarkForm submitAction={submitAction} />
+
       <Link
         to='/'
         search={{ tagMode: 'and', sort: 'newest' }}>
         一覧へ戻る
       </Link>
     </div>
+  )
+}
+
+interface RegisterNewBookmarkFormProps {
+  submitAction: ({ url, title }: { url: string; title: string }) => Promise<void>
+}
+
+function RegisterNewBookmarkForm({ submitAction }: RegisterNewBookmarkFormProps) {
+  const registerNewBookmarkFormSchema = v.object({
+    url: v.pipe(v.string(), v.url()),
+    title: v.string()
+  })
+
+  const registerNewBookmarkForm = useForm({
+    initialInput: {
+      url: '',
+      title: ''
+    },
+    schema: registerNewBookmarkFormSchema
+  })
+
+  const [_, throwError, isPending] = useActionState(async () => {
+    const currentRawUrl = getInput(registerNewBookmarkForm, { path: ['url'] }) ?? ''
+    const currentRawTitle = getInput(registerNewBookmarkForm, { path: ['title'] }) ?? ''
+
+    await submitAction({ url: currentRawUrl, title: currentRawTitle })
+  }, null)
+
+  return (
+    <form action={throwError}>
+      <fieldset>
+        <legend>ブックマーク新規登録</legend>
+
+        <Field
+          of={registerNewBookmarkForm}
+          path={['url']}>
+          {(field) => (
+            <label htmlFor={field.props.name}>
+              URL
+              <Input
+                id={field.props.name}
+                value={field.input}
+                type='url'
+                onValueChange={(newValue) => {
+                  field.onChange(newValue)
+                }}
+                required
+              />
+            </label>
+          )}
+        </Field>
+
+        <Field
+          of={registerNewBookmarkForm}
+          path={['title']}>
+          {(field) => (
+            <label htmlFor={field.props.name}>
+              タイトル
+              <Input
+                id={field.props.name}
+                value={field.input}
+                type='text'
+                onValueChange={(newValue) => {
+                  field.onChange(newValue)
+                }}
+                required
+              />
+            </label>
+          )}
+        </Field>
+      </fieldset>
+
+      <button
+        type='submit'
+        disabled={isPending}>
+        {isPending ? '登録中...' : '登録'}
+      </button>
+    </form>
   )
 }


### PR DESCRIPTION
## 変更内容

- 新規ブックマーク登録フォームを実装（@formisch/react + @base-ui/react Input）
- `addBookmark` サーバー関数を追加（uuidv7 で ID 生成、valibot バリデーション、DB への保存）
- 登録成功後に詳細ページへ遷移し、成功メッセージを表示
- ルーターの HistoryState に `newBookmarkCreated` を追加