### PR TITLE
fix(cd): use wrangler deploy instead of pages deploy

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   deploy:
-    name: Deploy Cloudflare Pages production
+    name: Deploy Cloudflare Workers production
     runs-on: ubuntu-24.04
 
     steps:
@@ -34,7 +34,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: >-
-            pages deploy ./dist
-            --project-name pantry
-            --branch=main
+          command: deploy


### PR DESCRIPTION
## 問題

デプロイワークフローが `wrangler pages deploy` を使用していたが、`pantry` は Pages プロジェクトではなく Workers としてデプロイされているため、以下のエラーで失敗していた:

```
Project not found. The specified project name does not match any of your existing projects. [code: 8000007]
```

## 修正

- `pages deploy ./dist --project-name pantry --branch=main` → `deploy` に変更
- ジョブ名を `Deploy Cloudflare Pages production` → `Deploy Cloudflare Workers production` に変更

`wrangler deploy` は `wrangler.jsonc` の設定を読み取るため、追加の引数は不要。