### PR TITLE
chore: add panda-css MCP server to opencode config

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -56,6 +56,11 @@
       "type": "local",
       "command": ["npx", "-y", "@playwright/mcp@latest"],
       "enabled": true
+    },
+    "panda-css": {
+      "type": "local",
+      "command": ["pnpm", "panda", "mcp"],
+      "enabled": true
     }
   },
   "references": {


### PR DESCRIPTION
Add `panda-css` MCP server configuration to `opencode.jsonc` so agents can query Panda CSS tokens, recipes, and patterns.