### PR TITLE
ci: harden OpenCode workflow

### DIFF
--- a/.github/workflows/opencode.yaml
+++ b/.github/workflows/opencode.yaml
@@ -12,6 +12,7 @@ jobs:
       contains(github.event.comment.body, '/oc') ||
       contains(github.event.comment.body, '/opencode')
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     permissions:
       id-token: write
     concurrency:

--- a/.github/workflows/opencode.yaml
+++ b/.github/workflows/opencode.yaml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
-      contents: write
-      pull-requests: write
-      issues: write
+    concurrency:
+      group: opencode-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Run OpenCode
-        uses: anomalyco/opencode/github@latest
+        uses: anomalyco/opencode/github@a3b97d9090ccf4aa9ac32268486283e3131e36b4 # github-v1.2.25
         env:
           QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
         with:


### PR DESCRIPTION
## Changes

- Pin `anomalyco/opencode/github@latest` to SHA (`a3b97d9` / github-v1.2.25) for supply chain security
- Remove unnecessary permissions (GitHub App only needs `id-token: write`)
- Add `concurrency` to prevent overlapping runs on the same issue/PR