### PR TITLE
feat: タグ一覧のIDに詳細画面へのリンクを追加

### DIFF
--- a/src/features/tags/tag-table.tsx
+++ b/src/features/tags/tag-table.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@tanstack/react-router'
 import { use } from 'react'
 
 import { TagSelectType } from '../../db/schema/tag'
@@ -17,7 +18,13 @@ export function TagTable({ tagPromise }: { readonly tagPromise: Promise<TagSelec
       <tbody>
         {tags.map((tag) => (
           <tr key={tag.id}>
-            <td>{tag.id}</td>
+            <td>
+              <Link
+                to='/tags/$id'
+                params={{ id: tag.id.toString() }}>
+                {tag.id}
+              </Link>
+            </td>
             <td>{tag.name}</td>
             <td>{tag.updatedAt.toString()}</td>
           </tr>


### PR DESCRIPTION
## 概要
タグ一覧画面（`TagTable`）のIDセルを詳細画面（`/tags/$id`）へのリンクに変更する。

## 変更内容
- `src/features/tags/tag-table.tsx` のIDを `Link` でラップ
- タグIDは数値型のため `toString()` でルートパラメータ（文字列）に変換

## 関連
- ブックマーク側は別PR（feat/bookmark-list-link-to-detail）で対応