### PR TITLE
chore(panda): disable strictTokens and strictPropertyValues

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -383,8 +383,8 @@ export default defineConfig({
 
   jsxFramework: 'react',
 
-  strictTokens: true,
-  strictPropertyValues: true,
+  strictTokens: false,
+  strictPropertyValues: false,
 
   validation: 'error'
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

UI/UX デザイン調整でトークン未定義の値を使いやすくするため、`panda.config.ts` の `strictTokens` と `strictPropertyValues` を `false` に変更しました。

## Test plan

- [ ] `pnpm run typecheck`
- [ ] `pnpm run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db12649b-c57d-44ea-b684-8b5eb172272c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db12649b-c57d-44ea-b684-8b5eb172272c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

