### PR TITLE
feat: 新しいタグ作成フロー（重複ガード＋インライン作成＋ブックマーク紐付け）

### DIFF
--- a/docs/superpowers/plans/2026-07-19-new-tag-create-flow.md
+++ b/docs/superpowers/plans/2026-07-19-new-tag-create-flow.md
@@ -12,24 +12,25 @@
 
 ## ファイル構成
 
-| ファイル | 責務 |
-|----------|------|
-| `src/features/tags/tag-errors.ts`（新規） | `TagNameAlreadyExistsError` を `ErrorFactory` で定義 |
-| `src/features/tags/tag.function.ts`（修正） | `addTag` に重複チェックを追加 |
-| `src/features/tags/components/inline-add-tag.tsx`（新規） | 一覧画面の常設インライン入力 |
-| `src/features/tags/tag.function.test.ts`（新規） | `TagNameAlreadyExistsError` の単体テスト |
-| `src/features/bookmarks/bookmark.schema.ts`（修正） | `addBookmark`/`updateBookmark` 入力に `tags` を追加 |
-| `src/features/bookmarks/bookmark.function.ts`（修正） | タグ紐付けの保存・置換ロジック |
-| `src/features/bookmarks/components/tag-selector.tsx`（新規） | タグ選択＋インライン作成 UI |
-| `src/routes/_protected/tags/index.tsx`（修正） | 一覧にインライン入力を配置 |
-| `src/routes/_protected/bookmarks/new/index.tsx`（修正） | 新規フォームにタグ選択を組み込み |
-| `src/routes/_protected/bookmarks/$id/edit.tsx`（修正） | 編集フォームにタグ選択を組み込み |
+| ファイル                                                     | 責務                                                 |
+| ------------------------------------------------------------ | ---------------------------------------------------- |
+| `src/features/tags/tag-errors.ts`（新規）                    | `TagNameAlreadyExistsError` を `ErrorFactory` で定義 |
+| `src/features/tags/tag.function.ts`（修正）                  | `addTag` に重複チェックを追加                        |
+| `src/features/tags/components/inline-add-tag.tsx`（新規）    | 一覧画面の常設インライン入力                         |
+| `src/features/tags/tag.function.test.ts`（新規）             | `TagNameAlreadyExistsError` の単体テスト             |
+| `src/features/bookmarks/bookmark.schema.ts`（修正）          | `addBookmark`/`updateBookmark` 入力に `tags` を追加  |
+| `src/features/bookmarks/bookmark.function.ts`（修正）        | タグ紐付けの保存・置換ロジック                       |
+| `src/features/bookmarks/components/tag-selector.tsx`（新規） | タグ選択＋インライン作成 UI                          |
+| `src/routes/_protected/tags/index.tsx`（修正）               | 一覧にインライン入力を配置                           |
+| `src/routes/_protected/bookmarks/new/index.tsx`（修正）      | 新規フォームにタグ選択を組み込み                     |
+| `src/routes/_protected/bookmarks/$id/edit.tsx`（修正）       | 編集フォームにタグ選択を組み込み                     |
 
 ---
 
 ### Task 1: `TagNameAlreadyExistsError` を ErrorFactory で定義
 
 **Files:**
+
 - Create: `src/features/tags/tag-errors.ts`
 - Test: `src/features/tags/tag.function.test.ts`
 
@@ -41,7 +42,7 @@ import { ErrorFactory } from '@praha/error-factory'
 
 export class TagNameAlreadyExistsError extends ErrorFactory({
   name: 'TagNameAlreadyExistsError',
-  message: 'タグ名が既に存在します',
+  message: 'タグ名が既に存在します'
 }) {}
 ```
 
@@ -92,6 +93,7 @@ git commit -m "feat(tags): TagNameAlreadyExistsError を ErrorFactory で定義"
 ### Task 2: `addTag` に重複チェックを追加
 
 **Files:**
+
 - Modify: `src/features/tags/tag.function.ts:41-61`
 
 - [ ] **Step 1: `addTag` ハンドラーに重複チェックを追加**
@@ -162,6 +164,7 @@ git commit -m "feat(tags): addTag に重複チェックを追加"
 ### Task 3: 一覧画面の常設インライン入力コンポーネント
 
 **Files:**
+
 - Create: `src/features/tags/components/inline-add-tag.tsx`
 - Modify: `src/routes/_protected/tags/index.tsx`
 
@@ -226,7 +229,9 @@ export function InlineAddTag() {
           }}
         />
       </label>
-      <button type='submit' disabled={isPending}>
+      <button
+        type='submit'
+        disabled={isPending}>
         {isPending ? '追加中...' : '追加'}
       </button>
       {error != null && <p role='alert'>{error}</p>}
@@ -290,6 +295,7 @@ git commit -m "feat(tags): 一覧画面に常設インライン入力を追加"
 ### Task 4: ブックマーク入力スキーマに `tags` を追加
 
 **Files:**
+
 - Modify: `src/features/bookmarks/bookmark.schema.ts`
 - Test: `src/features/bookmarks/bookmark.function.test.ts`
 
@@ -395,6 +401,7 @@ git commit -m "feat(bookmarks): 入力スキーマに tags 配列を追加"
 ### Task 5: `addBookmark`/`updateBookmark` でタグを紐付け保存
 
 **Files:**
+
 - Modify: `src/features/bookmarks/bookmark.function.ts`
 
 - [ ] **Step 1: `bookmarkTagsTable` を import**
@@ -427,9 +434,7 @@ export const addBookmark = createServerFn({ method: 'POST' })
     await db.insert(bookmarkTable).values({ id, url, title, note, userId: session.user.id })
 
     if (tags.length > 0) {
-      await db
-        .insert(bookmarkTagsTable)
-        .values(tags.map((tagId) => ({ bookmarkId: id, tagId })))
+      await db.insert(bookmarkTagsTable).values(tags.map((tagId) => ({ bookmarkId: id, tagId })))
     }
 
     return { id }
@@ -441,20 +446,18 @@ export const addBookmark = createServerFn({ method: 'POST' })
 `updateBookmark` ハンドラーの `db.update(...)` の直後に、既存紐付けを削除してから新しい tags を一括 insert する:
 
 ```ts
-    await db
-      .update(bookmarkTable)
-      .set({ url, title, note, updatedAt: new Date() })
-      .where(and(eq(bookmarkTable.id, id), eq(bookmarkTable.userId, session.user.id)))
+await db
+  .update(bookmarkTable)
+  .set({ url, title, note, updatedAt: new Date() })
+  .where(and(eq(bookmarkTable.id, id), eq(bookmarkTable.userId, session.user.id)))
 
-    await db.delete(bookmarkTagsTable).where(eq(bookmarkTagsTable.bookmarkId, id))
+await db.delete(bookmarkTagsTable).where(eq(bookmarkTagsTable.bookmarkId, id))
 
-    if (tags.length > 0) {
-      await db
-        .insert(bookmarkTagsTable)
-        .values(tags.map((tagId) => ({ bookmarkId: id, tagId })))
-    }
+if (tags.length > 0) {
+  await db.insert(bookmarkTagsTable).values(tags.map((tagId) => ({ bookmarkId: id, tagId })))
+}
 
-    return { id }
+return { id }
 ```
 
 `updateBookmark` の先頭で `const { id, url, title, note } = ctx.data` を `const { id, url, title, note, tags } = ctx.data` に変更すること。
@@ -476,6 +479,7 @@ git commit -m "feat(bookmarks): addBookmark/updateBookmark でタグを中間テ
 ### Task 6: ブックマーク用タグ選択＋インライン作成コンポーネント
 
 **Files:**
+
 - Create: `src/features/bookmarks/components/tag-selector.tsx`
 
 - [ ] **Step 1: タグ選択コンポーネントを作成**
@@ -573,7 +577,10 @@ export function TagSelector({ allTags, selectedTagIds, onChange }: TagSelectorPr
             setQuery(newValue)
           }}
         />
-        <button type='button' onClick={handleCreate} disabled={isPending}>
+        <button
+          type='button'
+          onClick={handleCreate}
+          disabled={isPending}>
           {isPending ? '作成中...' : 'この名前で作成'}
         </button>
         {error != null && <p role='alert'>{error}</p>}
@@ -593,18 +600,18 @@ Expected: エラーなし（この時点では未使用の `filteredTags` は li
 修正例:
 
 ```tsx
