### PR TITLE
fix: 日付の決定的描画でhydration mismatchを解消

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 # TypeSpec output
 api-spec/tsp-output/
 api-spec/dist/
+
+# git worktrees
+.worktrees/

--- a/src/features/bookmarks/components/bookmark-table.tsx
+++ b/src/features/bookmarks/components/bookmark-table.tsx
@@ -2,6 +2,7 @@ import { Link } from '@tanstack/react-router'
 import { use } from 'react'
 
 import { BookmarkSelectType } from '../../../db/schema/bookmark'
+import { formatDateTime } from '../../../lib/format-date'
 
 interface BookmarkTableProps {
   readonly bookmarkPromise: Promise<BookmarkSelectType[]>
@@ -34,7 +35,7 @@ export function BookmarkTable({ bookmarkPromise }: BookmarkTableProps) {
             <td>{tag.title}</td>
             <td>{tag.url}</td>
             <td>{tag.note}</td>
-            <td>{tag.updatedAt.toString()}</td>
+            <td>{formatDateTime(tag.updatedAt)}</td>
           </tr>
         ))}
       </tbody>

--- a/src/features/tags/tag-table.tsx
+++ b/src/features/tags/tag-table.tsx
@@ -2,6 +2,7 @@ import { Link } from '@tanstack/react-router'
 import { use } from 'react'
 
 import { TagSelectType } from '../../db/schema/tag'
+import { formatDateTime } from '../../lib/format-date'
 
 export function TagTable({ tagPromise }: { readonly tagPromise: Promise<TagSelectType[]> }) {
   const tags = use(tagPromise)
@@ -26,7 +27,7 @@ export function TagTable({ tagPromise }: { readonly tagPromise: Promise<TagSelec
               </Link>
             </td>
             <td>{tag.name}</td>
-            <td>{tag.updatedAt.toString()}</td>
+            <td>{formatDateTime(tag.updatedAt)}</td>
           </tr>
         ))}
       </tbody>

--- a/src/lib/format-date.ts
+++ b/src/lib/format-date.ts
@@ -1,0 +1,13 @@
+const dateTimeFormatter = new Intl.DateTimeFormat('ja-JP', {
+  timeZone: 'UTC',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit'
+})
+
+export function formatDateTime(date: Date): string {
+  return dateTimeFormatter.format(date)
+}


### PR DESCRIPTION
## 概要
ブックマーク一覧画面とタグ一覧画面で発生していた hydration mismatch を修正しました。

## 根本原因
両画面で `updatedAt` を `Date.toString()` で描画していたため、タイムゾーンに依存した文字列が出力されていました。
- サーバー（Cloudflare / UTC）: `Fri May 13 2022 00:46:31 GMT+0000`
- クライアント（ブラウザ / ローカルTZ）: `Fri May 13 2022 09:46:31 GMT+0900`

この乖離が hydration mismatch の原因でした。

## 変更内容
- `src/lib/format-date.ts`: `Intl.DateTimeFormat('ja-JP', { timeZone: 'UTC', ... })` による決定的な日付フォーマッタを追加
- `src/features/bookmarks/components/bookmark-table.tsx`: 上記フォーマッタを使用
- `src/features/tags/tag-table.tsx`: 上記フォーマッタを使用

サーバー・クライアント双方で同一の UTC ベース出力（例: `2022/05/13 00:46:31`）となるため、mismatch が解消されます。

## 検証
- Playwright（開発サーバーを `TZ=UTC` で起動）: 両画面ともコンソールエラー0件、日付セルがサーバー/クライアントで一致
- `typecheck` / `lint` / `test`（17件通過）: グリーン