### PR TITLE
feat: ブックマーク一覧のIDに詳細画面へのリンクを追加

### DIFF
--- a/src/features/bookmarks/components/bookmark-table.tsx
+++ b/src/features/bookmarks/components/bookmark-table.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@tanstack/react-router'
 import { use } from 'react'
 
 import { BookmarkSelectType } from '../../../db/schema/bookmark'
@@ -23,7 +24,13 @@ export function BookmarkTable({ bookmarkPromise }: BookmarkTableProps) {
       <tbody>
         {tags.map((tag) => (
           <tr key={tag.id}>
-            <td>{tag.id}</td>
+            <td>
+              <Link
+                to='/bookmarks/$id'
+                params={{ id: tag.id }}>
+                {tag.id}
+              </Link>
+            </td>
             <td>{tag.title}</td>
             <td>{tag.url}</td>
             <td>{tag.note}</td>


### PR DESCRIPTION
## 概要
ブックマーク一覧画面（`BookmarkTable`）のIDセルを詳細画面（`/bookmarks/$id`）へのリンクに変更する。

## 変更内容
- `src/features/bookmarks/components/bookmark-table.tsx` のIDを `Link` でラップ

## 関連
- タグ側は別PR（feat/tag-list-link-to-detail）で対応