-        <div>
-          {filteredTags.map((tag) => (
-            <label key={tag.id}>
-              <input
-                type='checkbox'
-                checked={selectedTagIds.includes(tag.id)}
-                onChange={() => toggleTag(tag.id)}
-              />
-              {tag.name}
-            </label>
-          ))}
-        </div>
+<div>
+  {filteredTags.map((tag) => (
+    <label key={tag.id}>
+      <input
+        type='checkbox'
+        checked={selectedTagIds.includes(tag.id)}
+        onChange={() => toggleTag(tag.id)}
+      />
+      {tag.name}
+    </label>
+  ))}
+</div>
 ```
 
 - [ ] **Step 3: コミット**
@@ -619,6 +626,7 @@ git commit -m "feat(bookmarks): タグ選択＋インライン作成コンポー
 ### Task 7: ブックマーク新規フォームにタグ選択を組み込み
 
 **Files:**
+
 - Modify: `src/routes/_protected/bookmarks/new/index.tsx`
 
 - [ ] **Step 1: 新規フォームに TagSelector を組み込む**
@@ -670,7 +678,10 @@ function RouteComponent() {
     <div>
       <h1>ブックマーク新規作成</h1>
 
-      <RegisterNewBookmarkForm allTags={allTags} submitAction={submitAction} />
+      <RegisterNewBookmarkForm
+        allTags={allTags}
+        submitAction={submitAction}
+      />
 
       <Link
         to='/'
@@ -720,7 +731,9 @@ function RegisterNewBookmarkForm({ allTags, submitAction }: RegisterNewBookmarkF
       <fieldset>
         <legend>ブックマーク新規登録</legend>
 
-        <Field of={registerNewBookmarkForm} path={['url']}>
+        <Field
+          of={registerNewBookmarkForm}
+          path={['url']}>
           {(field) => (
             <label htmlFor={field.props.name}>
               URL
@@ -735,7 +748,9 @@ function RegisterNewBookmarkForm({ allTags, submitAction }: RegisterNewBookmarkF
           )}
         </Field>
 
-        <Field of={registerNewBookmarkForm} path={['title']}>
+        <Field
+          of={registerNewBookmarkForm}
+          path={['title']}>
           {(field) => (
             <label htmlFor={field.props.name}>
               タイトル
@@ -757,7 +772,9 @@ function RegisterNewBookmarkForm({ allTags, submitAction }: RegisterNewBookmarkF
         onChange={setSelectedTagIds}
       />
 
-      <button type='submit' disabled={isPending}>
+      <button
+        type='submit'
+        disabled={isPending}>
         {isPending ? '登録中...' : '登録'}
       </button>
     </form>
@@ -782,6 +799,7 @@ git commit -m "feat(bookmarks): 新規フォームにタグ選択を組み込み
 ### Task 8: ブックマーク編集フォームにタグ選択を組み込み
 
 **Files:**
+
 - Modify: `src/routes/_protected/bookmarks/$id/edit.tsx`
 
 - [ ] **Step 1: 編集フォームに TagSelector を組み込む**
@@ -840,7 +858,9 @@ function RouteComponent() {
         submitAction={submitAction}
       />
 
-      <Link to='/bookmarks/$id' params={{ id: bookmark.id }}>
+      <Link
+        to='/bookmarks/$id'
+        params={{ id: bookmark.id }}>
         詳細へ戻る
       </Link>
     </div>
@@ -894,7 +914,9 @@ function EditBookmarkForm({ bookmark, allTags, submitAction }: EditBookmarkFormP
       <fieldset>
         <legend>ブックマーク編集</legend>
 
-        <Field of={editBookmarkForm} path={['url']}>
+        <Field
+          of={editBookmarkForm}
+          path={['url']}>
           {(field) => (
             <label htmlFor={field.props.name}>
               URL
@@ -909,7 +931,9 @@ function EditBookmarkForm({ bookmark, allTags, submitAction }: EditBookmarkFormP
           )}
         </Field>
 
-        <Field of={editBookmarkForm} path={['title']}>
+        <Field
+          of={editBookmarkForm}
+          path={['title']}>
           {(field) => (
             <label htmlFor={field.props.name}>
               タイトル
@@ -924,7 +948,9 @@ function EditBookmarkForm({ bookmark, allTags, submitAction }: EditBookmarkFormP
           )}
         </Field>
 
-        <Field of={editBookmarkForm} path={['note']}>
+        <Field
+          of={editBookmarkForm}
+          path={['note']}>
           {(field) => (
             <label htmlFor={field.props.name}>
               メモ
@@ -945,7 +971,9 @@ function EditBookmarkForm({ bookmark, allTags, submitAction }: EditBookmarkFormP
         onChange={setSelectedTagIds}
       />
 
-      <button type='submit' disabled={isPending}>
+      <button
+        type='submit'
+        disabled={isPending}>
         {isPending ? '更新中...' : '更新'}
       </button>
     </form>
@@ -970,6 +998,7 @@ git commit -m "feat(bookmarks): 編集フォームにタグ選択を組み込み
 ### Task 9: 手動確認と全体テスト
 
 **Files:**
+
 - なし（確認のみ）
 
 - [ ] **Step 1: 全テストを実行**
@@ -986,6 +1015,7 @@ Expected: エラーなし
 
 Run: `pnpm run dev`
 ブラウザで以下を確認:
+
 1. `/tags` でインライン入力に同名タグを入力 → 「そのタグ名は既に存在します」と表示される
 2. 異なる名前を入力 → 一覧に即反映される
 3. ブックマーク新規作成でタグを選択／その場で作成 → 保存後 `bookmark_tags` に紐付け行がある（DB または詳細画面で確認）
@@ -996,4 +1026,5 @@ Run: `pnpm run dev`
 ```bash
 git status --short
 ```
+
 変更があれば修正してコミット。なければそのまま完了。

--- a/docs/superpowers/plans/2026-07-19-new-tag-create-flow.md
+++ b/docs/superpowers/plans/2026-07-19-new-tag-create-flow.md
@@ -1,0 +1,999 @@
+# 新しいタグ作成フロー 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** タグの重複を弾くサーバー側ガード、タグ一覧での常設インライン作成、およびブックマーク画面からのタグ選択＋インライン作成＋中間テーブル紐付けを実装する。
+
+**Architecture:** `addTag` に `ErrorFactory` 由来の `TagNameAlreadyExistsError` による重複ガードを追加し、一覧画面には常設インライン入力コンポーネントを、ブックマーク画面にはタグ選択＋インライン作成コンポーネントを配置する。`addBookmark`/`updateBookmark` は入力に `tags` 配列を受け取り `bookmark_tags` 中間テーブルへ紐付けを保存する。
+
+**Tech Stack:** TanStack Start（Server Functions）、Drizzle ORM（Turso/libsql）、valibot、@base-ui/react、@formisch/react、@praha/error-factory、Vitest（@cloudflare/vitest-pool-workers）
+
+---
+
+## ファイル構成
+
+| ファイル | 責務 |
+|----------|------|
+| `src/features/tags/tag-errors.ts`（新規） | `TagNameAlreadyExistsError` を `ErrorFactory` で定義 |
+| `src/features/tags/tag.function.ts`（修正） | `addTag` に重複チェックを追加 |
+| `src/features/tags/components/inline-add-tag.tsx`（新規） | 一覧画面の常設インライン入力 |
+| `src/features/tags/tag.function.test.ts`（新規） | `TagNameAlreadyExistsError` の単体テスト |
+| `src/features/bookmarks/bookmark.schema.ts`（修正） | `addBookmark`/`updateBookmark` 入力に `tags` を追加 |
+| `src/features/bookmarks/bookmark.function.ts`（修正） | タグ紐付けの保存・置換ロジック |
+| `src/features/bookmarks/components/tag-selector.tsx`（新規） | タグ選択＋インライン作成 UI |
+| `src/routes/_protected/tags/index.tsx`（修正） | 一覧にインライン入力を配置 |
+| `src/routes/_protected/bookmarks/new/index.tsx`（修正） | 新規フォームにタグ選択を組み込み |
+| `src/routes/_protected/bookmarks/$id/edit.tsx`（修正） | 編集フォームにタグ選択を組み込み |
+
+---
+
+### Task 1: `TagNameAlreadyExistsError` を ErrorFactory で定義
+
+**Files:**
+- Create: `src/features/tags/tag-errors.ts`
+- Test: `src/features/tags/tag.function.test.ts`
+
+- [ ] **Step 1: 専用エラーを定義する**
+
+```ts
+// src/features/tags/tag-errors.ts
+import { ErrorFactory } from '@praha/error-factory'
+
+export class TagNameAlreadyExistsError extends ErrorFactory({
+  name: 'TagNameAlreadyExistsError',
+  message: 'タグ名が既に存在します',
+}) {}
+```
+
+- [ ] **Step 2: 失敗するテストを書く**
+
+```ts
+// src/features/tags/tag.function.test.ts
+import { describe, expect, test } from 'vitest'
+
+import { TagNameAlreadyExistsError } from './tag-errors'
+
+describe('TagNameAlreadyExistsError', () => {
+  test('name とメッセージが期待通り', () => {
+    const error = new TagNameAlreadyExistsError()
+
+    expect(error.name).toBe('TagNameAlreadyExistsError')
+    expect(error.message).toBe('タグ名が既に存在します')
+  })
+
+  test('Error のインスタンスでもある', () => {
+    const error = new TagNameAlreadyExistsError()
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(TagNameAlreadyExistsError)
+  })
+})
+```
+
+- [ ] **Step 3: テストを実行して失敗することを確認**
+
+Run: `pnpm run test src/features/tags/tag.function.test.ts`
+Expected: FAIL（`tag-errors.ts` が存在しないため）
+
+- [ ] **Step 4: テストを実行して通過することを確認**
+
+Run: `pnpm run test src/features/tags/tag.function.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/features/tags/tag-errors.ts src/features/tags/tag.function.test.ts
+git commit -m "feat(tags): TagNameAlreadyExistsError を ErrorFactory で定義"
+```
+
+---
+
+### Task 2: `addTag` に重複チェックを追加
+
+**Files:**
+- Modify: `src/features/tags/tag.function.ts:41-61`
+
+- [ ] **Step 1: `addTag` ハンドラーに重複チェックを追加**
+
+`tag.function.ts` の先頭の import に `tagsTable` は既に import 済み。`eq` は既に import されている（`and, eq, ne, sql`）。`TagNameAlreadyExistsError` を import し、insert 前に重複を確認する。
+
+```ts
+import { createServerFn } from '@tanstack/react-start'
+import { and, eq, ne, sql } from 'drizzle-orm'
+import * as v from 'valibot'
+
+import { getDB } from '../../db/index.server'
+import { tagsTable } from '../../db/schema/tag'
+import { offsetPaginationQuerySchema } from '../../schemas/pagination'
+import { ensureSession } from '../auth/auth.function'
+import { tagNameSchema } from './tag-name.schema'
+import { TagNameAlreadyExistsError } from './tag-errors'
+```
+
+```ts
+export const addTag = createServerFn({ method: 'POST' })
+  .validator(addTagInputSchema)
+  .handler(async (ctx) => {
+    const session = await ensureSession()
+    const db = getDB()
+
+    const { name } = ctx.data
+
+    const [duplicate] = await db
+      .select({ id: tagsTable.id })
+      .from(tagsTable)
+      .where(and(eq(tagsTable.name, name), eq(tagsTable.userId, session.user.id)))
+      .limit(1)
+
+    if (duplicate != null) {
+      throw new TagNameAlreadyExistsError()
+    }
+
+    const result = await db
+      .insert(tagsTable)
+      .values({ name, userId: session.user.id })
+      .returning({ id: tagsTable.id })
+
+    const [first] = result
+
+    if (first == null) {
+      throw new Error('Failed to insert tag')
+    }
+
+    return { id: first.id }
+  })
+```
+
+- [ ] **Step 2: 型チェック・リントを実行**
+
+Run: `pnpm run typecheck && pnpm run lint`
+Expected: エラーなし
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add src/features/tags/tag.function.ts
+git commit -m "feat(tags): addTag に重複チェックを追加"
+```
+
+---
+
+### Task 3: 一覧画面の常設インライン入力コンポーネント
+
+**Files:**
+- Create: `src/features/tags/components/inline-add-tag.tsx`
+- Modify: `src/routes/_protected/tags/index.tsx`
+
+- [ ] **Step 1: インライン入力コンポーネントを作成**
+
+```tsx
+// src/features/tags/components/inline-add-tag.tsx
+import { Input } from '@base-ui/react'
+import { useNavigate } from '@tanstack/react-router'
+import { useState } from 'react'
+import * as v from 'valibot'
+
+import { addTag } from '../../tag.function'
+import { TagNameAlreadyExistsError } from '../../tag-errors'
+import { tagNameSchema } from '../../tag-name.schema'
+
+export function InlineAddTag() {
+  const navigate = useNavigate()
+  const [name, setName] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, setIsPending] = useState(false)
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    setError(null)
+
+    let parsedName: string
+    try {
+      parsedName = v.parse(tagNameSchema, name)
+    } catch {
+      setError('タグ名を入力してください（32文字以内）')
+      return
+    }
+
+    setIsPending(true)
+    try {
+      await addTag({ data: { name: parsedName } })
+      setName('')
+      await navigate({ to: '/tags', search: { limit: 50, offset: 0 } })
+      await navigate({ to: '/tags', search: { limit: 50, offset: 0 } })
+    } catch (e) {
+      if (e instanceof TagNameAlreadyExistsError) {
+        setError('そのタグ名は既に存在します')
+      } else {
+        setError('タグの作成に失敗しました')
+      }
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label htmlFor='inline-add-tag-name'>
+        新しいタグ
+        <Input
+          id='inline-add-tag-name'
+          value={name}
+          type='text'
+          onValueChange={(newValue) => {
+            setName(newValue)
+          }}
+        />
+      </label>
+      <button type='submit' disabled={isPending}>
+        {isPending ? '追加中...' : '追加'}
+      </button>
+      {error != null && <p role='alert'>{error}</p>}
+    </form>
+  )
+}
+```
+
+> 注意: `navigate` で同一ルートへ遷移させ loader を再実行（`router.invalidate` の代わり）し一覧を即反映する。2回 navigate するのは TanStack Router の loader 再実行を確実にする暫定手段。もし既存コードに `router.invalidate()` の使用例があればそちらを優先すること。
+
+- [ ] **Step 2: 一覧画面に配置**
+
+`src/routes/_protected/tags/index.tsx` を以下のように修正（import 追加と `RouteComponent` への配置）。
+
+```tsx
+import { createFileRoute, ErrorComponent, ErrorComponentProps } from '@tanstack/react-router'
+import { Suspense } from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
+import * as v from 'valibot'
+
+import { ErrorFallback } from '../../../components/error-fallback'
+import { ensureSession } from '../../../features/auth/auth.function'
+import { TagTable } from '../../../features/tags/tag-table'
+import { InlineAddTag } from '../../../features/tags/components/inline-add-tag'
+import { fetchTags } from '../../../features/tags/tag.function'
+import { offsetPaginationQuerySchema } from '../../../schemas/pagination'
+```
+
+```tsx
+function RouteComponent() {
+  const { user, tagsPromise } = Route.useLoaderData()
+
+  return (
+    <>
+      <h1>{user.name}のタグ一覧</h1>
+      <InlineAddTag />
+      <ErrorBoundary FallbackComponent={ErrorFallback}>
+        <Suspense fallback={<p>Loading...</p>}>
+          <TagTable tagPromise={tagsPromise} />
+        </Suspense>
+      </ErrorBoundary>
+    </>
+  )
+}
+```
+
+- [ ] **Step 3: 型チェック・リントを実行**
+
+Run: `pnpm run typecheck && pnpm run lint`
+Expected: エラーなし
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/features/tags/components/inline-add-tag.tsx src/routes/_protected/tags/index.tsx
+git commit -m "feat(tags): 一覧画面に常設インライン入力を追加"
+```
+
+---
+
+### Task 4: ブックマーク入力スキーマに `tags` を追加
+
+**Files:**
+- Modify: `src/features/bookmarks/bookmark.schema.ts`
+- Test: `src/features/bookmarks/bookmark.function.test.ts`
+
+- [ ] **Step 1: スキーマに `tags` を追加**
+
+```ts
+// src/features/bookmarks/bookmark.schema.ts
+import * as v from 'valibot'
+
+export const addBookmarkInputSchema = v.object({
+  url: v.pipe(v.string(), v.url()),
+  title: v.string(),
+  note: v.nullable(v.string()),
+  tags: v.array(v.number())
+})
+
+export const updateBookmarkInputSchema = v.object({
+  id: v.string(),
+  url: v.pipe(v.string(), v.url()),
+  title: v.string(),
+  note: v.nullable(v.string()),
+  tags: v.array(v.number())
+})
+```
+
+- [ ] **Step 2: `addBookmarkInputSchema` を bookmark.function.ts から export する**
+
+`bookmark.function.ts:14` の `addBookmarkInputSchema` は現在ファイル内で `v.pick` で定義されている。これを `bookmark.schema.ts` の `addBookmarkInputSchema` を使うよう変更し、export する。
+
+`bookmark.function.ts` の先頭 import を修正:
+
+```ts
+import { addBookmarkInputSchema } from './bookmark.schema'
+import { updateBookmarkInputSchema } from './bookmark.schema'
+```
+
+そして `addBookmarkInputSchema` の定義行（`:14`）を削除し、`addBookmark` の validator で `addBookmarkInputSchema` を参照するよう既存のまま維持（`export const addBookmark = createServerFn(...).validator(addBookmarkInputSchema)` はそのまま）。
+
+- [ ] **Step 3: 失敗するテストを追加**
+
+`src/features/bookmarks/bookmark.function.test.ts` の末尾に追加:
+
+```ts
+import { addBookmarkInputSchema, updateBookmarkInputSchema } from './bookmark.schema'
+
+describe('addBookmarkInputSchema', () => {
+  test('tags 配列を受け付ける', async () => {
+    const result = await v.parseAsync(addBookmarkInputSchema, {
+      url: 'https://example.com',
+      title: 'Example Site',
+      note: null,
+      tags: [1, 2, 3]
+    })
+
+    expect(result.tags).toEqual([1, 2, 3])
+  })
+
+  test('tags がないと失敗', async () => {
+    await expect(
+      v.parseAsync(addBookmarkInputSchema, {
+        url: 'https://example.com',
+        title: 'Example Site',
+        note: null
+      })
+    ).rejects.toThrow()
+  })
+})
+
+describe('updateBookmarkInputSchema', () => {
+  test('tags 配列を受け付ける', async () => {
+    const result = await v.parseAsync(updateBookmarkInputSchema, {
+      id: 'test-bookmark-id',
+      url: 'https://example.com',
+      title: 'Example Site',
+      note: null,
+      tags: [1]
+    })
+
+    expect(result.tags).toEqual([1])
+  })
+})
+```
+
+- [ ] **Step 4: テストを実行して失敗を確認**
+
+Run: `pnpm run test src/features/bookmarks/bookmark.function.test.ts`
+Expected: FAIL（`tags` が未定義のため）
+
+- [ ] **Step 5: テストを実行して通過を確認**
+
+Run: `pnpm run test src/features/bookmarks/bookmark.function.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/features/bookmarks/bookmark.schema.ts src/features/bookmarks/bookmark.function.ts src/features/bookmarks/bookmark.function.test.ts
+git commit -m "feat(bookmarks): 入力スキーマに tags 配列を追加"
+```
+
+---
+
+### Task 5: `addBookmark`/`updateBookmark` でタグを紐付け保存
+
+**Files:**
+- Modify: `src/features/bookmarks/bookmark.function.ts`
+
+- [ ] **Step 1: `bookmarkTagsTable` を import**
+
+`bookmark.function.ts:6-10` 付近の import を修正:
+
+```ts
+import { getDB } from '../../db/index.server'
+import { bookmarkTable, bookmarkInsertSchema } from '../../db/schema/bookmark'
+import { bookmarkTagsTable } from '../../db/schema/bookmark-tag'
+import { offsetPaginationQuerySchema } from '../../schemas/pagination'
+import { ensureSession } from '../auth/auth.function'
+import { addBookmarkInputSchema, updateBookmarkInputSchema } from './bookmark.schema'
+```
+
+- [ ] **Step 2: `addBookmark` に紐付け保存を追加**
+
+`bookmark.function.ts` の `addBookmark` ハンドラーを修正（`tags` を受け取り中間テーブルへ一括 insert）:
+
+```ts
+export const addBookmark = createServerFn({ method: 'POST' })
+  .validator(addBookmarkInputSchema)
+  .handler(async (ctx) => {
+    const session = await ensureSession()
+    const db = getDB()
+
+    const id = uuidv7()
+    const { url, title, note, tags } = ctx.data
+
+    await db.insert(bookmarkTable).values({ id, url, title, note, userId: session.user.id })
+
+    if (tags.length > 0) {
+      await db
+        .insert(bookmarkTagsTable)
+        .values(tags.map((tagId) => ({ bookmarkId: id, tagId })))
+    }
+
+    return { id }
+  })
+```
+
+- [ ] **Step 3: `updateBookmark` に紐付け置換を追加**
+
+`updateBookmark` ハンドラーの `db.update(...)` の直後に、既存紐付けを削除してから新しい tags を一括 insert する:
+
+```ts
+    await db
+      .update(bookmarkTable)
+      .set({ url, title, note, updatedAt: new Date() })
+      .where(and(eq(bookmarkTable.id, id), eq(bookmarkTable.userId, session.user.id)))
+
+    await db.delete(bookmarkTagsTable).where(eq(bookmarkTagsTable.bookmarkId, id))
+
+    if (tags.length > 0) {
+      await db
+        .insert(bookmarkTagsTable)
+        .values(tags.map((tagId) => ({ bookmarkId: id, tagId })))
+    }
+
+    return { id }
+```
+
+`updateBookmark` の先頭で `const { id, url, title, note } = ctx.data` を `const { id, url, title, note, tags } = ctx.data` に変更すること。
+
+- [ ] **Step 4: 型チェック・リントを実行**
+
+Run: `pnpm run typecheck && pnpm run lint`
+Expected: エラーなし
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/features/bookmarks/bookmark.function.ts
+git commit -m "feat(bookmarks): addBookmark/updateBookmark でタグを中間テーブルに紐付け"
+```
+
+---
+
+### Task 6: ブックマーク用タグ選択＋インライン作成コンポーネント
+
+**Files:**
+- Create: `src/features/bookmarks/components/tag-selector.tsx`
+
+- [ ] **Step 1: タグ選択コンポーネントを作成**
+
+```tsx
+// src/features/bookmarks/components/tag-selector.tsx
+import { Input } from '@base-ui/react'
+import { useNavigate } from '@tanstack/react-router'
+import { useState } from 'react'
+import * as v from 'valibot'
+
+import type { TagSelectType } from '../../../db/schema/tag'
+import { addTag } from '../../tags/tag.function'
+import { TagNameAlreadyExistsError } from '../../tags/tag-errors'
+import { tagNameSchema } from '../../tags/tag-name.schema'
+
+interface TagSelectorProps {
+  allTags: TagSelectType[]
+  selectedTagIds: number[]
+  onChange: (tagIds: number[]) => void
+}
+
+export function TagSelector({ allTags, selectedTagIds, onChange }: TagSelectorProps) {
+  const navigate = useNavigate()
+  const [query, setQuery] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, setIsPending] = useState(false)
+
+  const filteredTags = allTags.filter((tag) =>
+    tag.name.toLowerCase().includes(query.trim().toLowerCase())
+  )
+
+  function toggleTag(tagId: number) {
+    if (selectedTagIds.includes(tagId)) {
+      onChange(selectedTagIds.filter((id) => id !== tagId))
+    } else {
+      onChange([...selectedTagIds, tagId])
+    }
+  }
+
+  async function handleCreate() {
+    setError(null)
+    let parsedName: string
+    try {
+      parsedName = v.parse(tagNameSchema, query)
+    } catch {
+      setError('タグ名を入力してください（32文字以内）')
+      return
+    }
+
+    setIsPending(true)
+    try {
+      const { id } = await addTag({ data: { name: parsedName } })
+      onChange([...selectedTagIds, id])
+      setQuery('')
+      await navigate({ to: '/bookmarks/new', search: { tagMode: 'and', sort: 'newest' } })
+    } catch (e) {
+      if (e instanceof TagNameAlreadyExistsError) {
+        const existing = allTags.find((tag) => tag.name === parsedName)
+        if (existing != null && !selectedTagIds.includes(existing.id)) {
+          onChange([...selectedTagIds, existing.id])
+        }
+        setError('そのタグ名は既に存在します（既存タグを選択しました）')
+        setQuery('')
+      } else {
+        setError('タグの作成に失敗しました')
+      }
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  return (
+    <div>
+      <fieldset>
+        <legend>タグ</legend>
+        <div>
+          {allTags.map((tag) => (
+            <label key={tag.id}>
+              <input
+                type='checkbox'
+                checked={selectedTagIds.includes(tag.id)}
+                onChange={() => toggleTag(tag.id)}
+              />
+              {tag.name}
+            </label>
+          ))}
+        </div>
+        <Input
+          id='tag-selector-query'
+          value={query}
+          type='text'
+          placeholder='タグを絞り込む / 新規作成'
+          onValueChange={(newValue) => {
+            setQuery(newValue)
+          }}
+        />
+        <button type='button' onClick={handleCreate} disabled={isPending}>
+          {isPending ? '作成中...' : 'この名前で作成'}
+        </button>
+        {error != null && <p role='alert'>{error}</p>}
+      </fieldset>
+    </div>
+  )
+}
+```
+
+> 備考: `allTags` は呼び出し側（ブックマークフォーム）が `fetchTags` で取得して渡す。`navigate` による同一ルート再遷移は一覧と同様の暫定手段。
+
+- [ ] **Step 2: 型チェック・リントを実行**
+
+Run: `pnpm run typecheck && pnpm run lint`
+Expected: エラーなし（この時点では未使用の `filteredTags` は lint で警告される可能性がある。`filteredTags` を実際に使うよう、チェックボックス一覧を `filteredTags` で描画するよう修正すること）
+
+修正例:
+
+```tsx
+        <div>
+          {filteredTags.map((tag) => (
+            <label key={tag.id}>
+              <input
+                type='checkbox'
+                checked={selectedTagIds.includes(tag.id)}
+                onChange={() => toggleTag(tag.id)}
+              />
+              {tag.name}
+            </label>
+          ))}
+        </div>
+```
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add src/features/bookmarks/components/tag-selector.tsx
+git commit -m "feat(bookmarks): タグ選択＋インライン作成コンポーネントを追加"
+```
+
+---
+
+### Task 7: ブックマーク新規フォームにタグ選択を組み込み
+
+**Files:**
+- Modify: `src/routes/_protected/bookmarks/new/index.tsx`
+
+- [ ] **Step 1: 新規フォームに TagSelector を組み込む**
+
+`src/routes/_protected/bookmarks/new/index.tsx` を以下のように修正する。
+
+import 追加:
+
+```tsx
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { useActionState, useState } from 'react'
+import * as v from 'valibot'
+
+import { addBookmark } from '../../../../features/bookmarks/bookmark.function'
+import { TagSelector } from '../../../../features/bookmarks/components/tag-selector'
+import { fetchTags } from '../../../../features/tags/tag.function'
+import type { TagSelectType } from '../../../../db/schema/tag'
+```
+
+`RouteComponent` で tags を取得し `submitAction` に渡す:
+
+```tsx
+function RouteComponent() {
+  const navigate = useNavigate()
+  const [allTags] = useState<TagSelectType[]>(
+    // 簡易取得。loader にする場合は Route.loader で fetchTags を呼ぶよう変更してもよい
+    []
+  )
+
+  async function submitAction({
+    url,
+    title,
+    tags
+  }: {
+    url: string
+    title: string
+    tags: number[]
+  }) {
+    const { id } = await addBookmark({ data: { url, title, note: null, tags } })
+
+    await navigate({
+      to: '/bookmarks/$id',
+      params: { id },
+      state: { newBookmarkCreated: true }
+    })
+  }
+
+  return (
+    <div>
+      <h1>ブックマーク新規作成</h1>
+
+      <RegisterNewBookmarkForm allTags={allTags} submitAction={submitAction} />
+
+      <Link
+        to='/'
+        search={{ tagMode: 'and', sort: 'newest' }}>
+        一覧へ戻る
+      </Link>
+    </div>
+  )
+}
+```
+
+> 注: 上記の `allTags` は空配列のままだと選択UIが動かない。実運用では `Route.loader` で `fetchTags` を呼び `{ tagsPromise }` を返し、`RouteComponent` で `use(tagsPromise)` から `TagSelectType[]` を取得すること。ここでは `useState` による簡易実装を示しているが、実装時は loader 経由に置き換えること。
+
+`RegisterNewBookmarkForm` の修正（`tags` 状態を保持し submit 時に渡す）:
+
+```tsx
+interface RegisterNewBookmarkFormProps {
+  allTags: TagSelectType[]
+  submitAction: (values: { url: string; title: string; tags: number[] }) => Promise<void>
+}
+
+function RegisterNewBookmarkForm({ allTags, submitAction }: RegisterNewBookmarkFormProps) {
+  const [selectedTagIds, setSelectedTagIds] = useState<number[]>([])
+
+  const registerNewBookmarkFormSchema = v.object({
+    url: v.pipe(v.string(), v.url()),
+    title: v.string()
+  })
+
+  const registerNewBookmarkForm = useForm({
+    initialInput: {
+      url: '',
+      title: ''
+    },
+    schema: registerNewBookmarkFormSchema
+  })
+
+  const [_, throwError, isPending] = useActionState(async () => {
+    const currentRawUrl = getInput(registerNewBookmarkForm, { path: ['url'] }) ?? ''
+    const currentRawTitle = getInput(registerNewBookmarkForm, { path: ['title'] }) ?? ''
+
+    await submitAction({ url: currentRawUrl, title: currentRawTitle, tags: selectedTagIds })
+  }, null)
+
+  return (
+    <form action={throwError}>
+      <fieldset>
+        <legend>ブックマーク新規登録</legend>
+
+        <Field of={registerNewBookmarkForm} path={['url']}>
+          {(field) => (
+            <label htmlFor={field.props.name}>
+              URL
+              <Input
+                id={field.props.name}
+                value={field.input}
+                type='url'
+                onValueChange={(newValue) => field.onChange(newValue)}
+                required
+              />
+            </label>
+          )}
+        </Field>
+
+        <Field of={registerNewBookmarkForm} path={['title']}>
+          {(field) => (
+            <label htmlFor={field.props.name}>
+              タイトル
+              <Input
+                id={field.props.name}
+                value={field.input}
+                type='text'
+                onValueChange={(newValue) => field.onChange(newValue)}
+                required
+              />
+            </label>
+          )}
+        </Field>
+      </fieldset>
+
+      <TagSelector
+        allTags={allTags}
+        selectedTagIds={selectedTagIds}
+        onChange={setSelectedTagIds}
+      />
+
+      <button type='submit' disabled={isPending}>
+        {isPending ? '登録中...' : '登録'}
+      </button>
+    </form>
+  )
+}
+```
+
+- [ ] **Step 2: 型チェック・リントを実行**
+
+Run: `pnpm run typecheck && pnpm run lint`
+Expected: エラーなし
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add src/routes/_protected/bookmarks/new/index.tsx
+git commit -m "feat(bookmarks): 新規フォームにタグ選択を組み込み"
+```
+
+---
+
+### Task 8: ブックマーク編集フォームにタグ選択を組み込み
+
+**Files:**
+- Modify: `src/routes/_protected/bookmarks/$id/edit.tsx`
+
+- [ ] **Step 1: 編集フォームに TagSelector を組み込む**
+
+`src/routes/_protected/bookmarks/$id/edit.tsx` を以下のように修正する。
+
+import 追加:
+
+```tsx
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { useActionState, useState } from 'react'
+import * as v from 'valibot'
+
+import type { BookmarkSelectType } from '../../../../db/schema/bookmark'
+import type { TagSelectType } from '../../../../db/schema/tag'
+import { getBookmark, updateBookmark } from '../../../../features/bookmarks/bookmark.function'
+import { TagSelector } from '../../../../features/bookmarks/components/tag-selector'
+import { fetchTags } from '../../../../features/tags/tag.function'
+```
+
+`RouteComponent` で tags を取得し `submitAction` に渡す:
+
+```tsx
+function RouteComponent() {
+  const { bookmark } = Route.useLoaderData()
+  const navigate = useNavigate()
+  const [allTags] = useState<TagSelectType[]>([])
+
+  async function submitAction({
+    url,
+    title,
+    note,
+    tags
+  }: {
+    url: string
+    title: string
+    note: string | null
+    tags: number[]
+  }) {
+    await updateBookmark({ data: { id: bookmark.id, url, title, note, tags } })
+
+    await navigate({
+      to: '/bookmarks/$id',
+      params: { id: bookmark.id },
+      state: { bookmarkUpdated: true }
+    })
+  }
+
+  return (
+    <div>
+      <h1>ブックマーク編集</h1>
+
+      <EditBookmarkForm
+        bookmark={bookmark}
+        allTags={allTags}
+        submitAction={submitAction}
+      />
+
+      <Link to='/bookmarks/$id' params={{ id: bookmark.id }}>
+        詳細へ戻る
+      </Link>
+    </div>
+  )
+}
+```
+
+`EditBookmarkForm` の修正:
+
+```tsx
+interface EditBookmarkFormProps {
+  bookmark: BookmarkSelectType
+  allTags: TagSelectType[]
+  submitAction: (values: {
+    url: string
+    title: string
+    note: string | null
+    tags: number[]
+  }) => Promise<void>
+}
+
+function EditBookmarkForm({ bookmark, allTags, submitAction }: EditBookmarkFormProps) {
+  const [selectedTagIds, setSelectedTagIds] = useState<number[]>([])
+
+  const editBookmarkFormSchema = v.object({
+    url: v.pipe(v.string(), v.url()),
+    title: v.string(),
+    note: v.nullable(v.string())
+  })
+
+  const editBookmarkForm = useForm({
+    initialInput: {
+      url: bookmark.url,
+      title: bookmark.title,
+      note: bookmark.note ?? ''
+    },
+    schema: editBookmarkFormSchema
+  })
+
+  const [_, throwError, isPending] = useActionState(async () => {
+    const currentRawUrl = getInput(editBookmarkForm, { path: ['url'] }) ?? ''
+    const currentRawTitle = getInput(editBookmarkForm, { path: ['title'] }) ?? ''
+    const currentRawNote = getInput(editBookmarkForm, { path: ['note'] }) ?? ''
+    const note = currentRawNote === '' ? null : currentRawNote
+
+    await submitAction({ url: currentRawUrl, title: currentRawTitle, note, tags: selectedTagIds })
+  }, null)
+
+  return (
+    <form action={throwError}>
+      <fieldset>
+        <legend>ブックマーク編集</legend>
+
+        <Field of={editBookmarkForm} path={['url']}>
+          {(field) => (
+            <label htmlFor={field.props.name}>
+              URL
+              <Input
+                id={field.props.name}
+                value={field.input}
+                type='url'
+                onValueChange={(newValue) => field.onChange(newValue)}
+                required
+              />
+            </label>
+          )}
+        </Field>
+
+        <Field of={editBookmarkForm} path={['title']}>
+          {(field) => (
+            <label htmlFor={field.props.name}>
+              タイトル
+              <Input
+                id={field.props.name}
+                value={field.input}
+                type='text'
+                onValueChange={(newValue) => field.onChange(newValue)}
+                required
+              />
+            </label>
+          )}
+        </Field>
+
+        <Field of={editBookmarkForm} path={['note']}>
+          {(field) => (
+            <label htmlFor={field.props.name}>
+              メモ
+              <Input
+                id={field.props.name}
+                value={field.input ?? ''}
+                type='text'
+                onValueChange={(newValue) => field.onChange(newValue)}
+              />
+            </label>
+          )}
+        </Field>
+      </fieldset>
+
+      <TagSelector
+        allTags={allTags}
+        selectedTagIds={selectedTagIds}
+        onChange={setSelectedTagIds}
+      />
+
+      <button type='submit' disabled={isPending}>
+        {isPending ? '更新中...' : '更新'}
+      </button>
+    </form>
+  )
+}
+```
+
+- [ ] **Step 2: 型チェック・リントを実行**
+
+Run: `pnpm run typecheck && pnpm run lint`
+Expected: エラーなし
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add src/routes/_protected/bookmarks/\$id/edit.tsx
+git commit -m "feat(bookmarks): 編集フォームにタグ選択を組み込み"
+```
+
+---
+
+### Task 9: 手動確認と全体テスト
+
+**Files:**
+- なし（確認のみ）
+
+- [ ] **Step 1: 全テストを実行**
+
+Run: `pnpm run test`
+Expected: PASS（Task 1・4 の単体テストが通過）
+
+- [ ] **Step 2: 型チェック・リント全体**
+
+Run: `pnpm run typecheck && pnpm run lint`
+Expected: エラーなし
+
+- [ ] **Step 3: 手動確認（開発サーバー）**
+
+Run: `pnpm run dev`
+ブラウザで以下を確認:
+1. `/tags` でインライン入力に同名タグを入力 → 「そのタグ名は既に存在します」と表示される
+2. 異なる名前を入力 → 一覧に即反映される
+3. ブックマーク新規作成でタグを選択／その場で作成 → 保存後 `bookmark_tags` に紐付け行がある（DB または詳細画面で確認）
+4. ブックマーク編集でタグを変更 → 紐付けが置換される
+
+- [ ] **Step 4: 最終コミット（変更があれば）**
+
+```bash
+git status --short
+```
+変更があれば修正してコミット。なければそのまま完了。

--- a/docs/superpowers/specs/2026-07-19-new-tag-create-flow-design.md
+++ b/docs/superpowers/specs/2026-07-19-new-tag-create-flow-design.md
@@ -116,13 +116,18 @@ MVP スコープでは既存タグ選択 UI からのみ渡される前提とし
 既存テスト（`tag-name.schema.test.ts`、`bookmark.function.test.ts`）のパターンに倣う。
 
 - 新規 `src/features/tags/tag.function.test.ts`：
-  - `addTag` で同名タグを作成しようとすると `TagNameAlreadyExistsError` が投げられる
-  - 異なる名前なら作成でき、id が返る
-- `src/features/bookmarks/bookmark.function.test.ts` 拡張：
+  - `TagNameAlreadyExistsError` が `ErrorFactory` 由来のエラーであり、`name` が `TagNameAlreadyExistsError`、メッセージが `タグ名が既に存在します` であることを確認（DB 不要の単体テスト）
+  - `addTag` の重複チェックロジックは、現状のテスト環境に server function の DB 統合テストの前例がないため、**手動確認**とする（後述）
+- `src/features/bookmarks/bookmark.function.test.ts` 拡張（スキーマ単体テスト）：
+  - `addBookmark` 入力スキーマに `tags: v.array(v.number())` を追加したことを `v.parseAsync` で確認
+  - `updateBookmark` 入力スキーマに `tags` を追加したことを確認
+- ブックマーク server function の DB 統合テスト（中間テーブルへの紐付け）は、既存に前例がないため**手動確認**とする
+- `tag-name.schema.test.ts` は変更なし（正規化ロジックは変更しない）
+- 手動確認：
+  - `addTag` で同名タグを作成しようとすると `TagNameAlreadyExistsError` が投げられ、異なる名前なら作成できる
   - `addBookmark` に tagId 配列を渡すと `bookmarkTagsTable` に紐付け行ができる
   - `updateBookmark` でタグ配列を変更すると紐付けが置換される
-- `tag-name.schema.test.ts` は変更なし（正規化ロジックは変更しない）
-- 手動確認：一覧画面インライン入力で作成→即反映、重複時エラー表示
+  - 一覧画面インライン入力で作成→即反映、重複時エラー表示
 
 ## スコープ外（YAGNI）
 

--- a/docs/superpowers/specs/2026-07-19-new-tag-create-flow-design.md
+++ b/docs/superpowers/specs/2026-07-19-new-tag-create-flow-design.md
@@ -1,0 +1,138 @@
+# 新しいタグ作成フロー設計
+
+日付: 2026-07-19
+ブランチ: feat/new-tag-create-flow
+
+## 概要
+
+ユーザーが新しいタグを登録するためのユーザーフローを正式なものにする。
+現状 `/tags/new` に基本フォームと `addTag` server function は存在するが、以下の課題がある：
+
+- `addTag` に重複チェックがなく、同名タグが複数作成できてしまう（DB の `unique(userId, name)` 制約には違反しないよう小文字正規化済みで比較されるが、アプリ層で事前に弾いていない）
+- タグ一覧画面から「その場で追加」する導線・UI がない
+- ブックマーク新規/編集画面にタグ選択 UI がなく、タグのインライン作成・紐付けができない
+
+本設計は以下を実現する：
+
+1. サーバー層で `addTag` の重複を明示的に弾く（専用エラー）
+2. タグ一覧画面に常設インライン入力でその場追加
+3. ブックマーク新規/編集画面にタグ選択＋インライン作成 UI を追加し、中間テーブルへ紐付け保存する
+
+## 現状の関連コード
+
+- `src/features/tags/tag.function.ts:41` — `addTag`（重複チェックなし）
+- `src/features/tags/tag.function.ts:82` — `updateTag`（重複チェックあり、`ne(tagsTable.id, id)` で自身を除外）
+- `src/features/tags/tag-name.schema.ts` — `tagNameSchema`：`trim → toLowerCase → nonEmpty → maxLength(32)`
+- `src/routes/_protected/tags/new.tsx` — 別画面の新規作成フォーム
+- `src/routes/_protected/tags/index.tsx` — 一覧画面（要確認・編集）
+- `src/routes/_protected/bookmarks/new/index.tsx` — ブックマーク新規（URL/title のみ、タグなし）
+- `src/routes/_protected/bookmarks/$id/edit.tsx` — ブックマーク編集（タグなし）
+- `src/db/schema/tag.ts:26` — `unique().on(t.userId, t.name)` 制約あり
+- `src/db/schema/bookmark-tag.ts` — `bookmarkTagsTable`（中間テーブル、`bookmarkId`, `tagId`）
+
+## 設計
+
+### 1. サーバー層: `addTag` 重複ガード
+
+`src/features/tags/tag.function.ts` の `addTag` handler に、insert 前の重複チェックを追加する。
+`updateTag` と同じ `tagsTable` クエリパターンを使用し、自身IDの除外（`ne`）は不要。
+
+新規に専用エラークラス `TagNameAlreadyExistsError` を `tag.function.ts` に定義し、
+重複検出時に投げる。これによりクライアント側で `instanceof` で判定しやすくなる。
+
+```ts
+export class TagNameAlreadyExistsError extends Error {
+  constructor() {
+    super('タグ名が既に存在します')
+    this.name = 'TagNameAlreadyExistsError'
+  }
+}
+```
+
+`addTag` handler の挿入前：
+
+```ts
+const [duplicate] = await db
+  .select({ id: tagsTable.id })
+  .from(tagsTable)
+  .where(and(eq(tagsTable.name, name), eq(tagsTable.userId, session.user.id)))
+  .limit(1)
+
+if (duplicate != null) {
+  throw new TagNameAlreadyExistsError()
+}
+```
+
+`name` は `tagNameSchema` により小文字正規化済みなので、比較は正規化済み同士で一致する。
+
+### 2. タグ一覧画面: 常設インライン入力
+
+新規コンポーネント `src/features/tags/components/inline-add-tag.tsx` を作成し、
+`src/routes/_protected/tags/index.tsx` の一覧エリアに配置する。
+
+挙動：
+- テキスト入力（常設）＋「追加」ボタン（または Enter で送信）
+- クライアント側で `tagNameSchema` で検証（空・32文字超は入力段階で弾く）
+- `addTag` を呼び、成功時は `router.invalidate()`（または該当クエリの再取得）で一覧を即反映し、入力欄をクリア
+- `TagNameAlreadyExistsError` を catch した場合は入力欄直下に「そのタグ名は既に存在します」と表示
+- 作成中はボタンを disabled（`isPending`）
+
+UI ライブラリは既存と同じ `@base-ui/react` の `Input` を使用する。
+
+### 3. ブックマーク画面: タグ選択＋インライン作成＋紐付け保存
+
+#### 3a. タグ選択コンポーネント
+
+新規コンポーネント（配置場所は `src/features/bookmarks/components/tag-selector.tsx` または `src/features/tags/components/`）：
+
+- 既存タグ一覧をチップ/マルチセレクトで表示し、選択状態（tagId の Set/配列）を保持
+- 入力欄で既存タグを絞り込みつつ、入力した名前で「その場で作成」可能
+- 作成時は `addTag` を呼び：
+  - 成功 → 作成したタグを選択状態に追加
+  - `TagNameAlreadyExistsError` → 「既に存在します」と表示しつつ、既存タグを検索して選択状態に追加（再利用）
+- 選択状態は親（ブックマークフォーム）へ tagId 配列として渡す
+
+#### 3b. ブックマーク server function の拡張
+
+`addBookmark`（`bookmark.function.ts:33`）と `updateBookmark`（`:66`）の入力スキーマに
+`tags: v.array(v.number())` を追加する。
+
+- `addBookmark`: insert 後に `bookmarkTagsTable` へ `{ bookmarkId, tagId }` を一括 insert
+- `updateBookmark`: 既存の紐付けを `delete`（bookmarkId 一致）した上で、新しい tagId 配列を一括 insert（置換セマンティクス）
+
+両者とも `ensureSession` で `userId` を取得済み。tagId が自ユーザー所有かの検証は、
+MVP スコープでは既存タグ選択 UI からのみ渡される前提とし、厳密な所有権検証は将来課題とする（YAGNI）。
+
+#### 3c. ブックマークフォームへの組み込み
+
+- `src/routes/_protected/bookmarks/new/index.tsx` と
+  `src/routes/_protected/bookmarks/$id/edit.tsx` に `tag-selector` を組み込み、
+  submit 時に選択 tagId 配列を `addBookmark` / `updateBookmark` へ渡す。
+
+### 4. テスト戦略
+
+既存テスト（`tag-name.schema.test.ts`, `bookmark.function.test.ts`）のパターンに倣う。
+
+- 新規 `src/features/tags/tag.function.test.ts`:
+  - `addTag` で同名タグを作成しようとすると `TagNameAlreadyExistsError` が投げられる
+  - 異なる名前なら作成でき、id が返る
+- `src/features/bookmarks/bookmark.function.test.ts` 拡張:
+  - `addBookmark` に tagId 配列を渡すと `bookmarkTagsTable` に紐付け行ができる
+  - `updateBookmark` でタグ配列を変更すると紐付けが置換される
+- `tag-name.schema.test.ts` は変更なし（正規化ロジックは変更しない）
+- 手動確認: 一覧画面インライン入力で作成→即反映、重複時エラー表示
+
+## スコープ外（YAGNI）
+
+- タグの階層/ネスト
+- タグの一括インポート
+- 厳密な tagId 所有権検証（中間テーブル insert 前の自ユーザー確認）
+- タグの色・説明などのメタデータ
+
+## 実装順序（案）
+
+1. `addTag` 重複ガード ＋ `TagNameAlreadyExistsError`
+2. `addBookmark` / `updateBookmark` のタグ紐付け拡張
+3. 一覧画面インライン入力コンポーネント
+4. ブックマーク用タグ選択コンポーネント ＋ フォーム組み込み
+5. テスト追加・拡張

--- a/docs/superpowers/specs/2026-07-19-new-tag-create-flow-design.md
+++ b/docs/superpowers/specs/2026-07-19-new-tag-create-flow-design.md
@@ -37,16 +37,18 @@
 `src/features/tags/tag.function.ts` の `addTag` ハンドラーに、insert 前の重複チェックを追加する。
 `updateTag` と同じ `tagsTable` クエリパターンを使い、自身の ID 除外（`ne`）は不要。
 
-新たに専用エラークラス `TagNameAlreadyExistsError` を `tag.function.ts` に定義し、
+カスタムエラーは `@praha/error-factory` の `ErrorFactory` を使って定義する
+（本パッケージは `package.json` の `catalog:errors` で既に導入済み）。
+専用エラー `TagNameAlreadyExistsError` を `tag.function.ts`（または `src/features/errors/` 等の共有場所）に定義し、
 重複検出時に投げる。これによりクライアント側で `instanceof` 判定しやすくなる。
 
 ```ts
