### PR TITLE
fix: opencode workflowのバグ修正

### DIFF
--- a/.github/workflows/opencode.yaml
+++ b/.github/workflows/opencode.yaml
@@ -13,6 +13,7 @@ jobs:
       contains(github.event.comment.body, '/opencode')
     runs-on: ubuntu-24.04
     permissions:
+      contents: read
       id-token: write
       pull-requests: write
       issues: write
@@ -28,4 +29,4 @@ jobs:
         env:
           QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
         with:
-          model: alibaba-token-plan/qwen3.8-max-preview
+          model: balian-token-plan-personal/qwen3.8-max-preview


### PR DESCRIPTION
## 修正内容

- `contents: read` 権限の追加（jobレベルでpermissionsを指定すると未列挙の権限はnoneになるため、checkoutが失敗する問題の修正）
- プロバイダIDを `opencode.jsonc` の定義（`balian-token-plan-personal`）と一致させる