### PR TITLE
feat: implement tag creation form and addTag server function

### DIFF
--- a/.issues/59/plan.md
+++ b/.issues/59/plan.md
@@ -1,0 +1,348 @@
+# タグ新規登録画面実装 Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** ブックマーク新規登録画面と同じ構成でタグ新規登録画面を実装し、作成後はタグ詳細画面へ遷移する。
+
+**Architecture:** `features/tags/tag.function.ts` に `addTag` server function を追加し、`tags/new.tsx` を `@formisch/react` + `@base-ui/react` + `valibot` + `useActionState` で書き直す。作成成功後は新規作成する `tags/$id/index.tsx` へ遷移し、登録完了メッセージを表示する。タグの ID は auto-increment の整数なので、Drizzle の `returning` で生成された ID を取得する。
+
+**Tech Stack:** TanStack Start, Hono (server function), @formisch/react, @base-ui/react, valibot, drizzle-orm
+
+---
+
+## File Structure
+
+- **Modify:** `src/features/tags/tag.function.ts` — `addTag` server function を追加
+- **Modify:** `src/routes/_protected/tags/new.tsx` — フォームをブックマーク新規登録画面と同じ構成に書き直し
+- **Create:** `src/routes/_protected/tags/$id/index.tsx` — タグ詳細画面（ブックマーク詳細画面と同じ最小構成）
+- **Modify:** `src/router.tsx` — `HistoryState` に `newTagCreated` を追加
+- **Auto-generated:** `src/routeTree.gen.ts`
+
+---
+
+### Task 1: `addTag` server function を追加
+
+**Files:**
+
+- Modify: `src/features/tags/tag.function.ts`
+
+- [ ] **Step 1: `addTag` を追加**
+
+```typescript
+import { createServerFn } from '@tanstack/react-start'
+import { eq } from 'drizzle-orm'
+import * as v from 'valibot'
+
+import { getDB } from '../../db/index.server'
+import { tagsTable, tagInsertSchema } from '../../db/schema/tag'
+import { offsetPaginationQuerySchema } from '../../schemas/pagination'
+import { ensureSession } from '../auth/auth.function'
+
+const addTagInputSchema = v.pick(tagInsertSchema, ['name'])
+
+export const fetchTags = createServerFn({ method: 'GET' })
+  .validator(offsetPaginationQuerySchema)
+  .handler(async (ctx) => {
+    const session = await ensureSession()
+
+    const { limit, offset } = ctx.data
+
+    const db = getDB()
+
+    return db
+      .select()
+      .from(tagsTable)
+      .where(eq(tagsTable.userId, session.user.id))
+      .limit(limit)
+      .offset(offset)
+  })
+
+export const addTag = createServerFn({ method: 'POST' })
+  .validator(addTagInputSchema)
+  .handler(async (ctx) => {
+    const session = await ensureSession()
+    const db = getDB()
+
+    const { name } = ctx.data
+
+    const result = await db
+      .insert(tagsTable)
+      .values({ name, userId: session.user.id })
+      .returning({ id: tagsTable.id })
+
+    const [first] = result
+
+    if (first == null) {
+      throw new Error('Failed to insert tag')
+    }
+
+    return { id: first.id }
+  })
+```
+
+- [ ] **Step 2: 型エラーがないことを確認**
+
+Run: `pnpm run typecheck`
+Expected: PASS
+
+---
+
+### Task 2: タグ新規登録フォームを書き直す
+
+**Files:**
+
+- Modify: `src/routes/_protected/tags/new.tsx`
+
+- [ ] **Step 1: ファイル全体をブックマーク新規登録画面と同じ構成に置き換える**
+
+```tsx
+import { Input } from '@base-ui/react'
+import { Field, getInput, useForm } from '@formisch/react'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { useActionState } from 'react'
+import * as v from 'valibot'
+
+import { addTag } from '../../../features/tags/tag.function'
+
+export const Route = createFileRoute('/_protected/tags/new')({
+  component: RouteComponent
+})
+
+function RouteComponent() {
+  const navigate = useNavigate()
+
+  async function submitAction({ name }: { name: string }) {
+    const { id } = await addTag({ data: { name } })
+
+    await navigate({
+      to: '/tags/$id',
+      params: { id: String(id) },
+      state: { newTagCreated: true }
+    })
+  }
+
+  return (
+    <div>
+      <h1>タグ新規作成</h1>
+
+      <RegisterNewTagForm submitAction={submitAction} />
+
+      <Link
+        to='/tags'
+        search={{ limit: 50, offset: 0 }}>
+        一覧へ戻る
+      </Link>
+    </div>
+  )
+}
+
+interface RegisterNewTagFormProps {
+  submitAction: ({ name }: { name: string }) => Promise<void>
+}
+
+function RegisterNewTagForm({ submitAction }: RegisterNewTagFormProps) {
+  const registerNewTagFormSchema = v.object({
+    name: v.string()
+  })
+
+  const registerNewTagForm = useForm({
+    initialInput: {
+      name: ''
+    },
+    schema: registerNewTagFormSchema
+  })
+
+  const [_, throwError, isPending] = useActionState(async () => {
+    const currentRawName = getInput(registerNewTagForm, { path: ['name'] }) ?? ''
+
+    await submitAction({ name: currentRawName })
+  }, null)
+
+  return (
+    <form action={throwError}>
+      <fieldset>
+        <legend>タグ新規登録</legend>
+
+        <Field
+          of={registerNewTagForm}
+          path={['name']}>
+          {(field) => (
+            <label htmlFor={field.props.name}>
+              タグ名
+              <Input
+                id={field.props.name}
+                value={field.input}
+                type='text'
+                onValueChange={(newValue) => {
+                  field.onChange(newValue)
+                }}
+                required
+              />
+            </label>
+          )}
+        </Field>
+      </fieldset>
+
+      <button
+        type='submit'
+        disabled={isPending}>
+        {isPending ? '登録中...' : '登録'}
+      </button>
+    </form>
+  )
+}
+```
+
+- [ ] **Step 2: 型エラーがないことを確認**
+
+Run: `pnpm run typecheck`
+Expected: PASS
+
+---
+
+### Task 3: タグ詳細画面を作成
+
+**Files:**
+
+- Create: `src/routes/_protected/tags/$id/index.tsx`
+
+- [ ] **Step 1: ブックマーク詳細画面と同じ構成でファイルを作成**
+
+```tsx
+import { createFileRoute, Link, useRouterState } from '@tanstack/react-router'
+import * as v from 'valibot'
+
+const tagDetailSearchSchema = v.object({
+  created: v.optional(v.boolean())
+})
+
+export const Route = createFileRoute('/_protected/tags/$id/')({
+  validateSearch: tagDetailSearchSchema,
+  component: RouteComponent
+})
+
+function RouteComponent() {
+  const { id } = Route.useParams()
+
+  const { newTagCreated } = useRouterState({
+    select: (s) => s.location.state
+  })
+
+  return (
+    <div>
+      {newTagCreated && <div role='alert'>タグを登録しました</div>}
+
+      <h1>タグ詳細</h1>
+
+      <p>ID: {id}</p>
+
+      <nav>
+        <Link
+          to='/tags/$id/edit'
+          params={{ id }}>
+          編集
+        </Link>
+
+        <Link
+          to='/tags'
+          search={{ limit: 50, offset: 0 }}>
+          一覧へ戻る
+        </Link>
+      </nav>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: 型エラーがないことを確認**
+
+Run: `pnpm run typecheck`
+Expected: PASS
+
+---
+
+### Task 4: ルーター履歴状態の型を拡張
+
+**Files:**
+
+- Modify: `src/router.tsx`
+
+- [ ] **Step 1: `HistoryState` に `newTagCreated` を追加**
+
+```typescript
+interface HistoryState {
+  newBookmarkCreated?: boolean
+  newTagCreated?: boolean
+}
+```
+
+既存の `newBookmarkCreated` は必須から任意に変更し、新規 `newTagCreated` も任意にする。
+
+- [ ] **Step 2: 型エラーがないことを確認**
+
+Run: `pnpm run typecheck`
+Expected: PASS
+
+---
+
+### Task 5: ルート生成と品質チェック
+
+**Files:**
+
+- Auto-generated: `src/routeTree.gen.ts`
+
+- [ ] **Step 1: TanStack Router のルート定義を再生成**
+
+Run: `pnpm run build`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 2: Lint / Format / Typecheck / Test を実行**
+
+Run:
+
+```bash
+pnpm run lint
+pnpm run format:check
+pnpm run typecheck
+pnpm run test
+```
+
+Expected: すべて PASS（lint は既存の warning が残るが error は 0）
+
+---
+
+### Task 6: 動作確認
+
+**Files:**
+
+- ブラウザ / Playwright
+
+- [ ] **Step 1: 開発サーバーを起動**
+
+Run: `pnpm run dev`
+
+- [ ] **Step 2: `/tags/new` にアクセスし、タグ名を入力して登録**
+
+Expected:
+
+- タグ詳細画面（`/tags/$id`）へ遷移する
+- 「タグを登録しました」のメッセージが表示される
+
+---
+
+### Task 7: コミット
+
+- [ ] **Step 1: 変更をステージしてコミット**
+
+```bash
+git add src/features/tags/tag.function.ts src/routes/_protected/tags/new.tsx src/routes/_protected/tags/\$id/index.tsx src/router.tsx src/routeTree.gen.ts
+git commit -m "feat: implement tag creation form and addTag server function (#59)"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** タグ新規登録フォーム（Task 2）、server function（Task 1）、詳細画面（Task 3）、履歴状態の型拡張（Task 4）、品質チェック（Task 5）、動作確認（Task 6）すべて網羅済み。
+- **Placeholder scan:** TBD / TODO / "implement later" なし。各ステップに実際のコードとコマンドを記載。
+- **Type consistency:** `addTag` は `{ id: number }` を返却し、`navigate` 時に `String(id)` で文字列に変換して `params` に渡す。タグの ID は auto-increment 整数。

