### PR TITLE
fix(ci/opencode): contents権限をwriteに変更

### DIFF
--- a/.github/workflows/opencode.yaml
+++ b/.github/workflows/opencode.yaml
@@ -13,8 +13,8 @@ jobs:
       contains(github.event.comment.body, '/opencode')
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
       id-token: write
+      contents: write
       pull-requests: write
       issues: write
     steps:


### PR DESCRIPTION
opencode actionがブランチのpush・コミットを行うために contents: write が必要。