### PR TITLE
chore: revert local Turso from apple/container to docker compose

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,9 @@
+services:
+  turso:
+    image: ghcr.io/tursodatabase/libsql-server@sha256:817fb6c6865d048a509f5c120905629fb9b5af20ad0c526cdc68a6d8793898ad
+    platform: linux/arm64
+    container_name: pantry-turso
+    ports:
+      - '8080:8080'
+    tmpfs:
+      - /var/lib/sqld

--- a/justfile
+++ b/justfile
@@ -2,16 +2,11 @@ container_name := "pantry-turso"
 image_tag := "pantry-turso:local"
 
 local-db-build:
-  @container stop {{container_name}} 2>/dev/null || true
-  @container delete {{container_name}} 2>/dev/null || true
-  @container build --platform linux/arm64 -t {{image_tag}} -f Dockerfile .
-  @container run -d --name {{container_name}} --platform linux/arm64 -p 8080:8080 --tmpfs /var/lib/sqld {{image_tag}}
+  @docker compose down 2>/dev/null || true
+  @docker compose up -d
   @for i in $(seq 1 30); do curl -sf http://127.0.0.1:8080/v2 >/dev/null && exit 0; sleep 0.5; done; echo "local turso not ready on :8080" >&2; exit 1
   @pnpm dotenvx run -f .env.development -- pnpm run migrate:dev
   @pnpm dotenvx run -f .env.development -- pnpm tsx scripts/seed.ts
 
 local-db-clean:
-  @container stop {{container_name}} 2>/dev/null || true
-  @container delete {{container_name}} 2>/dev/null || true
-  @container image delete --force {{image_tag}} 2>/dev/null || true
-  
+  @docker compose down 2>/dev/null || true


### PR DESCRIPTION
apple/containerでコンテナ起動がうまくいかなくなったため、docker composeを使う形に戻す。