--- a/src/features/tags/tag.function.ts
+++ b/src/features/tags/tag.function.ts
@@ -1,10 +1,13 @@
 import { createServerFn } from '@tanstack/react-start'
 import { eq } from 'drizzle-orm'
+import * as v from 'valibot'
 
 import { getDB } from '../../db/index.server'
-import { tagsTable } from '../../db/schema/tag'
+import { tagsTable, tagInsertSchema } from '../../db/schema/tag'
 import { offsetPaginationQuerySchema } from '../../schemas/pagination'
 import { ensureSession } from '../auth/auth.function'
+
+const addTagInputSchema = v.pick(tagInsertSchema, ['name'])
 
 export const fetchTags = createServerFn({ method: 'GET' })
   .validator(offsetPaginationQuerySchema)
@@ -21,4 +24,26 @@ export const fetchTags = createServerFn({ method: 'GET' })
       .where(eq(tagsTable.userId, session.user.id))
       .limit(limit)
       .offset(offset)
+  })
+
+export const addTag = createServerFn({ method: 'POST' })
+  .validator(addTagInputSchema)
+  .handler(async (ctx) => {
+    const session = await ensureSession()
+    const db = getDB()
+
+    const { name } = ctx.data
+
+    const result = await db
+      .insert(tagsTable)
+      .values({ name, userId: session.user.id })
+      .returning({ id: tagsTable.id })
+
+    const [first] = result
+
+    if (first == null) {
+      throw new Error('Failed to insert tag')
+    }
+
+    return { id: first.id }
   })

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as ProtectedSettingsIndexRouteImport } from './routes/_protected/
 import { Route as ProtectedBookmarksIndexRouteImport } from './routes/_protected/bookmarks/index'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 import { Route as ProtectedTagsNewRouteImport } from './routes/_protected/tags/new'
