### PR TITLE
ci: restore standalone OSV Scanner, remove it from Security

### DIFF
--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -1,0 +1,15 @@
+name: OSV Scanner
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  actions: read
+  security-events: write
+  contents: read
+
+jobs:
+  can-pr:
+    uses: 'google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@c51854704019a247608d928f370c98740469d4b5'

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -9,14 +9,6 @@ permissions:
   contents: read
 
 jobs:
-  osv-scanner:
-    permissions:
-      actions: read
-      security-events: write
-      contents: read
-
-    uses: 'google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@c51854704019a247608d928f370c98740469d4b5'
-
   gitleaks:
     runs-on: ubuntu-24.04
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- #118 で削除した `.github/workflows/osv-scanner.yaml` を復元しました（実質的な revert）
- 重複実行を避けるため、代わりに `.github/workflows/security.yaml` の `osv-scanner` ジョブを削除しました
- OSV Scanner は standalone workflow のみで実行されます

## Test plan

- [ ] PR の Checks で `OSV Scanner` が1回だけ実行されることを確認する
- [ ] `Security` workflow に `osv-scanner` ジョブが含まれていないことを確認する
- [ ] `Security` workflow の `gitleaks` ジョブが引き続き成功することを確認する

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8c9beba-2c20-4a6e-b6db-508683d86e9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8c9beba-2c20-4a6e-b6db-508683d86e9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

