### PR TITLE
feat(ui): introduce lucide-react icons across all screens

### DIFF
--- a/docs/superpowers/plans/2026-07-21-lucide-react-icons.md
+++ b/docs/superpowers/plans/2026-07-21-lucide-react-icons.md
@@ -1486,7 +1486,7 @@ import { ArrowLeft, CircleAlert } from 'lucide-react'
 `src/routes/_protected/tags/$id/index.tsx` の import 群に追加:
 
 ```tsx
-import { ArrowLeft, Bookmarks, CircleCheck, Pencil, Pin } from 'lucide-react'
+import { ArrowLeft, Bookmark, CircleCheck, Pencil, Pin } from 'lucide-react'
 ```
 
 - [ ] **Step 6: タグ登録フラッシュに CircleCheck**
@@ -1593,7 +1593,9 @@ import { ArrowLeft, Bookmarks, CircleCheck, Pencil, Pin } from 'lucide-react'
           </dd>
 ```
 
-- [ ] **Step 10: 「この棚のブックマークを見る」に Bookmarks**
+- [ ] **Step 10: 「この棚のブックマークを見る」に Bookmark**
+
+> Note: `Bookmarks`（複数形）は lucide-react@1.21.0 に存在しないため `Bookmark`（単数形）を使用する。
 
 次を探す:
 
@@ -1607,7 +1609,7 @@ import { ArrowLeft, Bookmarks, CircleCheck, Pencil, Pin } from 'lucide-react'
 
 ```tsx
           className='pantry-button pantry-button--accent'>
-          <Bookmarks
+          <Bookmark
             size={16}
             aria-hidden
           />{' '}