+import { Route as ProtectedTagsIdIndexRouteImport } from './routes/_protected/tags/$id/index'
 import { Route as ProtectedBookmarksNewIndexRouteImport } from './routes/_protected/bookmarks/new/index'
 import { Route as ProtectedBookmarksIdIndexRouteImport } from './routes/_protected/bookmarks/$id/index'
 import { Route as ProtectedTagsIdEditRouteImport } from './routes/_protected/tags/$id.edit'
@@ -67,6 +68,11 @@ const ProtectedTagsNewRoute = ProtectedTagsNewRouteImport.update({
   path: '/tags/new',
   getParentRoute: () => ProtectedRoute,
 } as any)
+const ProtectedTagsIdIndexRoute = ProtectedTagsIdIndexRouteImport.update({
+  id: '/tags/$id/',
+  path: '/tags/$id/',
+  getParentRoute: () => ProtectedRoute,
+} as any)
 const ProtectedBookmarksNewIndexRoute =
   ProtectedBookmarksNewIndexRouteImport.update({
     id: '/bookmarks/new/',
@@ -104,6 +110,7 @@ export interface FileRoutesByFullPath {
   '/tags/$id/edit': typeof ProtectedTagsIdEditRoute
   '/bookmarks/$id/': typeof ProtectedBookmarksIdIndexRoute
   '/bookmarks/new/': typeof ProtectedBookmarksNewIndexRoute
+  '/tags/$id/': typeof ProtectedTagsIdIndexRoute
 }
 export interface FileRoutesByTo {
   '/sign-up': typeof SignUpRoute
@@ -118,6 +125,7 @@ export interface FileRoutesByTo {
   '/tags/$id/edit': typeof ProtectedTagsIdEditRoute
   '/bookmarks/$id': typeof ProtectedBookmarksIdIndexRoute
   '/bookmarks/new': typeof ProtectedBookmarksNewIndexRoute
+  '/tags/$id': typeof ProtectedTagsIdIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -134,6 +142,7 @@ export interface FileRoutesById {
   '/_protected/tags/$id/edit': typeof ProtectedTagsIdEditRoute
   '/_protected/bookmarks/$id/': typeof ProtectedBookmarksIdIndexRoute
   '/_protected/bookmarks/new/': typeof ProtectedBookmarksNewIndexRoute
+  '/_protected/tags/$id/': typeof ProtectedTagsIdIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -150,6 +159,7 @@ export interface FileRouteTypes {
     | '/tags/$id/edit'
     | '/bookmarks/$id/'
     | '/bookmarks/new/'
+    | '/tags/$id/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/sign-up'
@@ -164,6 +174,7 @@ export interface FileRouteTypes {
     | '/tags/$id/edit'
     | '/bookmarks/$id'
     | '/bookmarks/new'
+    | '/tags/$id'
   id:
     | '__root__'
     | '/_protected'
@@ -179,6 +190,7 @@ export interface FileRouteTypes {
     | '/_protected/tags/$id/edit'
     | '/_protected/bookmarks/$id/'
     | '/_protected/bookmarks/new/'
+    | '/_protected/tags/$id/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -253,6 +265,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProtectedTagsNewRouteImport
       parentRoute: typeof ProtectedRoute
     }
+    '/_protected/tags/$id/': {
+      id: '/_protected/tags/$id/'
+      path: '/tags/$id'
+      fullPath: '/tags/$id/'
+      preLoaderRoute: typeof ProtectedTagsIdIndexRouteImport
+      parentRoute: typeof ProtectedRoute
+    }
     '/_protected/bookmarks/new/': {
       id: '/_protected/bookmarks/new/'
       path: '/bookmarks/new'
@@ -294,6 +313,7 @@ interface ProtectedRouteChildren {
   ProtectedTagsIdEditRoute: typeof ProtectedTagsIdEditRoute
   ProtectedBookmarksIdIndexRoute: typeof ProtectedBookmarksIdIndexRoute
   ProtectedBookmarksNewIndexRoute: typeof ProtectedBookmarksNewIndexRoute
+  ProtectedTagsIdIndexRoute: typeof ProtectedTagsIdIndexRoute
 }
 
 const ProtectedRouteChildren: ProtectedRouteChildren = {
@@ -306,6 +326,7 @@ const ProtectedRouteChildren: ProtectedRouteChildren = {
   ProtectedTagsIdEditRoute: ProtectedTagsIdEditRoute,
   ProtectedBookmarksIdIndexRoute: ProtectedBookmarksIdIndexRoute,
   ProtectedBookmarksNewIndexRoute: ProtectedBookmarksNewIndexRoute,
+  ProtectedTagsIdIndexRoute: ProtectedTagsIdIndexRoute,
 }
 
 const ProtectedRouteWithChildren = ProtectedRoute._addFileChildren(

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -38,6 +38,7 @@ declare module '@tanstack/react-router' {
   }
 
   interface HistoryState {
-    newBookmarkCreated: boolean
+    newBookmarkCreated?: boolean
+    newTagCreated?: boolean
   }
 }

--- a/src/routes/_protected/tags/$id/index.tsx
+++ b/src/routes/_protected/tags/$id/index.tsx
@@ -1,0 +1,43 @@
+import { createFileRoute, Link, useRouterState } from '@tanstack/react-router'
+import * as v from 'valibot'
+
+const tagDetailSearchSchema = v.object({
+  created: v.optional(v.boolean())
+})
+
+export const Route = createFileRoute('/_protected/tags/$id/')({
+  validateSearch: tagDetailSearchSchema,
+  component: RouteComponent
+})
+
+function RouteComponent() {
+  const { id } = Route.useParams()
+
+  const { newTagCreated } = useRouterState({
+    select: (s) => s.location.state
+  })
+
+  return (
+    <div>
+      {newTagCreated && <div role='alert'>タグを登録しました</div>}
+
+      <h1>タグ詳細</h1>
+
+      <p>ID: {id}</p>
+
+      <nav>
+        <Link
+          to='/tags/$id/edit'
+          params={{ id }}>
+          編集
+        </Link>
+
+        <Link
+          to='/tags'
+          search={{ limit: 50, offset: 0 }}>
+          一覧へ戻る
+        </Link>
+      </nav>
+    </div>
+  )
+}

--- a/src/routes/_protected/tags/new.tsx
+++ b/src/routes/_protected/tags/new.tsx
@@ -1,33 +1,95 @@
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { Input } from '@base-ui/react'
+import { Field, getInput, useForm } from '@formisch/react'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { useActionState } from 'react'
+import * as v from 'valibot'
+
+import { addTag } from '../../../features/tags/tag.function'
 
 export const Route = createFileRoute('/_protected/tags/new')({
   component: RouteComponent
 })
 
 function RouteComponent() {
+  const navigate = useNavigate()
+
+  async function submitAction({ name }: { name: string }) {
+    const { id } = await addTag({ data: { name } })
+
+    await navigate({
+      to: '/tags/$id',
+      params: { id: String(id) },
+      state: { newTagCreated: true }
+    })
+  }
+
   return (
     <div>
-      <h1>タグ新規登録</h1>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault()
-        }}>
-        <label>
-          タグ名
-          <input
-            type='text'
-            name='name'
-            aria-label='タグ名'
-            required
-          />
-        </label>
-        <button type='submit'>保存</button>
-      </form>
+      <h1>タグ新規作成</h1>
+
+      <RegisterNewTagForm submitAction={submitAction} />
+
       <Link
         to='/tags'
         search={{ limit: 50, offset: 0 }}>
         一覧へ戻る
       </Link>
     </div>
+  )
+}
+
+interface RegisterNewTagFormProps {
+  submitAction: ({ name }: { name: string }) => Promise<void>
+}
+
+function RegisterNewTagForm({ submitAction }: RegisterNewTagFormProps) {
+  const registerNewTagFormSchema = v.object({
+    name: v.string()
+  })
+
+  const registerNewTagForm = useForm({
+    initialInput: {
+      name: ''
+    },
+    schema: registerNewTagFormSchema
+  })
+
+  const [_, throwError, isPending] = useActionState(async () => {
+    const currentRawName = getInput(registerNewTagForm, { path: ['name'] }) ?? ''
+
+    await submitAction({ name: currentRawName })
+  }, null)
+
+  return (
+    <form action={throwError}>
+      <fieldset>
+        <legend>タグ新規登録</legend>
+
+        <Field
+          of={registerNewTagForm}
+          path={['name']}>
+          {(field) => (
+            <label htmlFor={field.props.name}>
+              タグ名
+              <Input
+                id={field.props.name}
+                value={field.input}
+                type='text'
+                onValueChange={(newValue) => {
+                  field.onChange(newValue)
+                }}
+                required
+              />
+            </label>
+          )}
+        </Field>
+      </fieldset>
+
+      <button
+        type='submit'
+        disabled={isPending}>
+        {isPending ? '登録中...' : '登録'}
+      </button>
+    </form>
   )
 }


### PR DESCRIPTION
Closes #59

ブックマーク新規登録画面と同じ構成で、タグ新規登録画面を実装しました。

- `addTag` server function を追加
- タグ新規登録フォームを `@formisch/react` + `@base-ui/react` + `valibot` + `useActionState` で書き直し
- タグ詳細画面を新規作成
- 登録成功後は詳細画面へ遷移し、完了メッセージを表示