### PR TITLE
chore: add GitHub Issue Forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,47 @@
+name: Bug
+description: 壊れている、または意図と違う挙動を報告する
+labels: [bug]
+body:
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待する振る舞い
+      description: 本来どうなるべきか
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: 実際の振る舞い
+      description: いま何が起きているか
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: 再現手順
+      description: 再現に必要な操作を順番に
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: dropdown
+    id: environment
+    attributes:
+      label: 環境
+      description: 任意。分かれば選択
+      options:
+        - local
+        - preview
+        - production
+    validations:
+      required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: 関連メモ
+      description: 任意。ログ、スクショ、関連 Issue など
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,25 @@
+name: Chore
+description: リファクタ、CI、依存更新、インフラなどの作業
+labels: [chore]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: 何をするか
+      description: 具体的な作業内容
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: なぜ今やるか
+      description: やる理由・緊急性
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: 影響範囲
+      description: 任意。触るパッケージ、CI、デプロイなど
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,36 @@
+name: Feature
+description: 新しい振る舞い・画面・フローを追加する
+labels: [feature]
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: やりたいこと
+      description: 何を追加・変更したいか
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: 受け入れ条件
+      description: 完了とみなせる条件
+      placeholder: |
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+  - type: input
+    id: design-doc
+    attributes:
+      label: Design doc
+      description: 任意。docs/superpowers/specs/ へのパス
+      placeholder: docs/superpowers/specs/YYYY-MM-DD-topic-design.md
+    validations:
+      required: false
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: スコープ外
+      description: 任意。今回やらないこと
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/uiux.yml
+++ b/.github/ISSUE_TEMPLATE/uiux.yml
@@ -1,0 +1,48 @@
+name: UIUX
+description: 既存機能の見た目・操作感・モーションを改善する
+labels: [uiux]
+body:
+  - type: textarea
+    id: friction
+    attributes:
+      label: 今の摩擦
+      description: いまどこが使いにくい・違和感があるか
+    validations:
+      required: true
+  - type: textarea
+    id: desired-feel
+    attributes:
+      label: 目指す感触
+      description: どう感じられるようにしたいか
+    validations:
+      required: true
+  - type: textarea
+    id: screens
+    attributes:
+      label: 対象画面・ルート
+      description: 影響する画面やルート
+      placeholder: 例: /bookmarks、一覧のタグ棚
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: スクショ / 参考
+      description: 任意。現状のスクショや参考リンク
+    validations:
+      required: false
+  - type: textarea
+    id: motion-a11y
+    attributes:
+      label: Motion / a11y メモ
+      description: 任意。アニメーション、reduced motion、キーボード操作など
+    validations:
+      required: false
+  - type: input
+    id: design-doc
+    attributes:
+      label: Design doc
+      description: 任意。docs/superpowers/specs/ へのパス
+      placeholder: docs/superpowers/specs/YYYY-MM-DD-topic-design.md
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/uiux.yml
+++ b/.github/ISSUE_TEMPLATE/uiux.yml
@@ -21,7 +21,7 @@ body:
     attributes:
       label: 対象画面・ルート
       description: 影響する画面やルート
-      placeholder: 例: /bookmarks、一覧のタグ棚
+      placeholder: '例: /bookmarks、一覧のタグ棚'
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
## Summary
- Add Issue Forms under `.github/ISSUE_TEMPLATE/` for Bug, Feature, UIUX, and Chore
- Disable blank issues via `config.yml` (`blank_issues_enabled: false`)
- Forms auto-apply `bug` / `feature` / `uiux` / `chore` labels

## Test plan
- [ ] Open https://github.com/koralle/pantry/issues/new/choose and confirm only the four templates appear (no blank issue)
- [ ] Submit a Bug form: expected / actual / steps required; environment optional
- [ ] Submit a Feature form: goal / acceptance required; design doc & out of scope optional
- [ ] Submit a UIUX form: friction / desired feel / screens required; optional fields present
- [ ] Submit a Chore form: what / why required; impact optional
- [ ] Confirm each created issue gets the matching label


Made with [Cursor](https://cursor.com)