--- a/docs/superpowers/plans/2026-07-21-lucide-react-icons.md
+++ b/docs/superpowers/plans/2026-07-21-lucide-react-icons.md
@@ -1,0 +1,1891 @@
+# Lucide React アイコン一括導入 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** テキストのみの全画面 UI に lucide-react アイコンを一括導入し、既存テキストは併記したまま装飾アイコン（`aria-hidden`）を添える。
+
+**Architecture:** 各ファイルで lucide-react コンポーネントを直接 import し、JSX に挿入する。ラッパーコンポーネントは作らない。既存のボタン・リンクは既に `inline-flex; align-items: center` のためレイアウト変更はほぼ不要。ローダーの spin とスウォッチ・ブランドの中央揃えのみ app.css に少量追加する。
+
+**Tech Stack:** React 19, TanStack Start/Router, lucide-react, CSS (app.css), Vitest / oxlint / tsgo
+
+**Spec:** `docs/superpowers/specs/2026-07-21-lucide-react-icons-design.md`
+
+**Conventions（全タスク共通）:**
+
+- アイコンは基本 `size={16}`。強調（見出し・空状態）は `size={20}`。チップ・テーブルセル等の小さい文脈は `size={14}`。
+- テキストが必ず併記されるため、全アイコンに `aria-hidden` を付ける。
+- アイコン名は `lucide-react` の現行名（`TriangleAlert`, `CircleCheck`, `CircleAlert`, `LoaderCircle` 等）。存在は確認済み。
+- コミットは Conventional Commits（`feat(ui): ...`）。
+
+---
+
+## File Structure
+
+| ファイル                                                                  | 変更内容                                                      |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `src/app.css`                                                             | spinner keyframe、スウォッチ中央揃え、サインインブランド flex |
+| `src/components/ui-state.tsx`                                             | UiLoading/UiEmpty/UiError にアイコン                          |
+| `src/components/error-fallback.tsx`                                       | ErrorFallback に TriangleAlert                                |
+| `src/routes/_protected.tsx`                                               | シェル（新規/設定/ログアウト/棚切替/閉じる/タグ管理）         |
+| `src/features/bookmarks/components/bookmark-list.tsx`                     | ツールバー・チップ・読み込み                                  |
+| `src/features/bookmarks/components/bookmark-table.tsx`                    | URL カラムに Globe                                            |
+| `src/features/tags/components/entrance-boxes.tsx`                         | 玄関ボックス・空状態                                          |
+| `src/features/tags/tag-table.tsx`                                         | ピン列・編集                                                  |
+| `src/features/tags/components/tag-edit-fields.tsx`                        | ピントグル・ステッパー・スウォッチ                            |
+| `src/features/tags/components/inline-add-tag.tsx`                         | 追加ボタン                                                    |
+| `src/routes/_protected/bookmarks/$id/index.tsx`                           | 詳細（戻る/フラッシュ/URL/編集/削除/キャンセル）              |
+| `src/routes/_protected/bookmarks/$id/edit.tsx`                            | 編集ワークベンチ（戻るリンク）                                |
+| `src/routes/_protected/bookmarks/new/index.tsx`                           | 新規ワークベンチ（戻るリンク）                                |
+| `src/routes/_protected/bookmarks/-components/bookmark-workbench-form.tsx` | エラーサマリー・タイトル取得                                  |
+| `src/features/bookmarks/components/tag-selector.tsx`                      | 絞り込み・作成                                                |
+| `src/routes/_protected/tags/index.tsx`                                    | 新規タグリンク                                                |
+| `src/routes/_protected/tags/new.tsx`                                      | 戻る・エラーサマリー                                          |
+| `src/routes/_protected/tags/$id.edit.tsx`                                 | 戻る・エラーサマリー                                          |
+| `src/routes/_protected/tags/$id/index.tsx`                                | フラッシュ・戻る・ピン状態・編集                              |
+| `src/routes/sign-in/index.tsx`                                            | ブランド Package                                              |
+| `src/routes/sign-in/-components/sign-in-with-email-and-password-form.tsx` | Mail/Lock/LogIn/CircleAlert                                   |
+| `src/routes/_protected/settings/index.tsx`                                | ログアウト・玄関へ戻る                                        |
+
+---
+
+## Task 1: CSS 土台（spinner・スウォッチ・ブランド）
+
+**Files:**
+
+- Modify: `src/app.css`
+
+- [ ] **Step 1: spinner keyframe と `.pantry-spinner` を追加**
+
+`src/app.css` の `@keyframes pantry-skeleton-pulse { ... }` ブロック（約331-339行目）の直後に追加する:
+
+```css
+.pantry-spinner {
+  animation: pantry-spin 1s linear infinite;
+}
+
+@keyframes pantry-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+```
+
+- [ ] **Step 2: カラーパレットスウォッチを中央揃えにする**
+
+`.pantry-color-swatch { ... }` ルール（約997-1004行目）に `display`/`align-items`/`justify-content` を追加し、次と同じにする:
+
+```css
+.pantry-color-swatch {
+  inline-size: 2.75rem;
+  block-size: 2.75rem;
+  border-radius: var(--pantry-radius-box);
+  border: 2px solid transparent;
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+```
+
+- [ ] **Step 3: サインインブランドを flex にする**
+
+`.pantry-sign-in__brand { ... }` ルール（約1157-1162行目）に flex を追加し、次と同じにする:
+
+```css
+.pantry-sign-in__brand {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+```
+
+- [ ] **Step 4: 既存スタイルと衝突しないことを確認**
+
+Run: `pnpm run lint`
+Expected: エラーなし（CSS は oxlint 対象外だが、構文崩れがないことを確認するため通す）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/app.css
+git commit -m "feat(ui): add icon groundwork styles (spinner, swatch center, brand flex)"
+```
+
+---
+
+## Task 2: 共通ステートコンポーネント
+
+**Files:**
+
+- Modify: `src/components/ui-state.tsx`
+- Modify: `src/components/error-fallback.tsx`
+
+- [ ] **Step 1: `ui-state.tsx` にアイコンを追加**
+
+`src/components/ui-state.tsx` を次で置き換える:
+
+```tsx
+import { LoaderCircle, PackageOpen, RefreshCw, TriangleAlert } from 'lucide-react'
+import type { ReactNode } from 'react'
+
+export function UiLoading({ label = '読み込み中' }: { label?: string }) {
+  return (
+    <output
+      className='pantry-skeleton'
+      aria-live='polite'>
+      <LoaderCircle
+        size={16}
+        className='pantry-spinner'
+        aria-hidden
+      />{' '}
+      {label}
+    </output>
+  )
+}
+
+export function UiEmpty({ title, action }: { title: string; action?: ReactNode }) {
+  return (
+    <div className='pantry-empty'>
+      <PackageOpen
+        size={20}
+        aria-hidden
+      />
+      <p>{title}</p>
+      {action}
+    </div>
+  )
+}
+
+export function UiError({ message, onRetry }: { message: string; onRetry?: () => void }) {
+  return (
+    <div
+      className='pantry-error'
+      role='alert'>
+      <TriangleAlert
+        size={20}
+        aria-hidden
+      />
+      <p>{message}</p>
+      {onRetry ? (
+        <button
+          type='button'
+          onClick={onRetry}>
+          <RefreshCw
+            size={16}
+            aria-hidden
+          />{' '}
+          再試行
+        </button>
+      ) : undefined}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: `error-fallback.tsx` にアイコンを追加**
+
+`src/components/error-fallback.tsx` を次で置き換える:
+
+```tsx
+import { TriangleAlert } from 'lucide-react'
+import { FallbackProps, getErrorMessage } from 'react-error-boundary'
+
+export function ErrorFallback({ error }: FallbackProps) {
+  return (
+    <div role='alert'>
+      <TriangleAlert
+        size={20}
+        aria-hidden
+      />
+      <p>{getErrorMessage(error)}</p>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: テスト・型チェック**
+
+Run: `pnpm run test && pnpm run typecheck`
+Expected: 全テスト PASS、型エラーなし
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/components/ui-state.tsx src/components/error-fallback.tsx
+git commit -m "feat(ui): add icons to shared state components"
+```
+
+---
+
+## Task 3: アプリシェル
+
+**Files:**
+
+- Modify: `src/routes/_protected.tsx`
+
+- [ ] **Step 1: import を追加**
+
+`src/routes/_protected.tsx` 先頭の import 群に追加する（既存 import の後、相対 import の前）:
+
+```tsx
+import { LogOut, Menu, Plus, Settings, Tags, X } from 'lucide-react'
+```
+
+- [ ] **Step 2: サイドバーの「タグ管理」リンクに Tags アイコン**
+
+次を探す:
+
+```tsx
+<Link
+  to='/tags'
+  search={{ limit: 50, offset: 0 }}>
+  タグ管理
+</Link>
+```
+
+次で置き換える:
+
+```tsx
+<Link
+  to='/tags'
+  search={{ limit: 50, offset: 0 }}>
+  <Tags
+    size={16}
+    aria-hidden
+  />{' '}
+  タグ管理
+</Link>
+```
+
+- [ ] **Step 3: サイドバーの「設定」リンクに Settings アイコン**
+
+次を探す:
+
+```tsx
+<Link to='/settings'>設定</Link>
+```
+
+次で置き換える:
+
+```tsx
+<Link to='/settings'>
+  <Settings
+    size={16}
+    aria-hidden
+  />{' '}
+  設定
+</Link>
+```
+
+- [ ] **Step 4: モバイル「棚を変える」トリガーに Menu アイコン**
+
+次を探す:
+
+```tsx
+<Dialog.Trigger className='pantry-shelf-changer'>棚を変える</Dialog.Trigger>
+```
+
+次で置き換える:
+
+```tsx
+<Dialog.Trigger className='pantry-shelf-changer'>
+  <Menu
+    size={16}
+    aria-hidden
+  />{' '}
+  棚を変える
+</Dialog.Trigger>
+```
+
+- [ ] **Step 5: シート「閉じる」に X アイコン**
+
+次を探す:
+
+```tsx
+<Dialog.Close className='pantry-shelf-sheet__close'>閉じる</Dialog.Close>
+```
+
+次で置き換える:
+
+```tsx
+<Dialog.Close className='pantry-shelf-sheet__close'>
+  <X
+    size={16}
+    aria-hidden
+  />{' '}
+  閉じる
+</Dialog.Close>
+```
+
+- [ ] **Step 6: ヘッダー「＋新規」を Plus アイコンに置換**
+
+次を探す:
+
+```tsx
+              }}>
+              ＋新規
+            </Link>
+```
+
+次で置き換える:
+
+```tsx
+              }}>
+              <Plus
+                size={16}
+                aria-hidden
+              />{' '}
+              新規
+            </Link>
+```
+
+- [ ] **Step 7: ヘッダー「設定」リンクに Settings アイコン**
+
+次を探す:
+
+```tsx
+            <Link to='/settings'>設定</Link>
+            <button
+```
+
+次で置き換える:
+
+```tsx
+            <Link to='/settings'>
+              <Settings
+                size={16}
+                aria-hidden
+              />{' '}
+              設定
+            </Link>
+            <button
+```
+
+- [ ] **Step 8: ヘッダー「ログアウト」に LogOut アイコン**
+
+次を探す:
+
+```tsx
+              disabled={isPending}>
+              ログアウト
+            </button>
+```
+
+次で置き換える:
+
+```tsx
+              disabled={isPending}>
+              <LogOut
+                size={16}
+                aria-hidden
+              />{' '}
+              ログアウト
+            </button>
+```
+
+- [ ] **Step 9: テスト・型チェック**
+
+Run: `pnpm run test && pnpm run typecheck`
+Expected: 全テスト PASS、型エラーなし
+
+- [ ] **Step 10: コミット**
+
+```bash
+git add src/routes/_protected.tsx
+git commit -m "feat(ui): add icons to app shell header and sidebar"
+```
+
+---
+
+## Task 4: ブックマーク一覧
+
+**Files:**
+
+- Modify: `src/features/bookmarks/components/bookmark-list.tsx`
+
+- [ ] **Step 1: import を追加**
+
+`src/features/bookmarks/components/bookmark-list.tsx` の import 群に追加:
+
+```tsx
+import { ChevronDown, LayoutGrid, List, Plus, Search, X } from 'lucide-react'
+```
+
+- [ ] **Step 2: タイトル行「新規」リンクに Plus**
+
+次を探す:
+
+```tsx
+          className='pantry-list-toolbar__new'>
+          新規
+        </Link>
+```
+
+次で置き換える:
+
+```tsx
+          className='pantry-list-toolbar__new'>
+          <Plus
+            size={16}
+            aria-hidden
+          />{' '}
+          新規
+        </Link>
+```
+
+- [ ] **Step 3: 検索ボタンに Search**
+
+次を探す:
+
+```tsx
+<button type='submit'>検索</button>
+```
+
+次で置き換える:
+
+```tsx
+<button type='submit'>
+  <Search
+    size={16}
+    aria-hidden
+  />{' '}
+  検索
+</button>
+```
+
+- [ ] **Step 4: レイアウト切替「テーブル」に List**
+
+次を探す:
+
+```tsx
+            onClick={() => {
+              onLayoutChange('table')
+            }}>
+            テーブル
+          </button>
+```
+
+次で置き換える:
+
+```tsx
+            onClick={() => {
+              onLayoutChange('table')
+            }}>
+            <List
+              size={16}
+              aria-hidden
+            />{' '}
+            テーブル
+          </button>
+```
+
+- [ ] **Step 5: レイアウト切替「カード」に LayoutGrid**
+
+次を探す:
+
+```tsx
+            onClick={() => {
+              onLayoutChange('card')
+            }}>
+            カード
+          </button>
+```
+
+次で置き換える:
+
+```tsx
+            onClick={() => {
+              onLayoutChange('card')
+            }}>
+            <LayoutGrid
+              size={16}
+              aria-hidden
+            />{' '}
+            カード
+          </button>
+```
+
+- [ ] **Step 6: タグチップの `×` を X アイコンに置換**
+
+次を探す:
+
+```tsx
+            {tagName}
+            <span aria-hidden='true'> ×</span>
+            <span className='pantry-sr-only'>を外す</span>
+```
+
+次で置き換える:
+
+```tsx
+            {tagName}
+            <X
+              size={14}
+              aria-hidden
+            />
+            <span className='pantry-sr-only'>を外す</span>
+```
+
+- [ ] **Step 7: 「さらに読み込む」に ChevronDown**
+
+次を探す:
+
+```tsx
+              onClick={loadMore}>
+              {isLoadingMore ? '読み込み中…' : 'さらに読み込む'}
+            </button>
+```
+
+次で置き換える:
+
+```tsx
+              onClick={loadMore}>
+              <ChevronDown
+                size={16}
+                aria-hidden
+              />{' '}
+              {isLoadingMore ? '読み込み中…' : 'さらに読み込む'}
+            </button>
+```
+
+- [ ] **Step 8: テスト・型チェック**
+
+Run: `pnpm run test && pnpm run typecheck`
+Expected: 全テスト PASS、型エラーなし
+
+- [ ] **Step 9: コミット**
+
+```bash
+git add src/features/bookmarks/components/bookmark-list.tsx
+git commit -m "feat(ui): add icons to bookmark list toolbar and chips"
+```
+
+---
+
+## Task 5: ブックマークテーブル
+
+**Files:**
+
+- Modify: `src/features/bookmarks/components/bookmark-table.tsx`
+
+- [ ] **Step 1: import を追加**
+
+`src/features/bookmarks/components/bookmark-table.tsx` の import 群に追加:
+
+```tsx
+import { Globe } from 'lucide-react'
+```
+
+- [ ] **Step 2: URL カラムのリンクに Globe**
+
+次を探す:
+
+```tsx
+                className='pantry-bookmark-row-link pantry-bookmark-row-link--muted'>
+                {shortenUrl(bookmark.url, 48)}
+              </Link>
+```
+
+次で置き換える:
+
+```tsx
+                className='pantry-bookmark-row-link pantry-bookmark-row-link--muted'>
+                <Globe
+                  size={14}
+                  aria-hidden
+                />{' '}
+                {shortenUrl(bookmark.url, 48)}
+              </Link>
+```
+
+- [ ] **Step 3: テスト・型チェック**
+
+Run: `pnpm run test && pnpm run typecheck`
+Expected: 全テスト PASS、型エラーなし
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/features/bookmarks/components/bookmark-table.tsx
+git commit -m "feat(ui): add globe icon to bookmark table url column"
+```
+
+---
+
+## Task 6: 玄関ボックス
+
+**Files:**
+
+- Modify: `src/features/tags/components/entrance-boxes.tsx`
+
+- [ ] **Step 1: import を追加**
+
+`src/features/tags/components/entrance-boxes.tsx` の import 群に追加:
+
+```tsx
+import { Package, Plus } from 'lucide-react'
+```
+
+- [ ] **Step 2: 空状態アクションに Plus**
+
+次を探す:
+
+```tsx
+<div className='pantry-entrance-empty-actions'>
+  <Link to='/tags/new'>タグを作成</Link>
+  <Link to='/bookmarks/new'>新規ブックマーク</Link>
+</div>
+```
+
+次で置き換える:
+
+```tsx
+<div className='pantry-entrance-empty-actions'>
+  <Link to='/tags/new'>
+    <Plus
+      size={16}
+      aria-hidden
+    />{' '}
+    タグを作成
+  </Link>
+  <Link to='/bookmarks/new'>
+    <Plus
+      size={16}
+      aria-hidden
+    />{' '}
+    新規ブックマーク
+  </Link>
+</div>
+```
+
+- [ ] **Step 3: 各ボックスの名前に Package**
+
+次を探す:
+
+```tsx
+<span className='pantry-entrance-box__name'>{tag.name}</span>
+```
+
+次で置き換える:
+
+```tsx
+<span className='pantry-entrance-box__name'>
+  <Package
+    size={16}
+    aria-hidden
+  />{' '}
+  {tag.name}
+</span>
+```
+
+- [ ] **Step 4: テスト・型チェック**
+
+Run: `pnpm run test && pnpm run typecheck`
+Expected: 全テスト PASS、型エラーなし
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/features/tags/components/entrance-boxes.tsx
+git commit -m "feat(ui): add package icons to entrance boxes"
+```
+
+---
+
+## Task 7: タグ管理
+
+**Files:**
+
+- Modify: `src/features/tags/tag-table.tsx`
+- Modify: `src/features/tags/components/tag-edit-fields.tsx`
+- Modify: `src/features/tags/components/inline-add-tag.tsx`
+- Modify: `src/routes/_protected/tags/index.tsx`
+
+- [ ] **Step 1: `tag-table.tsx` に import を追加**
+
+`src/features/tags/tag-table.tsx` の import 群に追加:
+
+```tsx
+import { Pencil, Pin } from 'lucide-react'
+```
+
+- [ ] **Step 2: ピン列を Pin アイコンに置換**
+
+`tag-table.tsx` で次を探す:
+
+```tsx
+{
+  tag.pinned ? (
+    <span aria-label='ピン留め中'>ピン</span>
+  ) : (
+    <span className='pantry-tag-table__muted'>—</span>
+  )
+}
+```
+
+次で置き換える:
+
+```tsx
+{
+  tag.pinned ? (
+    <span>
+      <Pin
+        size={16}
+        aria-hidden
+      />
+      <span className='pantry-sr-only'>ピン留め中</span>
+    </span>
+  ) : (
+    <span className='pantry-tag-table__muted'>—</span>
+  )
+}
+```
+
+- [ ] **Step 3: 「編集」リンクに Pencil**
+
+`tag-table.tsx` で次を探す:
+
+```tsx
+                className='pantry-text-link'>
+                編集
+              </Link>
+```
+
+次で置き換える:
+
+```tsx
+                className='pantry-text-link'>
+                <Pencil
+                  size={16}
+                  aria-hidden
+                />{' '}
+                編集
+              </Link>
+```
+
+- [ ] **Step 4: `tag-edit-fields.tsx` に import を追加**
+
+`src/features/tags/components/tag-edit-fields.tsx` の import 群に追加:
+
+```tsx
+import { Check, Minus, Pin, PinOff, Plus } from 'lucide-react'
+```
+
+- [ ] **Step 5: ピントグルに Pin/PinOff**
+
+`tag-edit-fields.tsx` で次を探す:
+
+```tsx
+          {pinLabel(pinned)}
+        </button>
+```
+
+次で置き換える:
+
+```tsx
+          {pinned ? (
+            <PinOff
+              size={16}
+              aria-hidden
+            />
+          ) : (
+            <Pin
+              size={16}
+              aria-hidden
+            />
+          )}{' '}
+          {pinLabel(pinned)}
+        </button>
+```
+
+- [ ] **Step 6: 選択中スウォッチに Check**
+
+`tag-edit-fields.tsx` で次を探す:
+
+```tsx
+                aria-pressed={selected}
+                aria-label={`色 ${swatch}`}
+                onClick={() => {
+                  onColorChange(swatch)
+                }}
+              />
+```
+
+次で置き換える:
+
+```tsx
+                aria-pressed={selected}
+                aria-label={`色 ${swatch}`}
+                onClick={() => {
+                  onColorChange(swatch)
+                }}>
+                {selected ? (
+                  <Check
+                    size={16}
+                    color='#fff'
+                    aria-hidden
+                  />
+                ) : null}
+              </button>
+```
+
+- [ ] **Step 7: 並び順ステッパーの `−` を Minus に置換**
+
+`tag-edit-fields.tsx` で次を探す:
+
+```tsx
+            onClick={() => {
+              onSortOrderChange(sortOrder - 1)
+            }}>
+            −
+          </button>
+```
+
+次で置き換える:
+
+```tsx
+            onClick={() => {
+              onSortOrderChange(sortOrder - 1)
+            }}>
+            <Minus
+              size={16}
+              aria-hidden
+            />
+          </button>
+```
+
+- [ ] **Step 8: 並び順ステッパーの `＋` を Plus に置換**
+
+`tag-edit-fields.tsx` で次を探す:
+
+```tsx
+            onClick={() => {
+              onSortOrderChange(sortOrder + 1)
+            }}>
+            ＋
+          </button>
+```
+
+次で置き換える:
+
+```tsx
+            onClick={() => {
+              onSortOrderChange(sortOrder + 1)
+            }}>
+            <Plus
+              size={16}
+              aria-hidden
+            />
+          </button>
+```
+
+- [ ] **Step 9: `inline-add-tag.tsx` に import と Plus**
+
+`src/features/tags/components/inline-add-tag.tsx` の import 群に追加:
+
+```tsx
+import { Plus } from 'lucide-react'
+```
+
+次を探す:
+
+```tsx
+            disabled={isPending}>
+            {isPending ? '追加中...' : '追加'}
+          </button>
+```
+
+次で置き換える:
+
+```tsx
+            disabled={isPending}>
+            <Plus
+              size={16}
+              aria-hidden
+            />{' '}
+            {isPending ? '追加中...' : '追加'}
+          </button>
+```
+
+- [ ] **Step 10: `tags/index.tsx` に import と Plus**
+
+`src/routes/_protected/tags/index.tsx` の import 群に追加:
+
+```tsx
+import { Plus } from 'lucide-react'
+```
+
+次を探す:
+
+```tsx
+          className='pantry-button pantry-button--accent'>
+          新規タグ
+        </Link>
+```
+
+次で置き換える:
+
+```tsx
+          className='pantry-button pantry-button--accent'>
+          <Plus
+            size={16}
+            aria-hidden
+          />{' '}
+          新規タグ
+        </Link>
+```
+
+- [ ] **Step 11: テスト・型チェック**
+
+Run: `pnpm run test && pnpm run typecheck`
+Expected: 全テスト PASS、型エラーなし
+
+- [ ] **Step 12: コミット**
+
+```bash
+git add src/features/tags/tag-table.tsx src/features/tags/components/tag-edit-fields.tsx src/features/tags/components/inline-add-tag.tsx src/routes/_protected/tags/index.tsx
+git commit -m "feat(ui): add icons to tag management screens"
+```
+
+---
+
+## Task 8: ブックマーク詳細・編集
+
+**Files:**
+
+- Modify: `src/routes/_protected/bookmarks/$id/index.tsx`
+- Modify: `src/routes/_protected/bookmarks/$id/edit.tsx`
+- Modify: `src/routes/_protected/bookmarks/new/index.tsx`
+
+- [ ] **Step 1: `$id/index.tsx` に import を追加**
+
+`src/routes/_protected/bookmarks/$id/index.tsx` の import 群に追加:
+
+```tsx
+import { ArrowLeft, CircleCheck, ExternalLink, Pencil, Trash2, X } from 'lucide-react'
+```
+
+- [ ] **Step 2: 登録フラッシュに CircleCheck**
+
+次を探す:
+
+```tsx
+          role='alert'>
+          ブックマークを登録しました
+        </div>
+```
+
+次で置き換える:
+
+```tsx
+          role='alert'>
+          <CircleCheck
+            size={16}
+            aria-hidden
+          />{' '}
+          ブックマークを登録しました
+        </div>
+```
+
+- [ ] **Step 3: 更新フラッシュに CircleCheck**
+
+次を探す:
+
+```tsx
+          role='alert'>
+          ブックマークを更新しました
+        </div>
+```
+
+次で置き換える:
+
+```tsx
+          role='alert'>
+          <CircleCheck
+            size={16}
+            aria-hidden
+          />{' '}
+          ブックマークを更新しました
+        </div>
+```
+
+- [ ] **Step 4: 「一覧へ戻る」ナビに ArrowLeft**
+
+次を探す:
+
+```tsx
+          className='pantry-text-link'>
+          一覧へ戻る
+        </Link>
+      </nav>
+```
+
+次で置き換える:
+
+```tsx
+          className='pantry-text-link'>
+          <ArrowLeft
+            size={16}
+            aria-hidden
+          />{' '}
+          一覧へ戻る
+        </Link>
+      </nav>
+```
+
+- [ ] **Step 5: 外部 URL リンクに ExternalLink**
+
+次を探す:
+
+```tsx
+          className='pantry-detail__url'>
+          {bookmark.url}
+        </a>
+```
+
+次で置き換える:
+
+```tsx
+          className='pantry-detail__url'>
+          {bookmark.url}{' '}
+          <ExternalLink
+            size={14}
+            aria-hidden
+          />
+        </a>
+```
+
+- [ ] **Step 6: 「編集」アクションに Pencil**
+
+次を探す:
+
+```tsx
+          className='pantry-button pantry-button--accent'>
+          編集
+        </Link>
+```
+
+次で置き換える:
+
+```tsx
+          className='pantry-button pantry-button--accent'>
+          <Pencil
+            size={16}
+            aria-hidden
+          />{' '}
+          編集
+        </Link>
+```
+
+- [ ] **Step 7: 「削除」トリガーに Trash2**
+
+次を探す:
+
+```tsx
+            disabled={isDeleting}>
+            削除
+          </Dialog.Trigger>
+```
+
+次で置き換える:
+
+```tsx
+            disabled={isDeleting}>
+            <Trash2
+              size={16}
+              aria-hidden
+            />{' '}
+            削除
+          </Dialog.Trigger>
+```
+
+- [ ] **Step 8: ダイアログ「キャンセル」に X**
+
+次を探す:
+
+```tsx
+                  disabled={isDeleting}>
+                  キャンセル
+                </Dialog.Close>
+```
+
+次で置き換える:
+
+```tsx
+                  disabled={isDeleting}>
+                  <X
+                    size={16}
+                    aria-hidden
+                  />{' '}
+                  キャンセル
+                </Dialog.Close>
+```
+
+- [ ] **Step 9: ダイアログ「削除を確認」に Trash2**
+
+次を探す:
+
+```tsx
+                  disabled={isDeleting}>
+                  {isDeleting ? '削除中…' : '削除を確認'}
+                </button>
+```
+
+次で置き換える:
+
+```tsx
+                  disabled={isDeleting}>
+                  <Trash2
+                    size={16}
+                    aria-hidden
+                  />{' '}
+                  {isDeleting ? '削除中…' : '削除を確認'}
+                </button>
+```
+
+- [ ] **Step 10: `$id/edit.tsx` に import と戻るリンク2件**
+
+`src/routes/_protected/bookmarks/$id/edit.tsx` の import 群に追加:
+
+```tsx
+import { ArrowLeft } from 'lucide-react'
+```
+
+次を探す:
+
+```tsx
+          className='pantry-text-link'>
+          詳細へ戻る
+        </Link>
+```
+
+次で置き換える:
+
+```tsx
+          className='pantry-text-link'>
+          <ArrowLeft
+            size={16}
+            aria-hidden
+          />{' '}
+          詳細へ戻る
+        </Link>
+```
+
+次を探す:
+
+```tsx
+          className='pantry-text-link'>
+          一覧へ戻る
+        </Link>
+      </nav>
+```
+
+次で置き換える:
+
+```tsx
+          className='pantry-text-link'>
+          <ArrowLeft
+            size={16}
+            aria-hidden
+          />{' '}
+          一覧へ戻る
+        </Link>
+      </nav>
+```
+
+- [ ] **Step 11: `new/index.tsx` に import と戻るリンク**
+
+`src/routes/_protected/bookmarks/new/index.tsx` の import 群に追加:
+
+```tsx
+import { ArrowLeft } from 'lucide-react'
+```
+
+次を探す:
+
+```tsx
+          className='pantry-text-link'>
+          一覧へ戻る
+        </Link>
+      </nav>
+```
+
+次で置き換える:
+
+```tsx
+          className='pantry-text-link'>
+          <ArrowLeft
+            size={16}
+            aria-hidden
+          />{' '}
+          一覧へ戻る
+        </Link>
+      </nav>
+```
+
+- [ ] **Step 12: テスト・型チェック**
+
+Run: `pnpm run test && pnpm run typecheck`
+Expected: 全テスト PASS、型エラーなし
+
+- [ ] **Step 13: コミット**
+
+```bash
+git add "src/routes/_protected/bookmarks/\$id/index.tsx" "src/routes/_protected/bookmarks/\$id/edit.tsx" src/routes/_protected/bookmarks/new/index.tsx
+git commit -m "feat(ui): add icons to bookmark detail and workbench nav"
+```
+
+---
+
+## Task 9: ワークベンチフォーム・タグセレクター
+
+**Files:**
+
+- Modify: `src/routes/_protected/bookmarks/-components/bookmark-workbench-form.tsx`
+- Modify: `src/features/bookmarks/components/tag-selector.tsx`
+
+- [ ] **Step 1: `bookmark-workbench-form.tsx` に import を追加**
+
+`src/routes/_protected/bookmarks/-components/bookmark-workbench-form.tsx` の import 群に追加:
+
+```tsx
+import { CircleAlert, Download } from 'lucide-react'
+```
+
+- [ ] **Step 2: フォームエラーサマリーに CircleAlert**
+
+次を探す:
+
+```tsx
+          aria-live='polite'>
+          <p>次を確認してください</p>
+```
+
+次で置き換える:
+
+```tsx
+          aria-live='polite'>
+          <p>
+            <CircleAlert
+              size={16}
+              aria-hidden
+            />{' '}
+            次を確認してください
+          </p>
+```
+
+- [ ] **Step 3: 「タイトルを取得」に Download**
+
+次を探す:
+
+```tsx
+                  disabled={busy}>
+                  {isFetchingTitle ? '取得中…' : 'タイトルを取得'}
+                </button>
+```
+
+次で置き換える:
+
+```tsx
+                  disabled={busy}>
+                  <Download
+                    size={16}
+                    aria-hidden
+                  />{' '}
+                  {isFetchingTitle ? '取得中…' : 'タイトルを取得'}
+                </button>
+```
+
+- [ ] **Step 4: `tag-selector.tsx` に import を追加**
+
+`src/features/bookmarks/components/tag-selector.tsx` の import 群に追加:
+
+```tsx
+import { Plus, Search } from 'lucide-react'
+```
+
+- [ ] **Step 5: 絞り込みラベルに Search**
+
+次を探す:
+
+```tsx
+        <label htmlFor='tag-selector-query'>
+          タグを絞り込む / 新規作成
+```
+
+次で置き換える:
+
+```tsx
+        <label htmlFor='tag-selector-query'>
+          <Search
+            size={16}
+            aria-hidden
+          />{' '}
+          タグを絞り込む / 新規作成
+```
+
+- [ ] **Step 6: 「この名前で作成」に Plus**
+
+次を探す:
+
+```tsx
+          disabled={isPending}>
+          {isPending ? '作成中...' : 'この名前で作成'}
+        </button>
+```
+
+次で置き換える:
+
+```tsx
+          disabled={isPending}>
+          <Plus
+            size={16}
+            aria-hidden
+          />{' '}
+          {isPending ? '作成中...' : 'この名前で作成'}
+        </button>
+```
+
+- [ ] **Step 7: テスト・型チェック**
+
+Run: `pnpm run test && pnpm run typecheck`
+Expected: 全テスト PASS、型エラーなし
+
+- [ ] **Step 8: コミット**
+
+```bash
+git add "src/routes/_protected/bookmarks/-components/bookmark-workbench-form.tsx" src/features/bookmarks/components/tag-selector.tsx
+git commit -m "feat(ui): add icons to workbench form and tag selector"
+```
+
+---
+
+## Task 10: タグワークベンチ・タグ詳細
+
+**Files:**
+
+- Modify: `src/routes/_protected/tags/new.tsx`
+- Modify: `src/routes/_protected/tags/$id.edit.tsx`
+- Modify: `src/routes/_protected/tags/$id/index.tsx`
+
+- [ ] **Step 1: `tags/new.tsx` に import を追加**
+
+`src/routes/_protected/tags/new.tsx` の import 群に追加:
+
+```tsx
+import { ArrowLeft, CircleAlert } from 'lucide-react'
+```
+
+- [ ] **Step 2: 戻るリンクに ArrowLeft**
+
+`tags/new.tsx` で次を探す:
+
+```tsx
+          className='pantry-text-link'>
+          一覧へ戻る
+        </Link>
+      </nav>
+```
+
+次で置き換える:
+
+```tsx
+          className='pantry-text-link'>
+          <ArrowLeft
+            size={16}
+            aria-hidden
+          />{' '}
+          一覧へ戻る
+        </Link>
+      </nav>
+```
+
+- [ ] **Step 3: エラーサマリーに CircleAlert**
+
+`tags/new.tsx` で次を探す:
+
+```tsx
+          aria-live='polite'>
+          <p>{formError}</p>
+        </div>
+```
+
+次で置き換える:
+
+```tsx
+          aria-live='polite'>
+          <p>
+            <CircleAlert
+              size={16}
+              aria-hidden
+            />{' '}
+            {formError}
+          </p>
+        </div>
+```
+
+- [ ] **Step 4: `$id.edit.tsx` に import と戻るリンク・エラーサマリー**
+
+`src/routes/_protected/tags/$id.edit.tsx` の import 群に追加:
+
+```tsx
+import { ArrowLeft, CircleAlert } from 'lucide-react'
+```
+
+次を探す:
+
+```tsx
+          className='pantry-text-link'>
+          一覧へ戻る
+        </Link>
+      </nav>
+```
+
+次で置き換える:
+
+```tsx
+          className='pantry-text-link'>
+          <ArrowLeft
+            size={16}
+            aria-hidden
+          />{' '}
+          一覧へ戻る
+        </Link>
+      </nav>
+```
+
+次を探す:
+
+```tsx
+          aria-live='polite'>
+          <p>{formError}</p>
+        </div>
+```
+
+次で置き換える:
+
+```tsx
+          aria-live='polite'>
+          <p>
+            <CircleAlert
+              size={16}
+              aria-hidden
+            />{' '}
+            {formError}
+          </p>
+        </div>
+```
+
+- [ ] **Step 5: `$id/index.tsx` に import を追加**
+
+`src/routes/_protected/tags/$id/index.tsx` の import 群に追加:
+
+```tsx
+import { ArrowLeft, Bookmarks, CircleCheck, Pencil, Pin } from 'lucide-react'
+```
+
+- [ ] **Step 6: タグ登録フラッシュに CircleCheck**
+
+次を探す:
+
+```tsx
+{
+  newTagCreated ? <output className='pantry-flash'>タグを登録しました</output> : null
+}
+```
+
+次で置き換える:
+
+```tsx
+{
+  newTagCreated ? (
+    <output className='pantry-flash'>
+      <CircleCheck
+        size={16}
+        aria-hidden
+      />{' '}
+      タグを登録しました
+    </output>
+  ) : null
+}
+```
+
+- [ ] **Step 7: タグ更新フラッシュに CircleCheck**
+
+次を探す:
+
+```tsx
+{
+  tagUpdated ? <output className='pantry-flash'>タグを更新しました</output> : null
+}
+```
+
+次で置き換える:
+
+```tsx
+{
+  tagUpdated ? (
+    <output className='pantry-flash'>
+      <CircleCheck
+        size={16}
+        aria-hidden
+      />{' '}
+      タグを更新しました
+    </output>
+  ) : null
+}
+```
+
+- [ ] **Step 8: 戻るリンクに ArrowLeft**
+
+次を探す:
+
+```tsx
+          className='pantry-text-link'>
+          一覧へ戻る
+        </Link>
+      </nav>
+```
+
+次で置き換える:
+
+```tsx
+          className='pantry-text-link'>
+          <ArrowLeft
+            size={16}
+            aria-hidden
+          />{' '}
+          一覧へ戻る
+        </Link>
+      </nav>
+```
+
+- [ ] **Step 9: ピン状態に Pin**
+
+次を探す:
+
+```tsx
+          <dt>ピン</dt>
+          <dd>{tag.pinned ? '留めている' : 'なし'}</dd>
+```
+
+次で置き換える:
+
+```tsx
+          <dt>ピン</dt>
+          <dd>
+            {tag.pinned ? (
+              <>
+                <Pin
+                  size={16}
+                  aria-hidden
+                />{' '}
+                留めている
+              </>
+            ) : (
+              'なし'
+            )}
+          </dd>
+```
+
+- [ ] **Step 10: 「この棚のブックマークを見る」に Bookmarks**
+
+次を探す:
+
+```tsx
+          className='pantry-button pantry-button--accent'>
+          この棚のブックマークを見る
+        </Link>
+```
+
+次で置き換える:
+
+```tsx
+          className='pantry-button pantry-button--accent'>
+          <Bookmarks
+            size={16}
+            aria-hidden
+          />{' '}
+          この棚のブックマークを見る
+        </Link>
+```
+
+- [ ] **Step 11: 「編集」に Pencil**
+
+次を探す:
+
+```tsx
+          className='pantry-button pantry-button--secondary'>
+          編集
+        </Link>
+```
+
+次で置き換える:
+
+```tsx
+          className='pantry-button pantry-button--secondary'>
+          <Pencil
+            size={16}
+            aria-hidden
+          />{' '}
+          編集
+        </Link>
+```
+
+- [ ] **Step 12: テスト・型チェック**
+
+Run: `pnpm run test && pnpm run typecheck`
+Expected: 全テスト PASS、型エラーなし
+
+- [ ] **Step 13: コミット**
+
+```bash
+git add src/routes/_protected/tags/new.tsx "src/routes/_protected/tags/\$id.edit.tsx" "src/routes/_protected/tags/\$id/index.tsx"
+git commit -m "feat(ui): add icons to tag workbench and tag detail"
+```
+
+---
+
+## Task 11: 認証・設定
+
+**Files:**
+
+- Modify: `src/routes/sign-in/index.tsx`
+- Modify: `src/routes/sign-in/-components/sign-in-with-email-and-password-form.tsx`
+- Modify: `src/routes/_protected/settings/index.tsx`
+
+- [ ] **Step 1: `sign-in/index.tsx` に import とブランドアイコン**
+
+`src/routes/sign-in/index.tsx` の import 群に追加:
+
+```tsx
+import { Package } from 'lucide-react'
+```
+
+次を探す:
+
+```tsx
+<p className='pantry-sign-in__brand'>Pantry</p>
+```
+
+次で置き換える:
+
+```tsx
+<p className='pantry-sign-in__brand'>
+  <Package
+    size={28}
+    aria-hidden
+  />
+  Pantry
+</p>
+```
+
+- [ ] **Step 2: サインインフォームに import を追加**
+
+`src/routes/sign-in/-components/sign-in-with-email-and-password-form.tsx` の import 群に追加:
+
+```tsx
+import { CircleAlert, Lock, LogIn, Mail } from 'lucide-react'
+```
+
+- [ ] **Step 3: フォームエラーサマリーに CircleAlert**
+
+次を探す:
+
+```tsx
+          aria-live='polite'>
+          <p>{signInErrorMessage(signInError)}</p>
+        </div>
+```
+
+次で置き換える:
+
+```tsx
+          aria-live='polite'>
+          <p>
+            <CircleAlert
+              size={16}
+              aria-hidden
+            />{' '}
+            {signInErrorMessage(signInError)}
+          </p>
+        </div>
+```
+
+- [ ] **Step 4: メールラベルに Mail**
+
+次を探す:
+
+```tsx
+            <div className='pantry-field'>
+              <label htmlFor={field.props.name}>メール</label>
+```
+
+次で置き換える:
+
+```tsx
+            <div className='pantry-field'>
+              <label htmlFor={field.props.name}>
+                <Mail
+                  size={16}
+                  aria-hidden
+                />{' '}
+                メール
+              </label>
+```
+
+- [ ] **Step 5: パスワードラベルに Lock**
+
+次を探す:
+
+```tsx
+            <div className='pantry-field'>
+              <label htmlFor={field.props.name}>パスワード</label>
+```
+
+次で置き換える:
+
+```tsx
+            <div className='pantry-field'>
+              <label htmlFor={field.props.name}>
+                <Lock
+                  size={16}
+                  aria-hidden
+                />{' '}
+                パスワード
+              </label>
+```
+
+- [ ] **Step 6: サインイン送信に LogIn**
+
+次を探す:
+
+```tsx
+        disabled={isPending}>
+        {isPending ? 'サインイン中...' : 'サインイン'}
+      </button>
+```
+
+次で置き換える:
+
+```tsx
+        disabled={isPending}>
+        <LogIn
+          size={16}
+          aria-hidden
+        />{' '}
+        {isPending ? 'サインイン中...' : 'サインイン'}
+      </button>
+```
+
+- [ ] **Step 7: `settings/index.tsx` に import を追加**
+
+`src/routes/_protected/settings/index.tsx` の import 群に追加:
+
+```tsx
+import { ArrowLeft, LogOut } from 'lucide-react'
+```
+
+- [ ] **Step 8: ログアウトボタンに LogOut**
+
+次を探す:
+
+```tsx
+          disabled={isPending}>
+          {isPending ? 'ログアウト中...' : 'ログアウト'}
+        </button>
+```
+
+次で置き換える:
+
+```tsx
+          disabled={isPending}>
+          <LogOut
+            size={16}
+            aria-hidden
+          />{' '}
+          {isPending ? 'ログアウト中...' : 'ログアウト'}
+        </button>
+```
+
+- [ ] **Step 9: 「玄関へ戻る」に ArrowLeft**
+
+次を探す:
+
+```tsx
+        className='pantry-text-link'>
+        玄関へ戻る
+      </Link>
+```
+
+次で置き換える:
+
+```tsx
+        className='pantry-text-link'>
+        <ArrowLeft
+          size={16}
+          aria-hidden
+        />{' '}
+        玄関へ戻る
+      </Link>
+```
+
+- [ ] **Step 10: テスト・型チェック**
+
+Run: `pnpm run test && pnpm run typecheck`
+Expected: 全テスト PASS、型エラーなし
+
+- [ ] **Step 11: コミット**
+
+```bash
+git add src/routes/sign-in/index.tsx "src/routes/sign-in/-components/sign-in-with-email-and-password-form.tsx" src/routes/_protected/settings/index.tsx
+git commit -m "feat(ui): add icons to sign-in and settings"
+```
+
+---
+
+## Task 12: 最終検証
+
+- [ ] **Step 1: リント・フォーマット・テスト・型チェックを全実行**
+
+Run: `pnpm run lint && pnpm run format:check && pnpm run test && pnpm run typecheck`
+Expected: すべて成功
+
+- [ ] **Step 2: フォーマットが崩れていれば修正**
+
+もし `format:check` が失敗したら:
+
+Run: `pnpm run format`
+Expected: フォーマット適用後、再度 `pnpm run format:check` が通る
+
+- [ ] **Step 3: dev サーバーで全画面を目視確認**
+
+Run: `pnpm run dev`（バックグラウンド）
+
+ブラウザで以下を確認する:
+
+- `/sign-in`: Package ブランド、Mail/Lock ラベル、LogIn ボタン
+- `/`（玄関）: 各ボックスに Package、空状態に Plus
+- `/`（一覧 view=list）: ツールバーの Search/List/LayoutGrid/Plus、チップの X
+- ブックマーク詳細: ArrowLeft/CircleCheck/ExternalLink/Pencil/Trash2
+- `/tags`: Plus/新規タグ、Pin 列、Pencil 編集、ステッパーの Minus/Plus
+- `/settings`: LogOut、ArrowLeft
+- ローディング中に LoaderCircle が回転すること
+- エラー表示に TriangleAlert が出ること
+
+- [ ] **Step 4: dev サーバーを停止**
+
+- [ ] **Step 5: 変更がないか最終確認し、必要ならコミット**
+
+Run: `git status`
+Expected: フォーマット修正があればそれをコミット:
+
+```bash
+git add -A
+git commit -m "style: format after icon rollout"
+```

--- a/docs/superpowers/specs/2026-07-21-lucide-react-icons-design.md
+++ b/docs/superpowers/specs/2026-07-21-lucide-react-icons-design.md
@@ -1,0 +1,132 @@
+# Lucide React アイコン一括導入
+
+Issue: [#101 アイコンとしてLucide (lucide-react) を導入する](https://github.com/koralle/pantry/issues/101)
+
+## Goal
+
+アイコンが一切ないテキストのみの UI に、lucide-react を一括導入する。既存テキストはすべて残したままアイコンを併記し、無機質な印象を和らげて愛着の湧く画面にする。既存の Unicode 記号（`＋` `×` `−`）は対応する Lucide アイコンに置き換える。
+
+## Constraints and Decisions
+
+| 項目             | 決定                                                                                                                                            |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| 導入方法         | `lucide-react` のコンポーネントを各ファイルで直接 import。ラッパーコンポーネントは作らない                                                      |
+| 導入範囲         | 全画面に一括（1 PR）                                                                                                                            |
+| テキストとの関係 | テキスト併記。アイコンは装飾として `aria-hidden`                                                                                                |
+| サイズ           | 基本 `size={16}`。見出し・空状態など強調箇所は `size={20}`                                                                                      |
+| Unicode 記号     | `＋` `×` `−` を Lucide アイコンに置換。`—`（空セル）はテキストのまま                                                                            |
+| CSS              | レイアウト用は追加不要（ボタン・リンクは既に `inline-flex; align-items: center`）。`UiLoading` のローダー spin 用 keyframe を app.css に1つ追加 |
+| 依存             | `lucide-react` は package.json に存在済み。追加インストール不要                                                                                 |
+
+## Icon Mapping
+
+### 共通コンポーネント
+
+| ファイル                            | 箇所                 | アイコン                                    |
+| ----------------------------------- | -------------------- | ------------------------------------------- |
+| `src/components/ui-state.tsx`       | UiLoading            | `LoaderCircle`（+ CSS spin アニメーション） |
+| 同上                                | UiEmpty              | `PackageOpen`                               |
+| 同上                                | UiError メッセージ   | `TriangleAlert`                             |
+| 同上                                | UiError 再試行ボタン | `RefreshCw`                                 |
+| `src/components/error-fallback.tsx` | ErrorFallback        | `TriangleAlert`                             |
+
+### アプリシェル
+
+| ファイル                    | 箇所                     | アイコン   |
+| --------------------------- | ------------------------ | ---------- |
+| `src/routes/_protected.tsx` | 「＋新規」リンク         | `Plus`     |
+| 同上                        | 「設定」リンク           | `Settings` |
+| 同上                        | 「ログアウト」ボタン     | `LogOut`   |
+| 同上                        | 「棚を変える」(モバイル) | `Menu`     |
+| 同上                        | シート「閉じる」         | `X`        |
+| 同上                        | 「タグ管理」リンク       | `Tags`     |
+
+### ブックマーク一覧
+
+| ファイル                                               | 箇所                              | アイコン              |
+| ------------------------------------------------------ | --------------------------------- | --------------------- |
+| `src/features/bookmarks/components/bookmark-list.tsx`  | 「新規」リンク                    | `Plus`                |
+| 同上                                                   | 検索ボタン                        | `Search`              |
+| 同上                                                   | レイアウト切替（テーブル/カード） | `List` / `LayoutGrid` |
+| 同上                                                   | タグチップ削除 `×`                | `X`                   |
+| 同上                                                   | 「さらに読み込む」                | `ChevronDown`         |
+| `src/features/bookmarks/components/bookmark-table.tsx` | URL カラム（詳細への内部リンク）  | `Globe`               |
+
+### 玄関（ホーム）
+
+| ファイル                                          | 箇所             | アイコン  |
+| ------------------------------------------------- | ---------------- | --------- |
+| `src/features/tags/components/entrance-boxes.tsx` | 各ボックス       | `Package` |
+| 同上                                              | 空状態アクション | `Plus`    |
+
+### タグ管理
+
+| ファイル                                           | 箇所                        | アイコン         |
+| -------------------------------------------------- | --------------------------- | ---------------- |
+| `src/routes/_protected/tags/index.tsx`             | 「新規タグ」リンク          | `Plus`           |
+| `src/features/tags/tag-table.tsx`                  | ピン列                      | `Pin`            |
+| 同上                                               | 「編集」リンク              | `Pencil`         |
+| `src/features/tags/components/tag-edit-fields.tsx` | ピントグル                  | `Pin` / `PinOff` |
+| 同上                                               | ソート順ステッパー `−`/`＋` | `Minus` / `Plus` |
+| 同上                                               | カラー選択中スウォッチ      | `Check`          |
+| `src/features/tags/components/inline-add-tag.tsx`  | 「追加」ボタン              | `Plus`           |
+
+### ブックマーク詳細・編集
+
+| ファイル                                             | 箇所                         | アイコン       |
+| ---------------------------------------------------- | ---------------------------- | -------------- |
+| `src/routes/_protected/bookmarks/$id/index.tsx`      | 「一覧へ戻る」               | `ArrowLeft`    |
+| 同上                                                 | フラッシュメッセージ         | `CircleCheck`  |
+| 同上                                                 | 外部 URL リンク              | `ExternalLink` |
+| 同上                                                 | 「編集」                     | `Pencil`       |
+| 同上                                                 | 「削除」トリガー・確認ボタン | `Trash2`       |
+| 同上                                                 | ダイアログ「キャンセル」     | `X`            |
+| `src/routes/_protected/bookmarks/$id.edit.tsx`       | 戻るリンク群                 | `ArrowLeft`    |
+| `src/routes/_protected/bookmarks/new/index.tsx`      | 戻るリンク                   | `ArrowLeft`    |
+| `src/features/bookmarks/components/tag-selector.tsx` | 「この名前で作成」           | `Plus`         |
+| 同上                                                 | フィルタ入力                 | `Search`       |
+
+### ワークベンチフォーム
+
+| ファイル                                                                  | 箇所                   | アイコン      |
+| ------------------------------------------------------------------------- | ---------------------- | ------------- |
+| `src/routes/_protected/bookmarks/-components/bookmark-workbench-form.tsx` | フォームエラーサマリー | `CircleAlert` |
+| 同上                                                                      | 「タイトルを取得」     | `Download`    |
+| `src/routes/_protected/tags/new.tsx`                                      | 戻るリンク             | `ArrowLeft`   |
+| `src/routes/_protected/tags/$id.edit.tsx`                                 | 戻るリンク             | `ArrowLeft`   |
+| 同上                                                                      | フォームエラーサマリー | `CircleAlert` |
+
+### 認証
+
+| ファイル                                                                  | 箇所                   | アイコン      |
+| ------------------------------------------------------------------------- | ---------------------- | ------------- |
+| `src/routes/sign-in/index.tsx`                                            | ブランド領域           | `Package`     |
+| `src/routes/sign-in/-components/sign-in-with-email-and-password-form.tsx` | メールフィールド       | `Mail`        |
+| 同上                                                                      | パスワードフィールド   | `Lock`        |
+| 同上                                                                      | サインイン送信         | `LogIn`       |
+| 同上                                                                      | フォームエラーサマリー | `CircleAlert` |
+
+### 設定
+
+| ファイル                                   | 箇所           | アイコン    |
+| ------------------------------------------ | -------------- | ----------- |
+| `src/routes/_protected/settings/index.tsx` | 「ログアウト」 | `LogOut`    |
+| 同上                                       | 「玄関へ戻る」 | `ArrowLeft` |
+
+### 対象外
+
+- `src/routes/sign-up.tsx` — プレースホルダのみで UI なし
+- `src/routeTree.gen.ts` — 生成ファイル
+- API ルート — UI なし
+
+## Accessibility
+
+- 全アイコンに `aria-hidden` を付与し、装飾として扱う
+- 既存テキストはすべて残すため、スクリーンリーダーへの情報伝達は変化しない
+- `UiLoading` の spin アニメーションは `prefers-reduced-motion` を尊重する（app.css の既存パターンに準拠）
+
+## Testing
+
+- 既存の Vitest スイート（`pnpm run test`）が全件通ること
+- `pnpm run lint` / `pnpm run typecheck` が通ること
+- 手動確認: dev サーバーで全画面のアイコン表示を目視

--- a/src/app.css
+++ b/src/app.css
@@ -338,6 +338,16 @@ body {
   }
 }
 
+.pantry-spinner {
+  animation: pantry-spin 1s linear infinite;
+}
+
+@keyframes pantry-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .pantry-sr-only {
   position: absolute;
   inline-size: 1px;
@@ -1001,6 +1011,9 @@ body {
   border: 2px solid transparent;
   cursor: pointer;
   padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .pantry-color-swatch--clear {
@@ -1159,6 +1172,9 @@ body {
   font-size: 1.75rem;
   font-weight: 700;
   letter-spacing: 0.02em;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .pantry-sign-in__tagline {

--- a/src/components/error-fallback.tsx
+++ b/src/components/error-fallback.tsx
@@ -1,8 +1,13 @@
+import { TriangleAlert } from 'lucide-react'
 import { FallbackProps, getErrorMessage } from 'react-error-boundary'
 
 export function ErrorFallback({ error }: FallbackProps) {
   return (
     <div role='alert'>
+      <TriangleAlert
+        size={20}
+        aria-hidden
+      />
       <p>{getErrorMessage(error)}</p>
     </div>
   )

--- a/src/components/ui-state.tsx
+++ b/src/components/ui-state.tsx
@@ -1,3 +1,4 @@
+import { LoaderCircle, PackageOpen, RefreshCw, TriangleAlert } from 'lucide-react'
 import type { ReactNode } from 'react'
 
 export function UiLoading({ label = '読み込み中' }: { label?: string }) {
@@ -5,6 +6,11 @@ export function UiLoading({ label = '読み込み中' }: { label?: string }) {
     <output
       className='pantry-skeleton'
       aria-live='polite'>
+      <LoaderCircle
+        size={16}
+        className='pantry-spinner'
+        aria-hidden
+      />{' '}
       {label}
     </output>
   )
@@ -13,6 +19,10 @@ export function UiLoading({ label = '読み込み中' }: { label?: string }) {
 export function UiEmpty({ title, action }: { title: string; action?: ReactNode }) {
   return (
     <div className='pantry-empty'>
+      <PackageOpen
+        size={20}
+        aria-hidden
+      />
       <p>{title}</p>
       {action}
     </div>
@@ -24,11 +34,19 @@ export function UiError({ message, onRetry }: { message: string; onRetry?: () =>
     <div
       className='pantry-error'
       role='alert'>
+      <TriangleAlert
+        size={20}
+        aria-hidden
+      />
       <p>{message}</p>
       {onRetry ? (
         <button
           type='button'
           onClick={onRetry}>
+          <RefreshCw
+            size={16}
+            aria-hidden
+          />{' '}
           再試行
         </button>
       ) : undefined}

--- a/src/features/bookmarks/components/bookmark-list.tsx
+++ b/src/features/bookmarks/components/bookmark-list.tsx
@@ -1,4 +1,5 @@
 import { getRouteApi, Link, useNavigate, useRouter } from '@tanstack/react-router'
+import { ChevronDown, LayoutGrid, List, Plus, Search, X } from 'lucide-react'
 import { Suspense, use, useEffect, useId, useState } from 'react'
 import { ErrorBoundary, getErrorMessage } from 'react-error-boundary'
 import type { FallbackProps } from 'react-error-boundary'
@@ -189,6 +190,10 @@ function ListToolbar({
           to='/bookmarks/new'
           search={detailSearchFromList(search)}
           className='pantry-list-toolbar__new'>
+          <Plus
+            size={16}
+            aria-hidden
+          />{' '}
           新規
         </Link>
       </div>
@@ -218,7 +223,13 @@ function ListToolbar({
           }}
           placeholder='タイトル・URL・メモ'
         />
-        <button type='submit'>検索</button>
+        <button type='submit'>
+          <Search
+            size={16}
+            aria-hidden
+          />{' '}
+          検索
+        </button>
       </form>
 
       <div className='pantry-list-toolbar__controls'>
@@ -263,6 +274,10 @@ function ListToolbar({
             onClick={() => {
               onLayoutChange('table')
             }}>
+            <List
+              size={16}
+              aria-hidden
+            />{' '}
             テーブル
           </button>
           <button
@@ -271,6 +286,10 @@ function ListToolbar({
             onClick={() => {
               onLayoutChange('card')
             }}>
+            <LayoutGrid
+              size={16}
+              aria-hidden
+            />{' '}
             カード
           </button>
         </fieldset>
@@ -291,7 +310,10 @@ function ListToolbar({
               patchSearch({ tags: next })
             }}>
             {tagName}
-            <span aria-hidden='true'> ×</span>
+            <X
+              size={14}
+              aria-hidden
+            />
             <span className='pantry-sr-only'>を外す</span>
           </button>
         ))}
@@ -443,6 +465,10 @@ function BookmarkListResults({
               className='pantry-load-more'
               disabled={isLoadingMore}
               onClick={loadMore}>
+              <ChevronDown
+                size={16}
+                aria-hidden
+              />{' '}
               {isLoadingMore ? '読み込み中…' : 'さらに読み込む'}
             </button>
           )}

--- a/src/features/bookmarks/components/bookmark-table.tsx
+++ b/src/features/bookmarks/components/bookmark-table.tsx
@@ -1,4 +1,5 @@
 import { Link } from '@tanstack/react-router'
+import { Globe } from 'lucide-react'
 
 import { formatDateTime } from '../../../lib/format-date'
 import type { BookmarkListItem } from '../attach-bookmark-tags'
@@ -38,6 +39,10 @@ export function BookmarkTable({ bookmarks, detailSearch = {} }: BookmarkTablePro
                 params={{ id: bookmark.id }}
                 search={detailSearch}
                 className='pantry-bookmark-row-link pantry-bookmark-row-link--muted'>
+                <Globe
+                  size={14}
+                  aria-hidden
+                />{' '}
                 {shortenUrl(bookmark.url, 48)}
               </Link>
             </td>

--- a/src/features/bookmarks/components/tag-selector.tsx
+++ b/src/features/bookmarks/components/tag-selector.tsx
@@ -1,4 +1,5 @@
 import { Input } from '@base-ui/react'
+import { Plus, Search } from 'lucide-react'
 import { useState } from 'react'
 import * as v from 'valibot'
 
@@ -77,6 +78,10 @@ export function TagSelector({ allTags, selectedTagIds, onChange }: TagSelectorPr
           ))}
         </div>
         <label htmlFor='tag-selector-query'>
+          <Search
+            size={16}
+            aria-hidden
+          />{' '}
           タグを絞り込む / 新規作成
           <Input
             id='tag-selector-query'
@@ -92,6 +97,10 @@ export function TagSelector({ allTags, selectedTagIds, onChange }: TagSelectorPr
           type='button'
           onClick={handleCreate}
           disabled={isPending}>
+          <Plus
+            size={16}
+            aria-hidden
+          />{' '}
           {isPending ? '作成中...' : 'この名前で作成'}
         </button>
         {error != null && <p role='alert'>{error}</p>}

--- a/src/features/tags/components/entrance-boxes.tsx
+++ b/src/features/tags/components/entrance-boxes.tsx
@@ -1,4 +1,5 @@
 import { getRouteApi, Link, useRouter } from '@tanstack/react-router'
+import { Package, Plus } from 'lucide-react'
 import { Suspense, use } from 'react'
 import { ErrorBoundary, getErrorMessage } from 'react-error-boundary'
 import type { FallbackProps } from 'react-error-boundary'
@@ -42,8 +43,20 @@ function EntranceBoxesIdeal({ tags }: { readonly tags: ShelfTag[] }) {
         title='まだ箱がありません'
         action={
           <div className='pantry-entrance-empty-actions'>
-            <Link to='/tags/new'>タグを作成</Link>
-            <Link to='/bookmarks/new'>新規ブックマーク</Link>
+            <Link to='/tags/new'>
+              <Plus
+                size={16}
+                aria-hidden
+              />{' '}
+              タグを作成
+            </Link>
+            <Link to='/bookmarks/new'>
+              <Plus
+                size={16}
+                aria-hidden
+              />{' '}
+              新規ブックマーク
+            </Link>
           </div>
         }
       />
@@ -66,7 +79,13 @@ function EntranceBoxesIdeal({ tags }: { readonly tags: ShelfTag[] }) {
               style={tag.color != null ? { backgroundColor: tag.color } : undefined}
               aria-hidden='true'
             />
-            <span className='pantry-entrance-box__name'>{tag.name}</span>
+            <span className='pantry-entrance-box__name'>
+              <Package
+                size={16}
+                aria-hidden
+              />{' '}
+              {tag.name}
+            </span>
             <span className='pantry-entrance-box__count'>{tag.bookmarkCount}件</span>
           </Link>
         </li>

--- a/src/features/tags/components/inline-add-tag.tsx
+++ b/src/features/tags/components/inline-add-tag.tsx
@@ -1,5 +1,6 @@
 import { Input } from '@base-ui/react'
 import { useNavigate } from '@tanstack/react-router'
+import { Plus } from 'lucide-react'
 import { useState } from 'react'
 import * as v from 'valibot'
 
@@ -60,6 +61,10 @@ export function InlineAddTag() {
             type='submit'
             className='pantry-button pantry-button--secondary'
             disabled={isPending}>
+            <Plus
+              size={16}
+              aria-hidden
+            />{' '}
             {isPending ? '追加中...' : '追加'}
           </button>
         </div>

--- a/src/features/tags/components/tag-edit-fields.tsx
+++ b/src/features/tags/components/tag-edit-fields.tsx
@@ -1,3 +1,5 @@
+import { Check, Minus, Pin, PinOff, Plus } from 'lucide-react'
+
 import { TAG_COLOR_PALETTE } from '../tag-color-palette'
 
 type TagEditFieldsProps = {
@@ -41,6 +43,17 @@ export function TagEditFields({
           onClick={() => {
             onPinnedChange(!pinned)
           }}>
+          {pinned ? (
+            <PinOff
+              size={16}
+              aria-hidden
+            />
+          ) : (
+            <Pin
+              size={16}
+              aria-hidden
+            />
+          )}{' '}
           {pinLabel(pinned)}
         </button>
       </div>
@@ -71,8 +84,15 @@ export function TagEditFields({
                 aria-label={`色 ${swatch}`}
                 onClick={() => {
                   onColorChange(swatch)
-                }}
-              />
+                }}>
+                {selected ? (
+                  <Check
+                    size={16}
+                    color='#fff'
+                    aria-hidden
+                  />
+                ) : null}
+              </button>
             )
           })}
         </div>
@@ -89,7 +109,10 @@ export function TagEditFields({
             onClick={() => {
               onSortOrderChange(sortOrder - 1)
             }}>
-            −
+            <Minus
+              size={16}
+              aria-hidden
+            />
           </button>
           <input
             id='tag-sort-order'
@@ -113,7 +136,10 @@ export function TagEditFields({
             onClick={() => {
               onSortOrderChange(sortOrder + 1)
             }}>
-            ＋
+            <Plus
+              size={16}
+              aria-hidden
+            />
           </button>
         </div>
       </div>

--- a/src/features/tags/tag-table.tsx
+++ b/src/features/tags/tag-table.tsx
@@ -1,4 +1,5 @@
 import { Link } from '@tanstack/react-router'
+import { Pencil, Pin } from 'lucide-react'
 import { use } from 'react'
 
 import { UiEmpty } from '../../components/ui-state'
@@ -59,7 +60,13 @@ export function TagTable({ tagPromise }: { readonly tagPromise: Promise<ShelfTag
             <td className='pantry-tag-table__count'>{tag.bookmarkCount}</td>
             <td>
               {tag.pinned ? (
-                <span aria-label='ピン留め中'>ピン</span>
+                <span>
+                  <Pin
+                    size={16}
+                    aria-hidden
+                  />
+                  <span className='pantry-sr-only'>ピン留め中</span>
+                </span>
               ) : (
                 <span className='pantry-tag-table__muted'>—</span>
               )}
@@ -69,6 +76,10 @@ export function TagTable({ tagPromise }: { readonly tagPromise: Promise<ShelfTag
                 to='/tags/$id/edit'
                 params={{ id: String(tag.id) }}
                 className='pantry-text-link'>
+                <Pencil
+                  size={16}
+                  aria-hidden
+                />{' '}
                 編集
               </Link>
             </td>

--- a/src/routes/_protected.tsx
+++ b/src/routes/_protected.tsx
@@ -8,6 +8,7 @@ import {
   useRouter,
   useSearch
 } from '@tanstack/react-router'
+import { LogOut, Menu, Plus, Settings, Tags, X } from 'lucide-react'
 import { Suspense, useState, useTransition } from 'react'
 import { ErrorBoundary, getErrorMessage } from 'react-error-boundary'
 import type { FallbackProps } from 'react-error-boundary'
@@ -113,9 +114,19 @@ function Layout() {
           <Link
             to='/tags'
             search={{ limit: 50, offset: 0 }}>
+            <Tags
+              size={16}
+              aria-hidden
+            />{' '}
             タグ管理
           </Link>
-          <Link to='/settings'>設定</Link>
+          <Link to='/settings'>
+            <Settings
+              size={16}
+              aria-hidden
+            />{' '}
+            設定
+          </Link>
         </div>
       </aside>
 
@@ -132,13 +143,25 @@ function Layout() {
             <Dialog.Root
               open={shelfOpen}
               onOpenChange={setShelfOpen}>
-              <Dialog.Trigger className='pantry-shelf-changer'>棚を変える</Dialog.Trigger>
+              <Dialog.Trigger className='pantry-shelf-changer'>
+                <Menu
+                  size={16}
+                  aria-hidden
+                />{' '}
+                棚を変える
+              </Dialog.Trigger>
               <Dialog.Portal>
                 <Dialog.Backdrop className='pantry-shelf-sheet__backdrop' />
                 <Dialog.Popup className='pantry-shelf-sheet'>
                   <div className='pantry-shelf-sheet__header'>
                     <Dialog.Title className='pantry-shelf-sheet__title'>棚を選ぶ</Dialog.Title>
-                    <Dialog.Close className='pantry-shelf-sheet__close'>閉じる</Dialog.Close>
+                    <Dialog.Close className='pantry-shelf-sheet__close'>
+                      <X
+                        size={16}
+                        aria-hidden
+                      />{' '}
+                      閉じる
+                    </Dialog.Close>
                   </div>
                   {renderShelfNav(closeShelf)}
                 </Dialog.Popup>
@@ -154,14 +177,28 @@ function Layout() {
                   ? { tags: indexSearch.tags }
                   : {}
               }>
-              ＋新規
+              <Plus
+                size={16}
+                aria-hidden
+              />{' '}
+              新規
             </Link>
-            <Link to='/settings'>設定</Link>
+            <Link to='/settings'>
+              <Settings
+                size={16}
+                aria-hidden
+              />{' '}
+              設定
+            </Link>
             <button
               type='button'
               className='pantry-sign-out'
               onClick={handleSignOut}
               disabled={isPending}>
+              <LogOut
+                size={16}
+                aria-hidden
+              />{' '}
               ログアウト
             </button>
           </div>

--- a/src/routes/_protected/bookmarks/$id/edit.tsx
+++ b/src/routes/_protected/bookmarks/$id/edit.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { ArrowLeft } from 'lucide-react'
 import { useState } from 'react'
 import * as v from 'valibot'
 
@@ -94,12 +95,20 @@ function EditWorkbench({
           params={{ id: bookmark.id }}
           search={searchTags !== undefined ? { tags: searchTags } : {}}
           className='pantry-text-link'>
+          <ArrowLeft
+            size={16}
+            aria-hidden
+          />{' '}
           詳細へ戻る
         </Link>
         <Link
           to='/'
           search={listSearch}
           className='pantry-text-link'>
+          <ArrowLeft
+            size={16}
+            aria-hidden
+          />{' '}
           一覧へ戻る
         </Link>
       </nav>

--- a/src/routes/_protected/bookmarks/$id/index.tsx
+++ b/src/routes/_protected/bookmarks/$id/index.tsx
@@ -6,6 +6,7 @@ import {
   useRouter,
   useRouterState
 } from '@tanstack/react-router'
+import { ArrowLeft, CircleCheck, ExternalLink, Pencil, Trash2, X } from 'lucide-react'
 import { Suspense, use, useState, useTransition } from 'react'
 import { ErrorBoundary, getErrorMessage } from 'react-error-boundary'
 import type { FallbackProps } from 'react-error-boundary'
@@ -119,6 +120,10 @@ function RouteComponent() {
         <div
           className='pantry-flash'
           role='alert'>
+          <CircleCheck
+            size={16}
+            aria-hidden
+          />{' '}
           ブックマークを登録しました
         </div>
       ) : null}
@@ -126,6 +131,10 @@ function RouteComponent() {
         <div
           className='pantry-flash'
           role='alert'>
+          <CircleCheck
+            size={16}
+            aria-hidden
+          />{' '}
           ブックマークを更新しました
         </div>
       ) : null}
@@ -200,6 +209,10 @@ function DetailBody({
           to='/'
           search={listSearch}
           className='pantry-text-link'>
+          <ArrowLeft
+            size={16}
+            aria-hidden
+          />{' '}
           一覧へ戻る
         </Link>
       </nav>
@@ -211,7 +224,11 @@ function DetailBody({
           target='_blank'
           rel='noreferrer'
           className='pantry-detail__url'>
-          {bookmark.url}
+          {bookmark.url}{' '}
+          <ExternalLink
+            size={14}
+            aria-hidden
+          />
         </a>
       </header>
 
@@ -251,6 +268,10 @@ function DetailBody({
           params={{ id: bookmark.id }}
           search={listSearch.tags !== undefined ? { tags: listSearch.tags } : {}}
           className='pantry-button pantry-button--accent'>
+          <Pencil
+            size={16}
+            aria-hidden
+          />{' '}
           編集
         </Link>
 
@@ -265,6 +286,10 @@ function DetailBody({
           <Dialog.Trigger
             className='pantry-button pantry-button--danger'
             disabled={isDeleting}>
+            <Trash2
+              size={16}
+              aria-hidden
+            />{' '}
             削除
           </Dialog.Trigger>
           <Dialog.Portal>
@@ -285,6 +310,10 @@ function DetailBody({
                 <Dialog.Close
                   className='pantry-button pantry-button--secondary'
                   disabled={isDeleting}>
+                  <X
+                    size={16}
+                    aria-hidden
+                  />{' '}
                   キャンセル
                 </Dialog.Close>
                 <button
@@ -292,6 +321,10 @@ function DetailBody({
                   className='pantry-button pantry-button--danger'
                   onClick={handleDelete}
                   disabled={isDeleting}>
+                  <Trash2
+                    size={16}
+                    aria-hidden
+                  />{' '}
                   {isDeleting ? '削除中…' : '削除を確認'}
                 </button>
               </div>

--- a/src/routes/_protected/bookmarks/-components/bookmark-workbench-form.tsx
+++ b/src/routes/_protected/bookmarks/-components/bookmark-workbench-form.tsx
@@ -1,5 +1,6 @@
 import { Input } from '@base-ui/react'
 import { Field, getAllErrors, getInput, setInput, useForm, validate } from '@formisch/react'
+import { CircleAlert, Download } from 'lucide-react'
 import { useActionState, useState } from 'react'
 import * as v from 'valibot'
 
@@ -120,7 +121,13 @@ export function BookmarkWorkbenchForm({
           className='pantry-form-summary'
           role='alert'
           aria-live='polite'>
-          <p>次を確認してください</p>
+          <p>
+            <CircleAlert
+              size={16}
+              aria-hidden
+            />{' '}
+            次を確認してください
+          </p>
           <ul>
             {allSummary.map((message) => (
               <li key={message}>{message}</li>
@@ -158,6 +165,10 @@ export function BookmarkWorkbenchForm({
                     void handleFetchTitle()
                   }}
                   disabled={busy}>
+                  <Download
+                    size={16}
+                    aria-hidden
+                  />{' '}
                   {isFetchingTitle ? '取得中…' : 'タイトルを取得'}
                 </button>
               </div>

--- a/src/routes/_protected/bookmarks/new/index.tsx
+++ b/src/routes/_protected/bookmarks/new/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { ArrowLeft } from 'lucide-react'
 import { useState } from 'react'
 import * as v from 'valibot'
 
@@ -41,6 +42,10 @@ function RouteComponent() {
           to='/'
           search={listSearch}
           className='pantry-text-link'>
+          <ArrowLeft
+            size={16}
+            aria-hidden
+          />{' '}
           一覧へ戻る
         </Link>
       </nav>

--- a/src/routes/_protected/settings/index.tsx
+++ b/src/routes/_protected/settings/index.tsx
@@ -1,5 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query'
 import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
+import { ArrowLeft, LogOut } from 'lucide-react'
 import { useTransition } from 'react'
 
 import { defaultBookmarkSearch } from '../-lib/bookmark-search-schema'
@@ -62,6 +63,10 @@ function RouteComponent() {
           className='pantry-button pantry-button--accent'
           onClick={handleSignOut}
           disabled={isPending}>
+          <LogOut
+            size={16}
+            aria-hidden
+          />{' '}
           {isPending ? 'ログアウト中...' : 'ログアウト'}
         </button>
       </section>
@@ -70,6 +75,10 @@ function RouteComponent() {
         to='/'
         search={defaultBookmarkSearch}
         className='pantry-text-link'>
+        <ArrowLeft
+          size={16}
+          aria-hidden
+        />{' '}
         玄関へ戻る
       </Link>
     </div>

--- a/src/routes/_protected/tags/$id.edit.tsx
+++ b/src/routes/_protected/tags/$id.edit.tsx
@@ -1,6 +1,7 @@
 import { Input } from '@base-ui/react'
 import { Field, getInput, useForm } from '@formisch/react'
 import { createFileRoute, Link, useNavigate, useRouter } from '@tanstack/react-router'
+import { ArrowLeft, CircleAlert } from 'lucide-react'
 import { Suspense, use, useActionState, useState } from 'react'
 import { ErrorBoundary, getErrorMessage } from 'react-error-boundary'
 import type { FallbackProps } from 'react-error-boundary'
@@ -71,6 +72,10 @@ function RouteComponent() {
           to='/tags'
           search={{ limit: 50, offset: 0 }}
           className='pantry-text-link'>
+          <ArrowLeft
+            size={16}
+            aria-hidden
+          />{' '}
           一覧へ戻る
         </Link>
       </nav>
@@ -145,7 +150,13 @@ function EditTagForm({ tagPromise, submitAction }: EditTagFormProps) {
           className='pantry-form-summary'
           role='alert'
           aria-live='polite'>
-          <p>{formError}</p>
+          <p>
+            <CircleAlert
+              size={16}
+              aria-hidden
+            />{' '}
+            {formError}
+          </p>
         </div>
       ) : null}
 

--- a/src/routes/_protected/tags/$id/index.tsx
+++ b/src/routes/_protected/tags/$id/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Link, useRouter, useRouterState } from '@tanstack/react-router'
+import { ArrowLeft, Bookmark, CircleCheck, Pencil, Pin } from 'lucide-react'
 import { Suspense, use } from 'react'
 import { ErrorBoundary, getErrorMessage } from 'react-error-boundary'
 import type { FallbackProps } from 'react-error-boundary'
@@ -45,14 +46,34 @@ function RouteComponent() {
 
   return (
     <div className='pantry-workbench'>
-      {newTagCreated ? <output className='pantry-flash'>タグを登録しました</output> : null}
-      {tagUpdated ? <output className='pantry-flash'>タグを更新しました</output> : null}
+      {newTagCreated ? (
+        <output className='pantry-flash'>
+          <CircleCheck
+            size={16}
+            aria-hidden
+          />{' '}
+          タグを登録しました
+        </output>
+      ) : null}
+      {tagUpdated ? (
+        <output className='pantry-flash'>
+          <CircleCheck
+            size={16}
+            aria-hidden
+          />{' '}
+          タグを更新しました
+        </output>
+      ) : null}
 
       <nav className='pantry-workbench__nav'>
         <Link
           to='/tags'
           search={{ limit: 50, offset: 0 }}
           className='pantry-text-link'>
+          <ArrowLeft
+            size={16}
+            aria-hidden
+          />{' '}
           一覧へ戻る
         </Link>
       </nav>
@@ -96,7 +117,19 @@ function TagDetail({
       <dl className='pantry-tag-detail__meta'>
         <div>
           <dt>ピン</dt>
-          <dd>{tag.pinned ? '留めている' : 'なし'}</dd>
+          <dd>
+            {tag.pinned ? (
+              <>
+                <Pin
+                  size={16}
+                  aria-hidden
+                />{' '}
+                留めている
+              </>
+            ) : (
+              'なし'
+            )}
+          </dd>
         </div>
         <div>
           <dt>並び順</dt>
@@ -109,12 +142,20 @@ function TagDetail({
           to='/'
           search={tagShelfSearch(tag.name)}
           className='pantry-button pantry-button--accent'>
+          <Bookmark
+            size={16}
+            aria-hidden
+          />{' '}
           この棚のブックマークを見る
         </Link>
         <Link
           to='/tags/$id/edit'
           params={{ id }}
           className='pantry-button pantry-button--secondary'>
+          <Pencil
+            size={16}
+            aria-hidden
+          />{' '}
           編集
         </Link>
       </div>

--- a/src/routes/_protected/tags/index.tsx
+++ b/src/routes/_protected/tags/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, ErrorComponent, ErrorComponentProps, Link } from '@tanstack/react-router'
+import { Plus } from 'lucide-react'
 import { Suspense } from 'react'
 import { ErrorBoundary, getErrorMessage } from 'react-error-boundary'
 import type { FallbackProps } from 'react-error-boundary'
@@ -54,6 +55,10 @@ function RouteComponent() {
         <Link
           to='/tags/new'
           className='pantry-button pantry-button--accent'>
+          <Plus
+            size={16}
+            aria-hidden
+          />{' '}
           新規タグ
         </Link>
       </header>

--- a/src/routes/_protected/tags/new.tsx
+++ b/src/routes/_protected/tags/new.tsx
@@ -1,6 +1,7 @@
 import { Input } from '@base-ui/react'
 import { Field, getInput, useForm } from '@formisch/react'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { ArrowLeft, CircleAlert } from 'lucide-react'
 import { useActionState, useState } from 'react'
 import * as v from 'valibot'
 
@@ -43,6 +44,10 @@ function RouteComponent() {
           to='/tags'
           search={{ limit: 50, offset: 0 }}
           className='pantry-text-link'>
+          <ArrowLeft
+            size={16}
+            aria-hidden
+          />{' '}
           一覧へ戻る
         </Link>
       </nav>
@@ -110,7 +115,13 @@ function RegisterNewTagForm({ submitAction }: RegisterNewTagFormProps) {
           className='pantry-form-summary'
           role='alert'
           aria-live='polite'>
-          <p>{formError}</p>
+          <p>
+            <CircleAlert
+              size={16}
+              aria-hidden
+            />{' '}
+            {formError}
+          </p>
         </div>
       ) : null}
 

--- a/src/routes/sign-in/-components/sign-in-with-email-and-password-form.tsx
+++ b/src/routes/sign-in/-components/sign-in-with-email-and-password-form.tsx
@@ -1,5 +1,6 @@
 import { Input } from '@base-ui/react'
 import { Field, getInput, useForm } from '@formisch/react'
+import { CircleAlert, Lock, LogIn, Mail } from 'lucide-react'
 import { useActionState } from 'react'
 import { parseAsync } from 'valibot'
 
@@ -56,7 +57,13 @@ export const SignInWithEmailAndPasswordForm = ({
           className='pantry-form-summary'
           role='alert'
           aria-live='polite'>
-          <p>{signInErrorMessage(signInError)}</p>
+          <p>
+            <CircleAlert
+              size={16}
+              aria-hidden
+            />{' '}
+            {signInErrorMessage(signInError)}
+          </p>
         </div>
       ) : null}
 
@@ -70,7 +77,13 @@ export const SignInWithEmailAndPasswordForm = ({
           path={['email']}>
           {(field) => (
             <div className='pantry-field'>
-              <label htmlFor={field.props.name}>メール</label>
+              <label htmlFor={field.props.name}>
+                <Mail
+                  size={16}
+                  aria-hidden
+                />{' '}
+                メール
+              </label>
               <Input
                 id={field.props.name}
                 value={field.input}
@@ -92,7 +105,13 @@ export const SignInWithEmailAndPasswordForm = ({
           path={['password']}>
           {(field) => (
             <div className='pantry-field'>
-              <label htmlFor={field.props.name}>パスワード</label>
+              <label htmlFor={field.props.name}>
+                <Lock
+                  size={16}
+                  aria-hidden
+                />{' '}
+                パスワード
+              </label>
               <Input
                 id={field.props.name}
                 value={field.input}
@@ -114,6 +133,10 @@ export const SignInWithEmailAndPasswordForm = ({
         type='submit'
         className='pantry-button pantry-button--accent'
         disabled={isPending}>
+        <LogIn
+          size={16}
+          aria-hidden
+        />{' '}
         {isPending ? 'サインイン中...' : 'サインイン'}
       </button>
     </form>

--- a/src/routes/sign-in/index.tsx
+++ b/src/routes/sign-in/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, useRouter, useSearch } from '@tanstack/react-router'
+import { Package } from 'lucide-react'
 import * as v from 'valibot'
 
 import { authClient } from '../../features/auth/auth-client'
@@ -40,7 +41,13 @@ function RouteComponent() {
   return (
     <div className='pantry-sign-in'>
       <div className='pantry-sign-in__panel'>
-        <p className='pantry-sign-in__brand'>Pantry</p>
+        <p className='pantry-sign-in__brand'>
+          <Package
+            size={28}
+            aria-hidden
+          />
+          Pantry
+        </p>
         <p className='pantry-sign-in__tagline'>自分の棚に入る</p>
         <SignInWithEmailAndPasswordForm onSignIn={onSignIn} />
       </div>


### PR DESCRIPTION
## Summary

- 全画面がテキストのみで無機質だったため、lucide-react の装飾アイコンを一括導入した（Issue #101）。既存テキストはすべて併記し、アイコンは `aria-hidden` で装飾扱い。
- アプリシェル／一覧／詳細／ワークベンチ／玄関／タグ管理／認証／設定／共通ステートコンポーネントの計22ファイルに追加。既存の Unicode 記号（`＋` `×` `−`）は対応する Lucide アイコンに置換。
- app.css にはローダーの spin keyframe・カラースウォッチの中央揃え・サインインブランドの flex を少量追加（既存の `prefers-reduced-motion` ブロックが spinner を自動無効化）。

## Test plan

- [x] `pnpm run format:check`
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] `pnpm run build`

## UI

- [ ] 一覧 / 登録 / 編集など触ったフローを手動確認した
- [ ] デスクトップとモバイル幅で主要操作できる
- [ ] エラーが利用者に見える

> 自動化ゲート（format/lint/typecheck/test/build）はすべて通過済み。上記 UI 項目は実アプリでの目視確認待ち。

Closes #101
