### PR TITLE
fix(ci/opencode): ワークフローのインデント修正とpermissions追加

### DIFF
--- a/.github/workflows/opencode.yaml
+++ b/.github/workflows/opencode.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
+      pull-requests: write
+      issues: write
     steps:
        - name: Checkout repository
          uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -22,9 +24,9 @@ jobs:
            persist-credentials: false
 
        - name: Run OpenCode
-        uses: anomalyco/opencode/github@latest
-        env:
-          QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
-        with:
-          model: alibaba-token-plan/qwen3.8-max-preview
+         uses: anomalyco/opencode/github@latest
+         env:
+           QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
+         with:
+           model: alibaba-token-plan/qwen3.8-max-preview
 

--- a/.github/workflows/opencode.yaml
+++ b/.github/workflows/opencode.yaml
@@ -1,4 +1,4 @@
-name: OpenCode 
+name: OpenCode
 
 on:
   issue_comment:
@@ -17,16 +17,15 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-       - name: Checkout repository
-         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-         with:
-           fetch-depth: 1
-           persist-credentials: false
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
 
-       - name: Run OpenCode
-         uses: anomalyco/opencode/github@latest
-         env:
-           QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
-         with:
-           model: alibaba-token-plan/qwen3.8-max-preview
-
+      - name: Run OpenCode
+        uses: anomalyco/opencode/github@latest
+        env:
+          QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
+        with:
+          model: alibaba-token-plan/qwen3.8-max-preview


### PR DESCRIPTION
## 変更内容

`.github/workflows/opencode.yaml` のレビューで指摘した問題のうち、2点（ピン留め以外）を修正。

- **インデント修正**: `Run OpenCode` ステップの `uses:` / `env:` / `with:` のインデントが1つ目のステップとずれており、YAML構造が壊れていたのを修正
- **permissions追加**: PR/Issue へのコメント投稿に必要な `pull-requests: write` と `issues: write` を追加

## 補足
- `anomalyco/opencode/github@latest` の SHA ピン留め（サプライチェーン攻撃対策）は今回は見送り