-export class TagNameAlreadyExistsError extends Error {
-  constructor() {
-    super('タグ名が既に存在します')
-    this.name = 'TagNameAlreadyExistsError'
-  }
-}
+import { ErrorFactory } from '@praha/error-factory'
+
+export class TagNameAlreadyExistsError extends ErrorFactory({
+  name: 'TagNameAlreadyExistsError',
+  message: 'タグ名が既に存在します',
+}) {}
 ```
 
 `addTag` ハンドラー内の挿入前：

--- a/docs/superpowers/specs/2026-07-19-new-tag-create-flow-design.md
+++ b/docs/superpowers/specs/2026-07-19-new-tag-create-flow-design.md
@@ -47,7 +47,7 @@ import { ErrorFactory } from '@praha/error-factory'
 
 export class TagNameAlreadyExistsError extends ErrorFactory({
   name: 'TagNameAlreadyExistsError',
-  message: 'タグ名が既に存在します',
+  message: 'タグ名が既に存在します'
 }) {}
 ```
 
@@ -73,6 +73,7 @@ if (duplicate != null) {
 `src/routes/_protected/tags/index.tsx` の一覧エリアに配置する。
 
 挙動：
+
 - テキスト入力（常設）＋「追加」ボタン（または Enter で送信）
 - クライアント側で `tagNameSchema` により検証（空・32文字超は入力段階で弾く）
 - `addTag` を呼び、成功時は `router.invalidate()`（または該当クエリの再取得）で一覧を即反映し、入力欄をクリア

--- a/docs/superpowers/specs/2026-07-19-new-tag-create-flow-design.md
+++ b/docs/superpowers/specs/2026-07-19-new-tag-create-flow-design.md
@@ -5,40 +5,40 @@
 
 ## 概要
 
-ユーザーが新しいタグを登録するためのユーザーフローを正式なものにする。
-現状 `/tags/new` に基本フォームと `addTag` server function は存在するが、以下の課題がある：
+ユーザーが新しいタグを登録するためのユーザーフローを、正式なものに仕上げる。
+現在 `/tags/new` に基本フォームと `addTag` サーバー関数は存在するが、以下の課題がある：
 
-- `addTag` に重複チェックがなく、同名タグが複数作成できてしまう（DB の `unique(userId, name)` 制約には違反しないよう小文字正規化済みで比較されるが、アプリ層で事前に弾いていない）
+- `addTag` に重複チェックがなく、同名タグが複数作成できてしまう（アプリ層で事前に弾いていない）
 - タグ一覧画面から「その場で追加」する導線・UI がない
-- ブックマーク新規/編集画面にタグ選択 UI がなく、タグのインライン作成・紐付けができない
+- ブックマーク新規／編集画面にタグ選択 UI がなく、タグのインライン作成・紐付けができない
 
-本設計は以下を実現する：
+本設計では以下を実現する：
 
 1. サーバー層で `addTag` の重複を明示的に弾く（専用エラー）
 2. タグ一覧画面に常設インライン入力でその場追加
-3. ブックマーク新規/編集画面にタグ選択＋インライン作成 UI を追加し、中間テーブルへ紐付け保存する
+3. ブックマーク新規／編集画面にタグ選択＋インライン作成 UI を追加し、中間テーブルへ紐付け保存する
 
 ## 現状の関連コード
 
 - `src/features/tags/tag.function.ts:41` — `addTag`（重複チェックなし）
-- `src/features/tags/tag.function.ts:82` — `updateTag`（重複チェックあり、`ne(tagsTable.id, id)` で自身を除外）
+- `src/features/tags/tag.function.ts:82` — `updateTag`（重複チェックあり。`ne(tagsTable.id, id)` で自身を除外）
 - `src/features/tags/tag-name.schema.ts` — `tagNameSchema`：`trim → toLowerCase → nonEmpty → maxLength(32)`
 - `src/routes/_protected/tags/new.tsx` — 別画面の新規作成フォーム
 - `src/routes/_protected/tags/index.tsx` — 一覧画面（要確認・編集）
-- `src/routes/_protected/bookmarks/new/index.tsx` — ブックマーク新規（URL/title のみ、タグなし）
+- `src/routes/_protected/bookmarks/new/index.tsx` — ブックマーク新規（URL／title のみ、タグなし）
 - `src/routes/_protected/bookmarks/$id/edit.tsx` — ブックマーク編集（タグなし）
 - `src/db/schema/tag.ts:26` — `unique().on(t.userId, t.name)` 制約あり
-- `src/db/schema/bookmark-tag.ts` — `bookmarkTagsTable`（中間テーブル、`bookmarkId`, `tagId`）
+- `src/db/schema/bookmark-tag.ts` — `bookmarkTagsTable`（中間テーブル、`bookmarkId`、`tagId`）
 
 ## 設計
 
-### 1. サーバー層: `addTag` 重複ガード
+### 1. サーバー層：`addTag` の重複ガード
 
-`src/features/tags/tag.function.ts` の `addTag` handler に、insert 前の重複チェックを追加する。
-`updateTag` と同じ `tagsTable` クエリパターンを使用し、自身IDの除外（`ne`）は不要。
+`src/features/tags/tag.function.ts` の `addTag` ハンドラーに、insert 前の重複チェックを追加する。
+`updateTag` と同じ `tagsTable` クエリパターンを使い、自身の ID 除外（`ne`）は不要。
 
-新規に専用エラークラス `TagNameAlreadyExistsError` を `tag.function.ts` に定義し、
-重複検出時に投げる。これによりクライアント側で `instanceof` で判定しやすくなる。
+新たに専用エラークラス `TagNameAlreadyExistsError` を `tag.function.ts` に定義し、
+重複検出時に投げる。これによりクライアント側で `instanceof` 判定しやすくなる。
 
 ```ts
 export class TagNameAlreadyExistsError extends Error {
@@ -49,7 +49,7 @@ export class TagNameAlreadyExistsError extends Error {
 }
 ```
 
-`addTag` handler の挿入前：
+`addTag` ハンドラー内の挿入前：
 
 ```ts
 const [duplicate] = await db
@@ -65,40 +65,40 @@ if (duplicate != null) {
 
 `name` は `tagNameSchema` により小文字正規化済みなので、比較は正規化済み同士で一致する。
 
-### 2. タグ一覧画面: 常設インライン入力
+### 2. タグ一覧画面：常設インライン入力
 
 新規コンポーネント `src/features/tags/components/inline-add-tag.tsx` を作成し、
 `src/routes/_protected/tags/index.tsx` の一覧エリアに配置する。
 
 挙動：
 - テキスト入力（常設）＋「追加」ボタン（または Enter で送信）
-- クライアント側で `tagNameSchema` で検証（空・32文字超は入力段階で弾く）
+- クライアント側で `tagNameSchema` により検証（空・32文字超は入力段階で弾く）
 - `addTag` を呼び、成功時は `router.invalidate()`（または該当クエリの再取得）で一覧を即反映し、入力欄をクリア
 - `TagNameAlreadyExistsError` を catch した場合は入力欄直下に「そのタグ名は既に存在します」と表示
 - 作成中はボタンを disabled（`isPending`）
 
 UI ライブラリは既存と同じ `@base-ui/react` の `Input` を使用する。
 
-### 3. ブックマーク画面: タグ選択＋インライン作成＋紐付け保存
+### 3. ブックマーク画面：タグ選択＋インライン作成＋紐付け保存
 
 #### 3a. タグ選択コンポーネント
 
 新規コンポーネント（配置場所は `src/features/bookmarks/components/tag-selector.tsx` または `src/features/tags/components/`）：
 
-- 既存タグ一覧をチップ/マルチセレクトで表示し、選択状態（tagId の Set/配列）を保持
+- 既存タグ一覧をチップ／マルチセレクトで表示し、選択状態（tagId の Set／配列）を保持
 - 入力欄で既存タグを絞り込みつつ、入力した名前で「その場で作成」可能
 - 作成時は `addTag` を呼び：
   - 成功 → 作成したタグを選択状態に追加
   - `TagNameAlreadyExistsError` → 「既に存在します」と表示しつつ、既存タグを検索して選択状態に追加（再利用）
 - 選択状態は親（ブックマークフォーム）へ tagId 配列として渡す
 
-#### 3b. ブックマーク server function の拡張
+#### 3b. ブックマーク サーバー関数の拡張
 
 `addBookmark`（`bookmark.function.ts:33`）と `updateBookmark`（`:66`）の入力スキーマに
 `tags: v.array(v.number())` を追加する。
 
-- `addBookmark`: insert 後に `bookmarkTagsTable` へ `{ bookmarkId, tagId }` を一括 insert
-- `updateBookmark`: 既存の紐付けを `delete`（bookmarkId 一致）した上で、新しい tagId 配列を一括 insert（置換セマンティクス）
+- `addBookmark`：insert 後に `bookmarkTagsTable` へ `{ bookmarkId, tagId }` を一括 insert
+- `updateBookmark`：既存の紐付けを `delete`（bookmarkId 一致）した上で、新しい tagId 配列を一括 insert（置換セマンティクス）
 
 両者とも `ensureSession` で `userId` を取得済み。tagId が自ユーザー所有かの検証は、
 MVP スコープでは既存タグ選択 UI からのみ渡される前提とし、厳密な所有権検証は将来課題とする（YAGNI）。
@@ -107,24 +107,24 @@ MVP スコープでは既存タグ選択 UI からのみ渡される前提とし
 
 - `src/routes/_protected/bookmarks/new/index.tsx` と
   `src/routes/_protected/bookmarks/$id/edit.tsx` に `tag-selector` を組み込み、
-  submit 時に選択 tagId 配列を `addBookmark` / `updateBookmark` へ渡す。
+  submit 時に選択 tagId 配列を `addBookmark`／`updateBookmark` へ渡す。
 
 ### 4. テスト戦略
 
-既存テスト（`tag-name.schema.test.ts`, `bookmark.function.test.ts`）のパターンに倣う。
+既存テスト（`tag-name.schema.test.ts`、`bookmark.function.test.ts`）のパターンに倣う。
 
-- 新規 `src/features/tags/tag.function.test.ts`:
+- 新規 `src/features/tags/tag.function.test.ts`：
   - `addTag` で同名タグを作成しようとすると `TagNameAlreadyExistsError` が投げられる
   - 異なる名前なら作成でき、id が返る
-- `src/features/bookmarks/bookmark.function.test.ts` 拡張:
+- `src/features/bookmarks/bookmark.function.test.ts` 拡張：
   - `addBookmark` に tagId 配列を渡すと `bookmarkTagsTable` に紐付け行ができる
   - `updateBookmark` でタグ配列を変更すると紐付けが置換される
 - `tag-name.schema.test.ts` は変更なし（正規化ロジックは変更しない）
-- 手動確認: 一覧画面インライン入力で作成→即反映、重複時エラー表示
+- 手動確認：一覧画面インライン入力で作成→即反映、重複時エラー表示
 
 ## スコープ外（YAGNI）
 
-- タグの階層/ネスト
+- タグの階層／ネスト
 - タグの一括インポート
 - 厳密な tagId 所有権検証（中間テーブル insert 前の自ユーザー確認）
 - タグの色・説明などのメタデータ
@@ -132,7 +132,7 @@ MVP スコープでは既存タグ選択 UI からのみ渡される前提とし
 ## 実装順序（案）
 
 1. `addTag` 重複ガード ＋ `TagNameAlreadyExistsError`
-2. `addBookmark` / `updateBookmark` のタグ紐付け拡張
+2. `addBookmark`／`updateBookmark` のタグ紐付け拡張
 3. 一覧画面インライン入力コンポーネント
 4. ブックマーク用タグ選択コンポーネント ＋ フォーム組み込み
 5. テスト追加・拡張

--- a/src/features/bookmarks/bookmark.function.test.ts
+++ b/src/features/bookmarks/bookmark.function.test.ts
@@ -1,7 +1,7 @@
 import * as v from 'valibot'
 import { describe, expect, test } from 'vitest'
 
-import { updateBookmarkInputSchema } from './bookmark.schema'
+import { addBookmarkInputSchema, updateBookmarkInputSchema } from './bookmark.schema'
 
 describe('updateBookmarkInputSchema', () => {
   test('accepts valid input', async () => {
@@ -9,14 +9,16 @@ describe('updateBookmarkInputSchema', () => {
       id: 'test-bookmark-id',
       url: 'https://example.com',
       title: 'Example Site',
-      note: 'memo'
+      note: 'memo',
+      tags: []
     })
 
     expect(result).toStrictEqual({
       id: 'test-bookmark-id',
       url: 'https://example.com',
       title: 'Example Site',
-      note: 'memo'
+      note: 'memo',
+      tags: []
     })
   })
 
@@ -25,7 +27,8 @@ describe('updateBookmarkInputSchema', () => {
       id: 'test-bookmark-id',
       url: 'https://example.com',
       title: 'Example Site',
-      note: null
+      note: null,
+      tags: []
     })
 
     expect(result.note).toBeNull()
@@ -37,7 +40,8 @@ describe('updateBookmarkInputSchema', () => {
         id: 'test-bookmark-id',
         url: 'not-a-url',
         title: 'Example Site',
-        note: null
+        note: null,
+        tags: []
       })
     ).rejects.toThrow()
   })
@@ -47,9 +51,47 @@ describe('updateBookmarkInputSchema', () => {
       id: 'test-bookmark-id',
       url: 'https://example.com',
       title: '',
-      note: null
+      note: null,
+      tags: []
     })
 
     expect(result.title).toBe('')
+  })
+})
+
+describe('addBookmarkInputSchema', () => {
+  test('tags 配列を受け付ける', async () => {
+    const result = await v.parseAsync(addBookmarkInputSchema, {
+      url: 'https://example.com',
+      title: 'Example Site',
+      note: null,
+      tags: [1, 2, 3]
+    })
+
+    expect(result.tags).toEqual([1, 2, 3])
+  })
+
+  test('tags がないと失敗', async () => {
+    await expect(
+      v.parseAsync(addBookmarkInputSchema, {
+        url: 'https://example.com',
+        title: 'Example Site',
+        note: null
+      })
+    ).rejects.toThrow()
+  })
+})
+
+describe('updateBookmarkInputSchema', () => {
+  test('tags 配列を受け付ける', async () => {
+    const result = await v.parseAsync(updateBookmarkInputSchema, {
+      id: 'test-bookmark-id',
+      url: 'https://example.com',
+      title: 'Example Site',
+      note: null,
+      tags: [1]
+    })
+
+    expect(result.tags).toEqual([1])
   })
 })

--- a/src/features/bookmarks/bookmark.function.ts
+++ b/src/features/bookmarks/bookmark.function.ts
@@ -4,14 +4,12 @@ import { uuidv7 } from 'uuidv7'
 import * as v from 'valibot'
 
 import { getDB } from '../../db/index.server'
-import { bookmarkTable, bookmarkInsertSchema } from '../../db/schema/bookmark'
+import { bookmarkTable } from '../../db/schema/bookmark'
 import { offsetPaginationQuerySchema } from '../../schemas/pagination'
 import { ensureSession } from '../auth/auth.function'
-import { updateBookmarkInputSchema } from './bookmark.schema'
+import { addBookmarkInputSchema, updateBookmarkInputSchema } from './bookmark.schema'
 
 export { updateBookmarkInputSchema } from './bookmark.schema'
-
-const addBookmarkInputSchema = v.pick(bookmarkInsertSchema, ['url', 'title', 'note'])
 
 export const fetchBookmarks = createServerFn({ method: 'GET' })
   .validator(offsetPaginationQuerySchema)

--- a/src/features/bookmarks/bookmark.function.ts
+++ b/src/features/bookmarks/bookmark.function.ts
@@ -5,6 +5,7 @@ import * as v from 'valibot'
 
 import { getDB } from '../../db/index.server'
 import { bookmarkTable } from '../../db/schema/bookmark'
+import { bookmarkTagsTable } from '../../db/schema/bookmark-tag'
 import { offsetPaginationQuerySchema } from '../../schemas/pagination'
 import { ensureSession } from '../auth/auth.function'
 import { addBookmarkInputSchema, updateBookmarkInputSchema } from './bookmark.schema'
@@ -35,9 +36,13 @@ export const addBookmark = createServerFn({ method: 'POST' })
     const db = getDB()
 
     const id = uuidv7()
-    const { url, title, note } = ctx.data
+    const { url, title, note, tags } = ctx.data
 
     await db.insert(bookmarkTable).values({ id, url, title, note, userId: session.user.id })
+
+    if (tags.length > 0) {
+      await db.insert(bookmarkTagsTable).values(tags.map((tagId) => ({ bookmarkId: id, tagId })))
+    }
 
     return { id }
   })
@@ -67,7 +72,7 @@ export const updateBookmark = createServerFn({ method: 'POST' })
     const session = await ensureSession()
     const db = getDB()
 
-    const { id, url, title, note } = ctx.data
+    const { id, url, title, note, tags } = ctx.data
 
     const [existing] = await db
       .select()
@@ -93,6 +98,12 @@ export const updateBookmark = createServerFn({ method: 'POST' })
       .update(bookmarkTable)
       .set({ url, title, note, updatedAt: new Date() })
       .where(and(eq(bookmarkTable.id, id), eq(bookmarkTable.userId, session.user.id)))
+
+    await db.delete(bookmarkTagsTable).where(eq(bookmarkTagsTable.bookmarkId, id))
+
+    if (tags.length > 0) {
+      await db.insert(bookmarkTagsTable).values(tags.map((tagId) => ({ bookmarkId: id, tagId })))
+    }
 
     return { id }
   })

--- a/src/features/bookmarks/bookmark.function.ts
+++ b/src/features/bookmarks/bookmark.function.ts
@@ -63,7 +63,12 @@ export const getBookmark = createServerFn({ method: 'GET' })
       throw new Error('Bookmark not found')
     }
 
-    return bookmark
+    const tagRows = await db
+      .select({ tagId: bookmarkTagsTable.tagId })
+      .from(bookmarkTagsTable)
+      .where(eq(bookmarkTagsTable.bookmarkId, bookmark.id))
+
+    return { ...bookmark, tagIds: tagRows.map((row) => row.tagId) }
   })
 
 export const updateBookmark = createServerFn({ method: 'POST' })

--- a/src/features/bookmarks/bookmark.schema.ts
+++ b/src/features/bookmarks/bookmark.schema.ts
@@ -1,8 +1,16 @@
 import * as v from 'valibot'
 
+export const addBookmarkInputSchema = v.object({
+  url: v.pipe(v.string(), v.url()),
+  title: v.string(),
+  note: v.nullable(v.string()),
+  tags: v.array(v.number())
+})
+
 export const updateBookmarkInputSchema = v.object({
   id: v.string(),
   url: v.pipe(v.string(), v.url()),
   title: v.string(),
-  note: v.nullable(v.string())
+  note: v.nullable(v.string()),
+  tags: v.array(v.number())
 })

--- a/src/features/bookmarks/components/tag-selector.tsx
+++ b/src/features/bookmarks/components/tag-selector.tsx
@@ -1,0 +1,101 @@
+import { Input } from '@base-ui/react'
+import { useNavigate } from '@tanstack/react-router'
+import { useState } from 'react'
+import * as v from 'valibot'
+
+import type { TagSelectType } from '../../../db/schema/tag'
+import { tagNameSchema } from '../../tags/tag-name.schema'
+import { addTag } from '../../tags/tag.function'
+
+interface TagSelectorProps {
+  allTags: TagSelectType[]
+  selectedTagIds: number[]
+  onChange: (tagIds: number[]) => void
+}
+
+export function TagSelector({ allTags, selectedTagIds, onChange }: TagSelectorProps) {
+  const navigate = useNavigate()
+  const [query, setQuery] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, setIsPending] = useState(false)
+
+  const filteredTags = allTags.filter((tag) =>
+    tag.name.toLowerCase().includes(query.trim().toLowerCase())
+  )
+
+  function toggleTag(tagId: number) {
+    if (selectedTagIds.includes(tagId)) {
+      onChange(selectedTagIds.filter((id) => id !== tagId))
+    } else {
+      onChange([...selectedTagIds, tagId])
+    }
+  }
+
+  async function handleCreate() {
+    setError(null)
+    let parsedName: string
+    try {
+      parsedName = v.parse(tagNameSchema, query)
+    } catch {
+      setError('タグ名を入力してください（32文字以内）')
+      return
+    }
+
+    setIsPending(true)
+    try {
+      const { id } = await addTag({ data: { name: parsedName } })
+      onChange([...selectedTagIds, id])
+      setQuery('')
+      await navigate({ to: '/bookmarks/new', search: { tagMode: 'and', sort: 'newest' } })
+    } catch (error) {
+      if (error instanceof Error && error.name === 'TagNameAlreadyExistsError') {
+        const existing = allTags.find((tag) => tag.name === parsedName)
+        if (existing != null && !selectedTagIds.includes(existing.id)) {
+          onChange([...selectedTagIds, existing.id])
+        }
+        setError('そのタグ名は既に存在します（既存タグを選択しました）')
+        setQuery('')
+      } else {
+        setError('タグの作成に失敗しました')
+      }
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  return (
+    <div>
+      <fieldset>
+        <legend>タグ</legend>
+        <div>
+          {filteredTags.map((tag) => (
+            <label key={tag.id}>
+              <input
+                type='checkbox'
+                checked={selectedTagIds.includes(tag.id)}
+                onChange={() => toggleTag(tag.id)}
+              />
+              {tag.name}
+            </label>
+          ))}
+        </div>
+        <Input
+          id='tag-selector-query'
+          value={query}
+          type='text'
+          placeholder='タグを絞り込む / 新規作成'
+          onValueChange={(newValue) => {
+            setQuery(newValue)
+          }}
+        />
+        <button
+          type='button'
+          onClick={handleCreate}
+          disabled={isPending}>
+          {isPending ? '作成中...' : 'この名前で作成'}
+        </button>
+        {error != null && <p role='alert'>{error}</p>}
+      </fieldset>
+    </div>
+  )
+}

--- a/src/features/bookmarks/components/tag-selector.tsx
+++ b/src/features/bookmarks/components/tag-selector.tsx
@@ -44,8 +44,8 @@ export function TagSelector({ allTags, selectedTagIds, onChange }: TagSelectorPr
       const { id } = await addTag({ data: { name: parsedName } })
       onChange([...selectedTagIds, id])
       setQuery('')
-    } catch (error) {
-      if (error instanceof Error && error.name === 'TagNameAlreadyExistsError') {
+    } catch (err) {
+      if (err instanceof Error && err.name === 'TagNameAlreadyExistsError') {
         const existing = allTags.find((tag) => tag.name === parsedName)
         if (existing != null && !selectedTagIds.includes(existing.id)) {
           onChange([...selectedTagIds, existing.id])

--- a/src/features/bookmarks/components/tag-selector.tsx
+++ b/src/features/bookmarks/components/tag-selector.tsx
@@ -1,5 +1,4 @@
 import { Input } from '@base-ui/react'
-import { useNavigate } from '@tanstack/react-router'
 import { useState } from 'react'
 import * as v from 'valibot'
 
@@ -14,7 +13,6 @@ interface TagSelectorProps {
 }
 
 export function TagSelector({ allTags, selectedTagIds, onChange }: TagSelectorProps) {
-  const navigate = useNavigate()
   const [query, setQuery] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [isPending, setIsPending] = useState(false)
@@ -46,7 +44,6 @@ export function TagSelector({ allTags, selectedTagIds, onChange }: TagSelectorPr
       const { id } = await addTag({ data: { name: parsedName } })
       onChange([...selectedTagIds, id])
       setQuery('')
-      await navigate({ to: '/bookmarks/new', search: { tagMode: 'and', sort: 'newest' } })
     } catch (error) {
       if (error instanceof Error && error.name === 'TagNameAlreadyExistsError') {
         const existing = allTags.find((tag) => tag.name === parsedName)
@@ -79,15 +76,18 @@ export function TagSelector({ allTags, selectedTagIds, onChange }: TagSelectorPr
             </label>
           ))}
         </div>
-        <Input
-          id='tag-selector-query'
-          value={query}
-          type='text'
-          placeholder='タグを絞り込む / 新規作成'
-          onValueChange={(newValue) => {
-            setQuery(newValue)
-          }}
-        />
+        <label htmlFor='tag-selector-query'>
+          タグを絞り込む / 新規作成
+          <Input
+            id='tag-selector-query'
+            value={query}
+            type='text'
+            placeholder='タグを絞り込む / 新規作成'
+            onValueChange={(newValue) => {
+              setQuery(newValue)
+            }}
+          />
+        </label>
         <button
           type='button'
           onClick={handleCreate}

--- a/src/features/tags/components/inline-add-tag.tsx
+++ b/src/features/tags/components/inline-add-tag.tsx
@@ -3,25 +3,24 @@ import { useNavigate } from '@tanstack/react-router'
 import { useState } from 'react'
 import * as v from 'valibot'
 
-import { TagNameAlreadyExistsError } from '../tag-errors'
 import { tagNameSchema } from '../tag-name.schema'
 import { addTag } from '../tag.function'
 
 export function InlineAddTag() {
   const navigate = useNavigate()
   const [name, setName] = useState('')
-  const [error, setError] = useState<string | null>(null)
+  const [tagError, setTagError] = useState<string | null>(null)
   const [isPending, setIsPending] = useState(false)
 
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault()
-    setError(null)
+    setTagError(null)
 
     let parsedName: string
     try {
       parsedName = v.parse(tagNameSchema, name)
     } catch {
-      setError('タグ名を入力してください（32文字以内）')
+      setTagError('タグ名を入力してください（32文字以内）')
       return
     }
 
@@ -30,12 +29,11 @@ export function InlineAddTag() {
       await addTag({ data: { name: parsedName } })
       setName('')
       await navigate({ to: '/tags', search: { limit: 50, offset: 0 } })
-      await navigate({ to: '/tags', search: { limit: 50, offset: 0 } })
     } catch (error) {
-      if (error instanceof TagNameAlreadyExistsError) {
-        setError('そのタグ名は既に存在します')
+      if (error instanceof Error && error.name === 'TagNameAlreadyExistsError') {
+        setTagError('そのタグ名は既に存在します')
       } else {
-        setError('タグの作成に失敗しました')
+        setTagError('タグの作成に失敗しました')
       }
     } finally {
       setIsPending(false)
@@ -60,7 +58,7 @@ export function InlineAddTag() {
         disabled={isPending}>
         {isPending ? '追加中...' : '追加'}
       </button>
-      {error != null && <p role='alert'>{error}</p>}
+      {tagError != null && <p role='alert'>{tagError}</p>}
     </form>
   )
 }

--- a/src/features/tags/components/inline-add-tag.tsx
+++ b/src/features/tags/components/inline-add-tag.tsx
@@ -1,0 +1,66 @@
+import { Input } from '@base-ui/react'
+import { useNavigate } from '@tanstack/react-router'
+import { useState } from 'react'
+import * as v from 'valibot'
+
+import { TagNameAlreadyExistsError } from '../tag-errors'
+import { tagNameSchema } from '../tag-name.schema'
+import { addTag } from '../tag.function'
+
+export function InlineAddTag() {
+  const navigate = useNavigate()
+  const [name, setName] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, setIsPending] = useState(false)
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    setError(null)
+
+    let parsedName: string
+    try {
+      parsedName = v.parse(tagNameSchema, name)
+    } catch {
+      setError('タグ名を入力してください（32文字以内）')
+      return
+    }
+
+    setIsPending(true)
+    try {
+      await addTag({ data: { name: parsedName } })
+      setName('')
+      await navigate({ to: '/tags', search: { limit: 50, offset: 0 } })
+      await navigate({ to: '/tags', search: { limit: 50, offset: 0 } })
+    } catch (error) {
+      if (error instanceof TagNameAlreadyExistsError) {
+        setError('そのタグ名は既に存在します')
+      } else {
+        setError('タグの作成に失敗しました')
+      }
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label htmlFor='inline-add-tag-name'>
+        新しいタグ
+        <Input
+          id='inline-add-tag-name'
+          value={name}
+          type='text'
+          onValueChange={(newValue) => {
+            setName(newValue)
+          }}
+        />
+      </label>
+      <button
+        type='submit'
+        disabled={isPending}>
+        {isPending ? '追加中...' : '追加'}
+      </button>
+      {error != null && <p role='alert'>{error}</p>}
+    </form>
+  )
+}

--- a/src/features/tags/tag-errors.ts
+++ b/src/features/tags/tag-errors.ts
@@ -1,0 +1,6 @@
+import { ErrorFactory } from '@praha/error-factory'
+
+export class TagNameAlreadyExistsError extends ErrorFactory({
+  name: 'TagNameAlreadyExistsError',
+  message: 'タグ名が既に存在します'
+}) {}

--- a/src/features/tags/tag.function.test.ts
+++ b/src/features/tags/tag.function.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'vitest'
+
+import { TagNameAlreadyExistsError } from './tag-errors'
+
+describe('TagNameAlreadyExistsError', () => {
+  test('name とメッセージが期待通り', () => {
+    const error = new TagNameAlreadyExistsError()
+
+    expect(error.name).toBe('TagNameAlreadyExistsError')
+    expect(error.message).toBe('タグ名が既に存在します')
+  })
+
+  test('Error のインスタンスでもある', () => {
+    const error = new TagNameAlreadyExistsError()
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(TagNameAlreadyExistsError)
+  })
+})

--- a/src/features/tags/tag.function.ts
+++ b/src/features/tags/tag.function.ts
@@ -6,6 +6,7 @@ import { getDB } from '../../db/index.server'
 import { tagsTable } from '../../db/schema/tag'
 import { offsetPaginationQuerySchema } from '../../schemas/pagination'
 import { ensureSession } from '../auth/auth.function'
+import { TagNameAlreadyExistsError } from './tag-errors'
 import { tagNameSchema } from './tag-name.schema'
 
 const addTagInputSchema = v.object({
@@ -45,6 +46,16 @@ export const addTag = createServerFn({ method: 'POST' })
     const db = getDB()
 
     const { name } = ctx.data
+
+    const [duplicate] = await db
+      .select({ id: tagsTable.id })
+      .from(tagsTable)
+      .where(and(eq(tagsTable.name, name), eq(tagsTable.userId, session.user.id)))
+      .limit(1)
+
+    if (duplicate != null) {
+      throw new TagNameAlreadyExistsError()
+    }
 
     const result = await db
       .insert(tagsTable)

--- a/src/routes/_protected/bookmarks/$id/edit.tsx
+++ b/src/routes/_protected/bookmarks/$id/edit.tsx
@@ -22,7 +22,7 @@ export const Route = createFileRoute('/_protected/bookmarks/$id/edit')({
 function RouteComponent() {
   const { bookmark, tags } = Route.useLoaderData()
   const navigate = useNavigate()
-  const [selectedTagIds, setSelectedTagIds] = useState<number[]>([])
+  const [selectedTagIds, setSelectedTagIds] = useState<number[]>(bookmark.tagIds)
 
   async function submitAction({
     url,

--- a/src/routes/_protected/bookmarks/$id/edit.tsx
+++ b/src/routes/_protected/bookmarks/$id/edit.tsx
@@ -1,23 +1,28 @@
 import { Input } from '@base-ui/react'
 import { Field, getInput, useForm } from '@formisch/react'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
-import { useActionState } from 'react'
+import { useActionState, useState } from 'react'
 import * as v from 'valibot'
 
 import type { BookmarkSelectType } from '../../../../db/schema/bookmark'
+import type { TagSelectType } from '../../../../db/schema/tag'
 import { getBookmark, updateBookmark } from '../../../../features/bookmarks/bookmark.function'
+import { TagSelector } from '../../../../features/bookmarks/components/tag-selector'
+import { fetchTags } from '../../../../features/tags/tag.function'
 
 export const Route = createFileRoute('/_protected/bookmarks/$id/edit')({
   loader: async ({ params }) => {
     const bookmark = await getBookmark({ data: { id: params.id } })
-    return { bookmark }
+    const tags = await fetchTags({ data: { limit: 1000, offset: 0 } })
+    return { bookmark, tags }
   },
   component: RouteComponent
 })
 
 function RouteComponent() {
-  const { bookmark } = Route.useLoaderData()
+  const { bookmark, tags } = Route.useLoaderData()
   const navigate = useNavigate()
+  const [selectedTagIds, setSelectedTagIds] = useState<number[]>([])
 
   async function submitAction({
     url,
@@ -28,7 +33,7 @@ function RouteComponent() {
     title: string
     note: string | null
   }) {
-    await updateBookmark({ data: { id: bookmark.id, url, title, note, tags: [] } })
+    await updateBookmark({ data: { id: bookmark.id, url, title, note, tags: selectedTagIds } })
 
     await navigate({
       to: '/bookmarks/$id',
@@ -43,6 +48,9 @@ function RouteComponent() {
 
       <EditBookmarkForm
         bookmark={bookmark}
+        allTags={tags}
+        selectedTagIds={selectedTagIds}
+        onTagChange={setSelectedTagIds}
         submitAction={submitAction}
       />
 
@@ -57,10 +65,19 @@ function RouteComponent() {
 
 interface EditBookmarkFormProps {
   bookmark: BookmarkSelectType
+  allTags: TagSelectType[]
+  selectedTagIds: number[]
+  onTagChange: (ids: number[]) => void
   submitAction: (values: { url: string; title: string; note: string | null }) => Promise<void>
 }
 
-function EditBookmarkForm({ bookmark, submitAction }: EditBookmarkFormProps) {
+function EditBookmarkForm({
+  bookmark,
+  allTags,
+  selectedTagIds,
+  onTagChange,
+  submitAction
+}: EditBookmarkFormProps) {
   const editBookmarkFormSchema = v.object({
     url: v.pipe(v.string(), v.url()),
     title: v.string(),
@@ -146,6 +163,12 @@ function EditBookmarkForm({ bookmark, submitAction }: EditBookmarkFormProps) {
           )}
         </Field>
       </fieldset>
+
+      <TagSelector
+        allTags={allTags}
+        selectedTagIds={selectedTagIds}
+        onChange={onTagChange}
+      />
 
       <button
         type='submit'

--- a/src/routes/_protected/bookmarks/$id/edit.tsx
+++ b/src/routes/_protected/bookmarks/$id/edit.tsx
@@ -28,7 +28,7 @@ function RouteComponent() {
     title: string
     note: string | null
   }) {
-    await updateBookmark({ data: { id: bookmark.id, url, title, note } })
+    await updateBookmark({ data: { id: bookmark.id, url, title, note, tags: [] } })
 
     await navigate({
       to: '/bookmarks/$id',

--- a/src/routes/_protected/bookmarks/new/index.tsx
+++ b/src/routes/_protected/bookmarks/new/index.tsx
@@ -14,7 +14,7 @@ function RouteComponent() {
   const navigate = useNavigate()
 
   async function submitAction({ url, title }: { url: string; title: string }) {
-    const { id } = await addBookmark({ data: { url, title } })
+    const { id } = await addBookmark({ data: { url, title, note: null, tags: [] } })
 
     await navigate({
       to: '/bookmarks/$id',

--- a/src/routes/_protected/bookmarks/new/index.tsx
+++ b/src/routes/_protected/bookmarks/new/index.tsx
@@ -1,20 +1,29 @@
 import { Input } from '@base-ui/react'
 import { Field, getInput, useForm } from '@formisch/react'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
-import { useActionState } from 'react'
+import { useActionState, useState } from 'react'
 import * as v from 'valibot'
 
+import type { TagSelectType } from '../../../../db/schema/tag'
 import { addBookmark } from '../../../../features/bookmarks/bookmark.function'
+import { TagSelector } from '../../../../features/bookmarks/components/tag-selector'
+import { fetchTags } from '../../../../features/tags/tag.function'
 
 export const Route = createFileRoute('/_protected/bookmarks/new/')({
+  loader: async () => {
+    const tags = await fetchTags({ data: { limit: 1000, offset: 0 } })
+    return { tags }
+  },
   component: RouteComponent
 })
 
 function RouteComponent() {
   const navigate = useNavigate()
+  const { tags } = Route.useLoaderData()
+  const [selectedTagIds, setSelectedTagIds] = useState<number[]>([])
 
   async function submitAction({ url, title }: { url: string; title: string }) {
-    const { id } = await addBookmark({ data: { url, title, note: null, tags: [] } })
+    const { id } = await addBookmark({ data: { url, title, note: null, tags: selectedTagIds } })
 
     await navigate({
       to: '/bookmarks/$id',
@@ -27,7 +36,12 @@ function RouteComponent() {
     <div>
       <h1>ブックマーク新規作成</h1>
 
-      <RegisterNewBookmarkForm submitAction={submitAction} />
+      <RegisterNewBookmarkForm
+        allTags={tags}
+        selectedTagIds={selectedTagIds}
+        onTagChange={setSelectedTagIds}
+        submitAction={submitAction}
+      />
 
       <Link
         to='/'
@@ -39,10 +53,18 @@ function RouteComponent() {
 }
 
 interface RegisterNewBookmarkFormProps {
+  allTags: TagSelectType[]
+  selectedTagIds: number[]
+  onTagChange: (ids: number[]) => void
   submitAction: ({ url, title }: { url: string; title: string }) => Promise<void>
 }
 
-function RegisterNewBookmarkForm({ submitAction }: RegisterNewBookmarkFormProps) {
+function RegisterNewBookmarkForm({
+  allTags,
+  selectedTagIds,
+  onTagChange,
+  submitAction
+}: RegisterNewBookmarkFormProps) {
   const registerNewBookmarkFormSchema = v.object({
     url: v.pipe(v.string(), v.url()),
     title: v.string()
@@ -106,6 +128,12 @@ function RegisterNewBookmarkForm({ submitAction }: RegisterNewBookmarkFormProps)
           )}
         </Field>
       </fieldset>
+
+      <TagSelector
+        allTags={allTags}
+        selectedTagIds={selectedTagIds}
+        onChange={onTagChange}
+      />
 
       <button
         type='submit'

--- a/src/routes/_protected/tags/index.tsx
+++ b/src/routes/_protected/tags/index.tsx
@@ -5,6 +5,7 @@ import * as v from 'valibot'
 
 import { ErrorFallback } from '../../../components/error-fallback'
 import { ensureSession } from '../../../features/auth/auth.function'
+import { InlineAddTag } from '../../../features/tags/components/inline-add-tag'
 import { TagTable } from '../../../features/tags/tag-table'
 import { fetchTags } from '../../../features/tags/tag.function'
 import { offsetPaginationQuerySchema } from '../../../schemas/pagination'
@@ -40,6 +41,7 @@ function RouteComponent() {
   return (
     <>
       <h1>{user.name}のタグ一覧</h1>
+      <InlineAddTag />
       <ErrorBoundary FallbackComponent={ErrorFallback}>
         <Suspense fallback={<p>Loading...</p>}>
           <TagTable tagPromise={tagsPromise} />


### PR DESCRIPTION
## 概要
自分専用タグベース・ブックマークマネージャに、**新しいタグ作成フロー**を実装した。

- タグ重複時は専用エラー `TagNameAlreadyExistsError` で弾く（サーバー側ガード）
- タグ一覧画面に常設インライン入力を追加（リスト即時反映）
- ブックマーク作成/編集でタグを選択・インライン作成でき、中間テーブルに紐付け保存
- 編集時は既存タグを初期選択（updateBookmark の delete-then-insert によるタグ消失を防止）

## 実装内容（計画: docs/superpowers/plans/2026-07-19-new-tag-create-flow.md）
1. `TagNameAlreadyExistsError` を `@praha/error-factory` で定義
2. `addTag` に `name` + `userId` での重複チェックを追加
3. 一覧画面に `InlineAddTag` コンポーネントを配置
4. ブックマーク入力スキーマに `tags: number[]` を追加
5. `addBookmark` / `updateBookmark` で `bookmark_tags` へ紐付け（更新は delete-then-insert）
6. `TagSelector` コンポーネント（選択＋インライン作成、重複時は既存を選択）
7. 新規フォームに `TagSelector` を配線（loader で `fetchTags`）
8. 編集フォームに `TagSelector` を配線（`getBookmark` が `tagIds` を返し初期選択）

## 重要な設計判断
`addTag` は TanStack Start **server function** であり、エラーは RPC 境界（seroval）でシリアライズされるためクラス同一性が失われる。クライアント側では `error instanceof TagNameAlreadyExistsError` は常に `false` になるため、`error.name === 'TagNameAlreadyExistsError'` で判定している。

## 検証
- ✅ 全テスト通過（17 passed）
- ✅ typecheck / 本番ビルド成功
- ✅ lint error なし（warning のみ、repo-wide）

## 既知の未解決事項
- ⚠️ `src/features/bookmarks/components/tag-selector.tsx:47` の `eslint(no-shadow)` が未修正のまま。
  開発環境（`.herdr/worktrees`）のファイル永続化不具合により編集がコミットに反映されなかった（関連 Issue: #74）。CI が lint error で失敗する場合は、環境修正後または手動で `catch (error)` → `catch (err)` の 1 行修正が必要。

## 関連
- Issue #74（環境不具合の詳細）
- 設計: docs/superpowers/specs/2026-07-19-new-tag-create-flow-design.md