### PR TITLE
fix(db): 本番で Turso env が undefined になり 500 になる問題を修正

### DIFF
--- a/src/db/index.server.ts
+++ b/src/db/index.server.ts
@@ -6,31 +6,29 @@ import * as authTables from './schema/auth-schema'
 import { bookmarkTable } from './schema/bookmark'
 import { bookmarkTagsTable } from './schema/bookmark-tag'
 import { tagsTable } from './schema/tag'
+import { resolveTursoConnection } from './turso-connection'
 
-export const db = drizzle({
-  connection: {
-    authToken: env.TURSO_AUTH_TOKEN,
-    url: env.TURSO_CONNECTION_URL
-  },
-  schema: {
-    ...authTables,
-    bookmark: bookmarkTable,
-    bookmarkTags: bookmarkTagsTable,
-    tags: tagsTable
-  }
-})
+const schema = {
+  ...authTables,
+  bookmark: bookmarkTable,
+  bookmarkTags: bookmarkTagsTable,
+  tags: tagsTable
+}
 
-export const getDB = createServerOnlyFn(() =>
-  drizzle({
-    connection: {
-      authToken: env.TURSO_AUTH_TOKEN,
-      url: env.TURSO_CONNECTION_URL
-    },
-    schema: {
-      ...authTables,
-      bookmark: bookmarkTable,
-      bookmarkTags: bookmarkTagsTable,
-      tags: tagsTable
-    }
+type PantryDB = ReturnType<typeof createDb>
+
+function createDb(connection: { url: string; authToken: string }) {
+  return drizzle({
+    connection,
+    schema
   })
-)
+}
+
+let cachedDb: PantryDB | undefined
+
+export const getDB = createServerOnlyFn(() => {
+  if (cachedDb === undefined) {
+    cachedDb = createDb(resolveTursoConnection(env))
+  }
+  return cachedDb
+})

--- a/src/db/turso-connection.test.ts
+++ b/src/db/turso-connection.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest'
+
+import { resolveTursoConnection } from './turso-connection'
+
+describe('resolveTursoConnection', () => {
+  test('reads url and authToken from the provided env at call time', () => {
+    const envBag: {
+      TURSO_CONNECTION_URL?: string
+      TURSO_AUTH_TOKEN?: string
+    } = {}
+
+    envBag.TURSO_CONNECTION_URL = 'libsql://pantry-production-db.turso.io'
+    envBag.TURSO_AUTH_TOKEN = 'test-token'
+
+    expect(resolveTursoConnection(envBag)).toEqual({
+      url: 'libsql://pantry-production-db.turso.io',
+      authToken: 'test-token'
+    })
+  })
+
+  test('throws when TURSO_CONNECTION_URL is missing', () => {
+    expect(() =>
+      resolveTursoConnection({
+        TURSO_AUTH_TOKEN: 'test-token'
+      })
+    ).toThrow(/TURSO_CONNECTION_URL/)
+  })
+
+  test('throws when TURSO_AUTH_TOKEN is missing', () => {
+    expect(() =>
+      resolveTursoConnection({
+        TURSO_CONNECTION_URL: 'libsql://pantry-production-db.turso.io'
+      })
+    ).toThrow(/TURSO_AUTH_TOKEN/)
+  })
+})

--- a/src/db/turso-connection.ts
+++ b/src/db/turso-connection.ts
@@ -1,0 +1,23 @@
+export type TursoConnectionEnv = {
+  readonly TURSO_CONNECTION_URL?: string
+  readonly TURSO_AUTH_TOKEN?: string
+}
+
+export type TursoConnection = {
+  readonly url: string
+  readonly authToken: string
+}
+
+export function resolveTursoConnection(env: TursoConnectionEnv): TursoConnection {
+  const url = env.TURSO_CONNECTION_URL
+  if (url === undefined || url.length === 0) {
+    throw new Error('TURSO_CONNECTION_URL is not defined')
+  }
+
+  const authToken = env.TURSO_AUTH_TOKEN
+  if (authToken === undefined) {
+    throw new Error('TURSO_AUTH_TOKEN is not defined')
+  }
+
+  return { url, authToken }
+}

--- a/src/features/auth/auth-config.ts
+++ b/src/features/auth/auth-config.ts
@@ -1,22 +1,36 @@
 import { drizzleAdapter } from '@better-auth/drizzle-adapter'
+import { createServerOnlyFn } from '@tanstack/react-start'
 import { betterAuth } from 'better-auth'
 import { admin } from 'better-auth/plugins'
 import { env } from 'cloudflare:workers'
 
-import { db } from '../../db/index.server'
+import { getDB } from '../../db/index.server'
 import * as schema from '../../db/schema/auth-schema'
 
-export const auth = betterAuth({
-  baseURL: env.BETTER_AUTH_URL,
-  secret: env.BETTER_AUTH_SECRET,
-  database: drizzleAdapter(db, {
-    provider: 'sqlite',
-    schema: {
-      ...schema
-    }
-  }),
-  emailAndPassword: {
-    enabled: true
-  },
-  plugins: [admin()]
+type Auth = ReturnType<typeof createAuth>
+
+function createAuth() {
+  return betterAuth({
+    baseURL: env.BETTER_AUTH_URL,
+    secret: env.BETTER_AUTH_SECRET,
+    database: drizzleAdapter(getDB(), {
+      provider: 'sqlite',
+      schema: {
+        ...schema
+      }
+    }),
+    emailAndPassword: {
+      enabled: true
+    },
+    plugins: [admin()]
+  })
+}
+
+let cachedAuth: Auth | undefined
+
+export const getAuth = createServerOnlyFn(() => {
+  if (cachedAuth === undefined) {
+    cachedAuth = createAuth()
+  }
+  return cachedAuth
 })

--- a/src/features/auth/auth.function.ts
+++ b/src/features/auth/auth.function.ts
@@ -1,17 +1,17 @@
 import { createServerFn } from '@tanstack/react-start'
 import { getRequestHeaders } from '@tanstack/react-start/server'
 
-import { auth } from './auth-config'
+import { getAuth } from './auth-config'
 
 export const getSession = createServerFn({ method: 'GET' }).handler(async () => {
   const headers = getRequestHeaders()
-  const session = await auth.api.getSession({ headers })
+  const session = await getAuth().api.getSession({ headers })
   return session
 })
 
 export const ensureSession = createServerFn({ method: 'GET' }).handler(async () => {
   const headers = getRequestHeaders()
-  const session = await auth.api.getSession({ headers })
+  const session = await getAuth().api.getSession({ headers })
   if (!session) {
     throw new Error('Unauthorized')
   }

--- a/src/routes/api/auth/$.ts
+++ b/src/routes/api/auth/$.ts
@@ -1,12 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router'
 
-import { auth } from '../../../features/auth/auth-config'
+import { getAuth } from '../../../features/auth/auth-config'
 
 export const Route = createFileRoute('/api/auth/$')({
   server: {
     handlers: {
-      GET: async ({ request }: { request: Request }) => auth.handler(request),
-      POST: async ({ request }: { request: Request }) => auth.handler(request)
+      GET: async ({ request }: { request: Request }) => getAuth().handler(request),
+      POST: async ({ request }: { request: Request }) => getAuth().handler(request)
     }
   }
 })


### PR DESCRIPTION
## Summary
- 本番 (`pantry.koralle-mgmg.com`) が毎リクエスト 500 になる原因は、モジュール初期化時に `env.TURSO_CONNECTION_URL` を読むと `undefined` になることだった
- `getDB` / `getAuth` でリクエスト時に env を遅延解決し、eager な `db` / `auth` トップレベル初期化をやめた
- Turso connection の解決ロジックを単体テスト可能な関数に切り出した

## Test plan
- [x] `pnpm run test`（38 tests）
- [x] `pnpm run typecheck`
- [ ] デプロイ後に `https://pantry.koralle-mgmg.com/` と `/sign-in` が 500 にならないこと
- [ ] サインイン〜ブックマーク一覧が表示できること


Made with [Cursor](https://cursor.com)