### PR TITLE
refactor(bookmarks): inject fetchTitleAction as a useActionState action

### DIFF
--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/fields.tsx
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/fields.tsx
@@ -4,7 +4,12 @@ import { Download } from 'lucide-react'
 
 import { StyledButton } from '../../../../../shared/components/styled-button'
 import { field, fieldError, fieldInput, fieldLabel, fieldUrlRow } from '../../../../../styles/form'
-import type { BookmarkFormFieldKey, BookmarkFormServerError, BookmarkFormStore } from './types'
+import type {
+  BookmarkFormFieldKey,
+  BookmarkFormServerError,
+  BookmarkFormStore,
+  BookmarkTitleFetchAction
+} from './types'
 
 export type BookmarkFormFieldIds = {
   readonly url: string
@@ -18,7 +23,7 @@ type BookmarkFormFieldsProps = {
   readonly serverFieldErrors?: BookmarkFormServerError['fields']
   readonly busy: boolean
   readonly isFetchingTitle: boolean
-  readonly onFetchTitle: ((url: string) => Promise<string | null>) | undefined
+  readonly fetchTitleAction: BookmarkTitleFetchAction | undefined
   readonly handleFetchTitle: () => void
   readonly onClearServerFieldError: (key: BookmarkFormFieldKey) => void
 }
@@ -45,7 +50,7 @@ export function BookmarkFormFields({
   serverFieldErrors,
   busy,
   isFetchingTitle,
-  onFetchTitle,
+  fetchTitleAction,
   handleFetchTitle,
   onClearServerFieldError
 }: BookmarkFormFieldsProps) {
@@ -91,7 +96,7 @@ export function BookmarkFormFields({
                     handleFieldChange('url')
                   }}
                 />
-                {onFetchTitle !== undefined ? (
+                {fetchTitleAction !== undefined ? (
                   <StyledButton
                     type='button'
                     onClick={handleFetchTitle}

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/fields.tsx
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/fields.tsx
@@ -4,12 +4,7 @@ import { Download } from 'lucide-react'
 
 import { StyledButton } from '../../../../../shared/components/styled-button'
 import { field, fieldError, fieldInput, fieldLabel, fieldUrlRow } from '../../../../../styles/form'
-import type {
-  BookmarkFormFieldKey,
-  BookmarkFormServerError,
-  BookmarkFormStore,
-  BookmarkTitleFetchAction
-} from './types'
+import type { BookmarkFormFieldKey, BookmarkFormServerError, BookmarkFormStore } from './types'
 
 export type BookmarkFormFieldIds = {
   readonly url: string
@@ -23,7 +18,6 @@ type BookmarkFormFieldsProps = {
   readonly serverFieldErrors?: BookmarkFormServerError['fields']
   readonly busy: boolean
   readonly isFetchingTitle: boolean
-  readonly fetchTitleAction: BookmarkTitleFetchAction | undefined
   readonly handleFetchTitle: () => void
   readonly onClearServerFieldError: (key: BookmarkFormFieldKey) => void
 }
@@ -50,7 +44,6 @@ export function BookmarkFormFields({
   serverFieldErrors,
   busy,
   isFetchingTitle,
-  fetchTitleAction,
   handleFetchTitle,
   onClearServerFieldError
 }: BookmarkFormFieldsProps) {
@@ -96,19 +89,17 @@ export function BookmarkFormFields({
                     handleFieldChange('url')
                   }}
                 />
-                {fetchTitleAction !== undefined ? (
-                  <StyledButton
-                    type='button'
-                    onClick={handleFetchTitle}
-                    disabled={busy}
-                    aria-busy={isFetchingTitle}>
-                    <Download
-                      size={16}
-                      aria-hidden
-                    />
-                    {isFetchingTitle ? '取得中…' : 'タイトルを取得'}
-                  </StyledButton>
-                ) : null}
+                <StyledButton
+                  type='button'
+                  onClick={handleFetchTitle}
+                  disabled={busy}
+                  aria-busy={isFetchingTitle}>
+                  <Download
+                    size={16}
+                    aria-hidden
+                  />
+                  {isFetchingTitle ? '取得中…' : 'タイトルを取得'}
+                </StyledButton>
               </div>
               {errorMessage !== undefined ? (
                 <p

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/index.stories.tsx
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/index.stories.tsx
@@ -67,11 +67,14 @@ export const RejectsEmptyUrl = Default.extend({
       note: null
     }
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement)
+    const fetchTitleAction = args.fetchTitleAction as Mock<BookmarkTitleFetchAction>
     await userEvent.click(canvas.getByRole('button', { name: 'タイトルを取得' }))
     await expect(canvas.getByRole('alert')).toHaveTextContent('先にURLを入力してください')
     await expect(canvas.getByLabelText('タイトル')).toHaveValue('手入力タイトル')
+    // 空 URL は dispatch 前に弾かれるため、Server (action) は呼ばれない
+    await expect(fetchTitleAction).not.toHaveBeenCalled()
   }
 })
 

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/index.stories.tsx
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/index.stories.tsx
@@ -34,6 +34,12 @@ const defaultInitialValues = {
   note: 'メモの下書き'
 } as const
 
+// タイトル取得を主目的としない story が共通で使う action。
+const defaultFetchTitleAction = fn<BookmarkTitleFetchAction>(async () => ({
+  status: 'success',
+  title: '取得したタイトル'
+}))
+
 export const Default = meta.story({
   args: {
     initialValues: defaultInitialValues,
@@ -201,6 +207,7 @@ export const ServerFieldErrorShownInFieldAndSummary = meta.story({
   args: {
     initialValues: defaultInitialValues,
     onSubmit: fn<(values: BookmarkFormSubmitValues) => void>(),
+    fetchTitleAction: defaultFetchTitleAction,
     serverError: {
       summary: '同じURLのブックマークが既に存在します',
       fields: { url: 'この URL は既に登録されています' }
@@ -226,6 +233,7 @@ export const EditingClearsMatchingServerFieldError = meta.story({
     <ControlledBookmarkForm
       initialValues={args.initialValues}
       onSubmit={args.onSubmit}
+      fetchTitleAction={defaultFetchTitleAction}
       initialServerError={{
         summary: '入力内容を確認してください',
         fields: {
@@ -237,7 +245,8 @@ export const EditingClearsMatchingServerFieldError = meta.story({
   ),
   args: {
     initialValues: defaultInitialValues,
-    onSubmit: fn<(values: BookmarkFormSubmitValues) => void>()
+    onSubmit: fn<(values: BookmarkFormSubmitValues) => void>(),
+    fetchTitleAction: defaultFetchTitleAction
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
@@ -263,6 +272,7 @@ export const EditingOtherFieldKeepsUnrelatedServerError = meta.story({
     <ControlledBookmarkForm
       initialValues={args.initialValues}
       onSubmit={args.onSubmit}
+      fetchTitleAction={defaultFetchTitleAction}
       initialServerError={{
         fields: {
           url: 'この URL は既に登録されています'
@@ -272,7 +282,8 @@ export const EditingOtherFieldKeepsUnrelatedServerError = meta.story({
   ),
   args: {
     initialValues: defaultInitialValues,
-    onSubmit: fn<(values: BookmarkFormSubmitValues) => void>()
+    onSubmit: fn<(values: BookmarkFormSubmitValues) => void>(),
+    fetchTitleAction: defaultFetchTitleAction
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/index.stories.tsx
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/index.stories.tsx
@@ -9,7 +9,8 @@ import type {
   BookmarkFormFieldKey,
   BookmarkFormProps,
   BookmarkFormServerError,
-  BookmarkFormSubmitValues
+  BookmarkFormSubmitValues,
+  BookmarkTitleFetchAction
 } from './index'
 
 const meta = preview.meta({
@@ -39,9 +40,9 @@ export const Default = meta.story({
     submitLabel: '更新',
     pendingLabel: '更新中…',
     onSubmit: fn<(...args: Parameters<BookmarkFormProps['onSubmit']>) => void>(),
-    onFetchTitle: fn(async () => {
+    fetchTitleAction: fn<BookmarkTitleFetchAction>(async () => {
       await new Promise((resolve) => setTimeout(resolve, 1500))
-      return '取得したタイトル'
+      return { status: 'success', title: '取得したタイトル' }
     })
   },
   play: async ({ canvasElement }) => {
@@ -72,11 +73,14 @@ export const RetryClearsTitleFetchError = Default.extend({
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement)
     const fetchButton = canvas.getByRole('button', { name: 'タイトルを取得' })
-    const onFetchTitle = args.onFetchTitle as Mock<(url: string) => Promise<string | null>>
-    onFetchTitle.mockImplementationOnce(async () => null)
-    onFetchTitle.mockImplementationOnce(async () => {
+    const fetchTitleAction = args.fetchTitleAction as Mock<BookmarkTitleFetchAction>
+    fetchTitleAction.mockImplementationOnce(async () => ({
+      status: 'error',
+      message: 'タイトルを取得できませんでした。手入力で続けられます'
+    }))
+    fetchTitleAction.mockImplementationOnce(async () => {
       await new Promise((resolve) => setTimeout(resolve, 1500))
-      return '再び取得したタイトル'
+      return { status: 'success', title: '再び取得したタイトル' }
     })
 
     await userEvent.click(fetchButton)
@@ -97,9 +101,9 @@ export const RetryClearsTitleFetchError = Default.extend({
 
 export const TitleFetchPending = Default.extend({
   args: {
-    onFetchTitle: fn(async (_url: string): Promise<string | null> => {
-      await new Promise<string | null>(() => {})
-      return null
+    fetchTitleAction: fn<BookmarkTitleFetchAction>(async () => {
+      await new Promise(() => {})
+      return { status: 'idle' }
     })
   },
   play: async ({ canvasElement }) => {

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/index.tsx
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/index.tsx
@@ -115,7 +115,6 @@ export function BookmarkForm({
           serverFieldErrors={serverError?.fields}
           busy={busy}
           isFetchingTitle={isFetchingTitle}
-          fetchTitleAction={fetchTitleAction}
           handleFetchTitle={handleFetchTitle}
           onClearServerFieldError={handleClearFieldError}
         />

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/index.tsx
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/index.tsx
@@ -18,7 +18,10 @@ export type {
   BookmarkFormInitialValues,
   BookmarkFormProps,
   BookmarkFormServerError,
-  BookmarkFormSubmitValues
+  BookmarkFormSubmitValues,
+  BookmarkTitleFetchAction,
+  BookmarkTitleFetchPayload,
+  BookmarkTitleFetchState
 } from './types'
 export type { BookmarkFormInput, BookmarkFormOutput } from './schema'
 
@@ -30,7 +33,7 @@ export function BookmarkForm({
   pendingLabel = '更新中…',
   legend = 'ブックマーク編集',
   onSubmit,
-  onFetchTitle
+  fetchTitleAction
 }: BookmarkFormProps) {
   const baseId = useId()
   const ids: BookmarkFormFieldIds & { readonly summary: string } = {
@@ -51,7 +54,7 @@ export function BookmarkForm({
 
   const { titleFetchError, isFetchingTitle, handleFetchTitle } = useBookmarkTitleFetch({
     form,
-    onFetchTitle,
+    fetchTitleAction,
     onClearFieldError
   })
 
@@ -112,7 +115,7 @@ export function BookmarkForm({
           serverFieldErrors={serverError?.fields}
           busy={busy}
           isFetchingTitle={isFetchingTitle}
-          onFetchTitle={onFetchTitle}
+          fetchTitleAction={fetchTitleAction}
           handleFetchTitle={handleFetchTitle}
           onClearServerFieldError={handleClearFieldError}
         />

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/index.tsx
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/index.tsx
@@ -19,9 +19,7 @@ export type {
   BookmarkFormProps,
   BookmarkFormServerError,
   BookmarkFormSubmitValues,
-  BookmarkTitleFetchAction,
-  BookmarkTitleFetchPayload,
-  BookmarkTitleFetchState
+  BookmarkTitleFetchAction
 } from './types'
 export type { BookmarkFormInput, BookmarkFormOutput } from './schema'
 

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/types.ts
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/types.ts
@@ -77,7 +77,7 @@ export type BookmarkFormProps = {
   readonly legend?: string
   readonly onSubmit: (values: BookmarkFormSubmitValues) => void | Promise<void>
   /** タイトル取得 action。useActionState にそのまま渡す。Server Function は注入側が持つ */
-  readonly fetchTitleAction?: BookmarkTitleFetchAction
+  readonly fetchTitleAction: BookmarkTitleFetchAction
 }
 
 export type BookmarkFormStore = FormStore<typeof bookmarkFormSchema>

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/types.ts
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/types.ts
@@ -31,29 +31,18 @@ export type BookmarkFormInitialValues = {
 
 export type BookmarkFormSubmitValues = BookmarkFormOutput
 
-/**
- * タイトル取得 action の payload。useActionState の第2引数として渡す。
- * FormData ではなく、URL を載せた通常のオブジェクト。
- */
+/** タイトル取得 action の payload。useActionState の第2引数に渡すオブジェクト */
 export type BookmarkTitleFetchPayload = {
   readonly url: string
 }
 
-/**
- * タイトル取得 action が返す state。
- * status: 'success' の title は hook 側が Formisch の store へ反映する
- * (action は form store にアクセスできない)。
- */
+/** タイトル取得 action が返す state。success の title は hook 側のラッパーが form へ反映する */
 export type BookmarkTitleFetchState =
   | { readonly status: 'idle' }
   | { readonly status: 'success'; readonly title: string }
   | { readonly status: 'error'; readonly message: string }
 
-/**
- * タイトル取得 action。useActionState の action 型に合わせたシグネチャを持つ。
- * 前回の state と payload ({ url }) を受け取り、次の state を返す。
- * form store には触れない。成功時の form 反映は hook 側のラッパー action が行う。
- */
+/** タイトル取得 action。前回の state と payload から次の state を返す。form 反映は hook 側のラッパーが行う */
 export type BookmarkTitleFetchAction = (
   previousState: BookmarkTitleFetchState,
   payload: BookmarkTitleFetchPayload

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/types.ts
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/types.ts
@@ -42,7 +42,11 @@ export type BookmarkTitleFetchState =
   | { readonly status: 'success'; readonly title: string }
   | { readonly status: 'error'; readonly message: string }
 
-/** タイトル取得 action。前回の state と payload から次の state を返す。form 反映は hook 側のラッパーが行う */
+/**
+ * タイトル取得 action。前回の state と payload から次の state を返す。
+ * 呼び出し時の previousState は 'success' にならない (ラッパーが反映後に idle へ正規化する)。
+ * 成功時の form 反映は hook 側のラッパーが行う。
+ */
 export type BookmarkTitleFetchAction = (
   previousState: BookmarkTitleFetchState,
   payload: BookmarkTitleFetchPayload

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/types.ts
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/types.ts
@@ -31,6 +31,33 @@ export type BookmarkFormInitialValues = {
 
 export type BookmarkFormSubmitValues = BookmarkFormOutput
 
+/**
+ * タイトル取得 action の payload。useActionState の第2引数として渡す。
+ * FormData ではなく、URL を載せた通常のオブジェクト。
+ */
+export type BookmarkTitleFetchPayload = {
+  readonly url: string
+}
+
+/**
+ * タイトル取得 action が返す state。
+ * status: 'success' の title は hook 側が Formisch の store へ反映する
+ * (action は form store にアクセスできない)。
+ */
+export type BookmarkTitleFetchState =
+  | { readonly status: 'idle' }
+  | { readonly status: 'success'; readonly title: string }
+  | { readonly status: 'error'; readonly message: string }
+
+/**
+ * そのまま useActionState に渡せるタイトル取得 action。
+ * 前回の state と payload ({ url }) を受け取り、次の state を返す。
+ */
+export type BookmarkTitleFetchAction = (
+  previousState: BookmarkTitleFetchState,
+  payload: BookmarkTitleFetchPayload
+) => Promise<BookmarkTitleFetchState>
+
 export type BookmarkFormProps = {
   readonly initialValues: BookmarkFormInitialValues
   /**
@@ -49,8 +76,8 @@ export type BookmarkFormProps = {
   readonly pendingLabel?: string
   readonly legend?: string
   readonly onSubmit: (values: BookmarkFormSubmitValues) => void | Promise<void>
-  /** タイトル取得。Server Function は注入側が持つ */
-  readonly onFetchTitle?: (url: string) => Promise<string | null>
+  /** タイトル取得 action。useActionState にそのまま渡す。Server Function は注入側が持つ */
+  readonly fetchTitleAction?: BookmarkTitleFetchAction
 }
 
 export type BookmarkFormStore = FormStore<typeof bookmarkFormSchema>

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/types.ts
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/types.ts
@@ -50,8 +50,9 @@ export type BookmarkTitleFetchState =
   | { readonly status: 'error'; readonly message: string }
 
 /**
- * そのまま useActionState に渡せるタイトル取得 action。
+ * タイトル取得 action。useActionState の action 型に合わせたシグネチャを持つ。
  * 前回の state と payload ({ url }) を受け取り、次の state を返す。
+ * form store には触れない。成功時の form 反映は hook 側のラッパー action が行う。
  */
 export type BookmarkTitleFetchAction = (
   previousState: BookmarkTitleFetchState,
@@ -76,7 +77,7 @@ export type BookmarkFormProps = {
   readonly pendingLabel?: string
   readonly legend?: string
   readonly onSubmit: (values: BookmarkFormSubmitValues) => void | Promise<void>
-  /** タイトル取得 action。useActionState にそのまま渡す。Server Function は注入側が持つ */
+  /** タイトル取得 action。hook 側のラッパーを経て useActionState に渡る。Server Function は注入側が持つ */
   readonly fetchTitleAction: BookmarkTitleFetchAction
 }
 

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/use-bookmark-title-fetch.ts
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/use-bookmark-title-fetch.ts
@@ -10,13 +10,9 @@ import type {
 
 const initialTitleFetchState: BookmarkTitleFetchState = { status: 'idle' }
 
-// 未指定時のフォールバック。未指定時は handleFetchTitle が dispatch しないため
-// 実行されることはない (useActionState の action は undefined にできない)。
-const noopTitleFetchAction: BookmarkTitleFetchAction = async () => ({ status: 'idle' })
-
 type UseBookmarkTitleFetchOptions = {
   readonly form: BookmarkFormStore
-  readonly fetchTitleAction: BookmarkTitleFetchAction | undefined
+  readonly fetchTitleAction: BookmarkTitleFetchAction
   readonly onClearFieldError: ((field: BookmarkFormFieldKey) => void) | undefined
 }
 
@@ -29,7 +25,7 @@ export function useBookmarkTitleFetch({
   // この action は form store にアクセスできないため、空 URL 判定と
   // 成功結果の form store への反映はこの hook 側で行う。
   const [titleFetchState, dispatch, isFetchingTitle] = useActionState(
-    fetchTitleAction ?? noopTitleFetchAction,
+    fetchTitleAction,
     initialTitleFetchState
   )
 
@@ -59,9 +55,6 @@ export function useBookmarkTitleFetch({
     (titleFetchState.status === 'error' && !isFetchingTitle ? titleFetchState.message : null)
 
   function handleFetchTitle() {
-    if (fetchTitleAction === undefined) {
-      return
-    }
     const currentInputUrl = getInput(form, { path: ['url'] }) ?? ''
     if (currentInputUrl.trim() === '') {
       setUrlRequiredError('先にURLを入力してください')

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/use-bookmark-title-fetch.ts
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/use-bookmark-title-fetch.ts
@@ -1,10 +1,11 @@
 import { getInput, setErrors, setInput } from '@formisch/react'
-import { startTransition, useActionState, useEffect, useEffectEvent, useState } from 'react'
+import { startTransition, useActionState, useState } from 'react'
 
 import type {
   BookmarkFormFieldKey,
   BookmarkFormStore,
   BookmarkTitleFetchAction,
+  BookmarkTitleFetchPayload,
   BookmarkTitleFetchState
 } from './types'
 
@@ -21,34 +22,32 @@ export function useBookmarkTitleFetch({
   fetchTitleAction,
   onClearFieldError
 }: UseBookmarkTitleFetchOptions) {
-  // 受け取った fetchTitleAction をそのまま useActionState に渡す。
-  // この action は form store にアクセスできないため、空 URL 判定と
-  // 成功結果の form store への反映はこの hook 側で行う。
+  // 注入された fetchTitleAction は form store にアクセスできないため、この hook 側で
+  // ラップし、success 時の form 反映 (setInput / error clear) を action 内で同期実行する。
+  // 注入 action は純粋なまま、form 反映は BookmarkForm 側が所有する。
+  // このラッパーは毎レンダー新しく生成されるが、useActionState が最新レンダーの action を
+  // 実行するため、閉包 (form / onClearFieldError / fetchTitleAction) は最新になる。
+  const applyFetchedTitleAction = async (
+    previous: BookmarkTitleFetchState,
+    payload: BookmarkTitleFetchPayload
+  ): Promise<BookmarkTitleFetchState> => {
+    const next = await fetchTitleAction(previous, payload)
+    if (next.status === 'success') {
+      setInput(form, { path: ['title'], input: next.title })
+      clearFieldError(form, 'title')
+      onClearFieldError?.('title')
+    }
+    return next
+  }
+
   const [titleFetchState, dispatch, isFetchingTitle] = useActionState(
-    fetchTitleAction,
+    applyFetchedTitleAction,
     initialTitleFetchState
   )
 
   // 空 URL は dispatch 前に弾くため useActionState の state には載せられない。
   // そのような form-local なエラーは hook 側で保持し、表示時に action 由来のエラーより優先する。
   const [urlRequiredError, setUrlRequiredError] = useState<string | null>(null)
-
-  // 成功 state (status: 'success') は action の戻り値としてしか得られないため、
-  // 受け取ってから Formisch の title input へ反映する。
-  // Formisch の field error と server error (onClearFieldError) も同時に clear する。
-  // 依存配列には state の変化だけを載せ、親の再レンダーで title が上書きされないようにする。
-  const applyFetchedTitle = useEffectEvent((title: string) => {
-    setInput(form, { path: ['title'], input: title })
-    clearFieldError(form, 'title')
-    onClearFieldError?.('title')
-  })
-
-  useEffect(() => {
-    if (titleFetchState.status !== 'success') {
-      return
-    }
-    applyFetchedTitle(titleFetchState.title)
-  }, [titleFetchState])
 
   const titleFetchError =
     urlRequiredError ??

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/use-bookmark-title-fetch.ts
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/use-bookmark-title-fetch.ts
@@ -1,67 +1,73 @@
 import { getInput, setErrors, setInput } from '@formisch/react'
-import { startTransition, useActionState } from 'react'
+import { startTransition, useActionState, useEffect, useEffectEvent, useState } from 'react'
 
-import type { BookmarkFormFieldKey, BookmarkFormStore } from './types'
+import type {
+  BookmarkFormFieldKey,
+  BookmarkFormStore,
+  BookmarkTitleFetchAction,
+  BookmarkTitleFetchState
+} from './types'
 
-type TitleFetchState =
-  | { readonly status: 'idle' }
-  | { readonly status: 'error'; readonly message: string }
+const initialTitleFetchState: BookmarkTitleFetchState = { status: 'idle' }
 
-type TitleFetchAction = {
-  readonly url: string
-}
+// 未指定時のフォールバック。未指定時は handleFetchTitle が dispatch しないため
+// 実行されることはない (useActionState の action は undefined にできない)。
+const noopTitleFetchAction: BookmarkTitleFetchAction = async () => ({ status: 'idle' })
 
 type UseBookmarkTitleFetchOptions = {
   readonly form: BookmarkFormStore
-  readonly onFetchTitle: ((url: string) => Promise<string | null>) | undefined
+  readonly fetchTitleAction: BookmarkTitleFetchAction | undefined
   readonly onClearFieldError: ((field: BookmarkFormFieldKey) => void) | undefined
 }
 
 export function useBookmarkTitleFetch({
   form,
-  onFetchTitle,
+  fetchTitleAction,
   onClearFieldError
 }: UseBookmarkTitleFetchOptions) {
+  // 受け取った fetchTitleAction をそのまま useActionState に渡す。
+  // この action は form store にアクセスできないため、空 URL 判定と
+  // 成功結果の form store への反映はこの hook 側で行う。
   const [titleFetchState, dispatch, isFetchingTitle] = useActionState(
-    async (_previous: TitleFetchState, action: TitleFetchAction): Promise<TitleFetchState> => {
-      if (action.url.trim() === '') {
-        return { status: 'error', message: '先にURLを入力してください' }
-      }
-      if (onFetchTitle === undefined) {
-        return { status: 'idle' }
-      }
-
-      try {
-        const fetchedTitle = await onFetchTitle(action.url)
-        if (fetchedTitle === null) {
-          return {
-            status: 'error',
-            message: 'タイトルを取得できませんでした。手入力で続けられます'
-          }
-        }
-
-        setInput(form, { path: ['title'], input: fetchedTitle })
-        clearFieldError(form, 'title')
-        onClearFieldError?.('title')
-        return { status: 'idle' }
-      } catch (error: unknown) {
-        return {
-          status: 'error',
-          message:
-            error instanceof Error
-              ? error.message
-              : 'タイトルを取得できませんでした。手入力で続けられます'
-        }
-      }
-    },
-    { status: 'idle' }
+    fetchTitleAction ?? noopTitleFetchAction,
+    initialTitleFetchState
   )
 
+  // 空 URL は dispatch 前に弾くため useActionState の state には載せられない。
+  // そのような form-local なエラーは hook 側で保持し、表示時に action 由来のエラーより優先する。
+  const [urlRequiredError, setUrlRequiredError] = useState<string | null>(null)
+
+  // 成功 state (status: 'success') は action の戻り値としてしか得られないため、
+  // 受け取ってから Formisch の title input へ反映する。
+  // Formisch の field error と server error (onClearFieldError) も同時に clear する。
+  // 依存配列には state の変化だけを載せ、親の再レンダーで title が上書きされないようにする。
+  const applyFetchedTitle = useEffectEvent((title: string) => {
+    setInput(form, { path: ['title'], input: title })
+    clearFieldError(form, 'title')
+    onClearFieldError?.('title')
+  })
+
+  useEffect(() => {
+    if (titleFetchState.status !== 'success') {
+      return
+    }
+    applyFetchedTitle(titleFetchState.title)
+  }, [titleFetchState])
+
   const titleFetchError =
-    !isFetchingTitle && titleFetchState.status === 'error' ? titleFetchState.message : null
+    urlRequiredError ??
+    (titleFetchState.status === 'error' && !isFetchingTitle ? titleFetchState.message : null)
 
   function handleFetchTitle() {
+    if (fetchTitleAction === undefined) {
+      return
+    }
     const currentInputUrl = getInput(form, { path: ['url'] }) ?? ''
+    if (currentInputUrl.trim() === '') {
+      setUrlRequiredError('先にURLを入力してください')
+      return
+    }
+    setUrlRequiredError(null)
     startTransition(() => {
       dispatch({ url: currentInputUrl })
     })

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/use-bookmark-title-fetch.ts
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/use-bookmark-title-fetch.ts
@@ -1,5 +1,5 @@
 import { getInput, setErrors, setInput } from '@formisch/react'
-import { startTransition, useActionState, useState } from 'react'
+import { startTransition, useActionState, useRef, useState } from 'react'
 
 import type {
   BookmarkFormFieldKey,
@@ -25,21 +25,30 @@ export function useBookmarkTitleFetch({
   fetchTitleAction,
   onClearFieldError
 }: UseBookmarkTitleFetchOptions) {
+  // 連打ガード用の in-flight ref。isPending はコミット前の同じレンダーでは false のままなので、
+  // 同期チェックできる ref で race window を塞ぐ (閉包の isFetchingTitle では塞げない)。
+  const inFlightRef = useRef(false)
+
   // 成功時の form 反映 (setInput / error clear) はこのラッパーが行う (fetchTitleAction は form store に触れないため)。
   // ラッパーは毎レンダー再生成されるが、useActionState は最新レンダーの action を実行する。
   const applyFetchedTitleAction = async (
     previous: BookmarkTitleFetchState,
     payload: BookmarkTitleFetchPayload
   ): Promise<BookmarkTitleFetchState> => {
-    const next = await fetchTitleAction(previous, payload)
-    if (next.status === 'success') {
-      setInput(form, { path: ['title'], input: next.title })
-      clearFieldError(form, 'title')
-      onClearFieldError?.('title')
-      // 反映後に success を state に残す必要はないため idle へ正規化する。
-      return { status: 'idle' }
+    try {
+      const next = await fetchTitleAction(previous, payload)
+      if (next.status === 'success') {
+        setInput(form, { path: ['title'], input: next.title })
+        clearFieldError(form, 'title')
+        onClearFieldError?.('title')
+        // 反映後に success を state に残す必要はないため idle へ正規化する。
+        return { status: 'idle' }
+      }
+      return next
+    } finally {
+      // 例外 (reject / throw) でも必ず in-flight を解除する。
+      inFlightRef.current = false
     }
-    return next
   }
 
   const [titleFetchState, dispatch, isFetchingTitle] = useActionState(
@@ -61,12 +70,17 @@ export function useBookmarkTitleFetch({
     (titleFetchState.status === 'error' && !isFetchingTitle ? titleFetchState.message : null)
 
   function handleFetchTitle() {
+    // 連打 (disabled がコミットされる前の同じレンダーの閉包) でも 2 回目の dispatch を防ぐ。
+    if (inFlightRef.current) {
+      return
+    }
     const currentInputUrl = getInput(form, { path: ['url'] }) ?? ''
     if (currentInputUrl.trim() === '') {
       setUrlEmptyErrorShown(true)
       return
     }
     setUrlEmptyErrorShown(false)
+    inFlightRef.current = true
     startTransition(() => {
       dispatch({ url: currentInputUrl })
     })

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/use-bookmark-title-fetch.ts
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/use-bookmark-title-fetch.ts
@@ -25,11 +25,8 @@ export function useBookmarkTitleFetch({
   fetchTitleAction,
   onClearFieldError
 }: UseBookmarkTitleFetchOptions) {
-  // 注入された fetchTitleAction は form store にアクセスできないため、この hook 側で
-  // ラップし、success 時の form 反映 (setInput / error clear) を action 内で同期実行する。
-  // 注入 action は純粋なまま、form 反映は BookmarkForm 側が所有する。
-  // このラッパーは毎レンダー新しく生成されるが、useActionState が最新レンダーの action を
-  // 実行するため、閉包 (form / onClearFieldError / fetchTitleAction) は最新になる。
+  // 成功時の form 反映 (setInput / error clear) はこのラッパーが行う (fetchTitleAction は form store に触れないため)。
+  // ラッパーは毎レンダー再生成されるが、useActionState は最新レンダーの action を実行する。
   const applyFetchedTitleAction = async (
     previous: BookmarkTitleFetchState,
     payload: BookmarkTitleFetchPayload
@@ -39,6 +36,8 @@ export function useBookmarkTitleFetch({
       setInput(form, { path: ['title'], input: next.title })
       clearFieldError(form, 'title')
       onClearFieldError?.('title')
+      // 反映後に success を state に残す必要はないため idle へ正規化する。
+      return { status: 'idle' }
     }
     return next
   }
@@ -48,11 +47,8 @@ export function useBookmarkTitleFetch({
     initialTitleFetchState
   )
 
-  // 空 URL は dispatch 前に弾くため useActionState の state には載せられない。
-  // 「表示するかどうか」だけをフラグで持ち、「なんと表示するか」は表示時に導出する。
-  // 文言を state に持たないため、URL の入力変更だけでエラーが自動で消える
-  // (フラグ && 現在入力が空、の導出表示の帰結)。
-  // 一度フラグが立ったあとに再び空へ戻すとクリックなしで再表示されるが、仕様として許容する。
+  // 空 URL は dispatch 前に弾くため、表示するかどうかだけをフラグで持ち、
+  // 文言は表示時に導出する (フラグ && 現在入力が空)。
   const [urlEmptyErrorShown, setUrlEmptyErrorShown] = useState(false)
 
   const urlEmptyError =

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/use-bookmark-title-fetch.ts
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/use-bookmark-title-fetch.ts
@@ -11,6 +11,9 @@ import type {
 
 const initialTitleFetchState: BookmarkTitleFetchState = { status: 'idle' }
 
+// 空 URL の表示文言。文言は state に保存せず、表示時にこの定数から導出する。
+const urlRequiredMessage = '先にURLを入力してください'
+
 type UseBookmarkTitleFetchOptions = {
   readonly form: BookmarkFormStore
   readonly fetchTitleAction: BookmarkTitleFetchAction
@@ -46,20 +49,28 @@ export function useBookmarkTitleFetch({
   )
 
   // 空 URL は dispatch 前に弾くため useActionState の state には載せられない。
-  // そのような form-local なエラーは hook 側で保持し、表示時に action 由来のエラーより優先する。
-  const [urlRequiredError, setUrlRequiredError] = useState<string | null>(null)
+  // 「表示するかどうか」だけをフラグで持ち、「なんと表示するか」は表示時に導出する。
+  // 文言を state に持たないため、URL の入力変更だけでエラーが自動で消える
+  // (フラグ && 現在入力が空、の導出表示の帰結)。
+  // 一度フラグが立ったあとに再び空へ戻すとクリックなしで再表示されるが、仕様として許容する。
+  const [urlEmptyErrorShown, setUrlEmptyErrorShown] = useState(false)
+
+  const urlEmptyError =
+    urlEmptyErrorShown && (getInput(form, { path: ['url'] }) ?? '').trim() === ''
+      ? urlRequiredMessage
+      : null
 
   const titleFetchError =
-    urlRequiredError ??
+    urlEmptyError ??
     (titleFetchState.status === 'error' && !isFetchingTitle ? titleFetchState.message : null)
 
   function handleFetchTitle() {
     const currentInputUrl = getInput(form, { path: ['url'] }) ?? ''
     if (currentInputUrl.trim() === '') {
-      setUrlRequiredError('先にURLを入力してください')
+      setUrlEmptyErrorShown(true)
       return
     }
-    setUrlRequiredError(null)
+    setUrlEmptyErrorShown(false)
     startTransition(() => {
       dispatch({ url: currentInputUrl })
     })

--- a/src/features/bookmarks/components/bookmark-editor/index.stories.tsx
+++ b/src/features/bookmarks/components/bookmark-editor/index.stories.tsx
@@ -15,6 +15,7 @@ import {
   bookmarkUrlSchema
 } from '../../domain/bookmark-values'
 import { BookmarkEditor } from './index'
+import type { BookmarkTitleFetchAction } from './index'
 
 const bookmarkId = v.parse(bookmarkIdSchema, uuidv7())
 
@@ -46,7 +47,10 @@ export const Default = meta.story({
     initialData,
     onUpdateBookmark: fn<ExecuteUpdateBookmark>(async () => ok({ bookmarkId })),
     onCompleted: fn(async () => undefined),
-    onFetchTitle: fn(async () => '取得したタイトル')
+    fetchTitleAction: fn<BookmarkTitleFetchAction>(async () => ({
+      status: 'success',
+      title: '取得したタイトル'
+    }))
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)

--- a/src/features/bookmarks/components/bookmark-editor/index.tsx
+++ b/src/features/bookmarks/components/bookmark-editor/index.tsx
@@ -24,7 +24,7 @@ export type BookmarkEditorProps = {
   readonly initialData: BookmarkEditorData
   readonly onUpdateBookmark: ExecuteUpdateBookmark
   readonly onCompleted: (bookmarkId: BookmarkId) => Promise<void>
-  readonly fetchTitleAction?: BookmarkTitleFetchAction
+  readonly fetchTitleAction: BookmarkTitleFetchAction
 }
 
 /**
@@ -112,7 +112,7 @@ export function BookmarkEditor({
       submitLabel='更新'
       pendingLabel='更新中…'
       onSubmit={handleSubmit}
-      {...(fetchTitleAction != null ? { fetchTitleAction } : {})}
+      fetchTitleAction={fetchTitleAction}
     />
   )
 }

--- a/src/features/bookmarks/components/bookmark-editor/index.tsx
+++ b/src/features/bookmarks/components/bookmark-editor/index.tsx
@@ -14,11 +14,7 @@ import type {
 } from './bookmark-form'
 
 export type { ExecuteUpdateBookmark }
-export type {
-  BookmarkTitleFetchAction,
-  BookmarkTitleFetchPayload,
-  BookmarkTitleFetchState
-} from './bookmark-form'
+export type { BookmarkTitleFetchAction } from './bookmark-form'
 
 export type BookmarkEditorProps = {
   readonly initialData: BookmarkEditorData

--- a/src/features/bookmarks/components/bookmark-editor/index.tsx
+++ b/src/features/bookmarks/components/bookmark-editor/index.tsx
@@ -9,16 +9,22 @@ import { BookmarkForm } from './bookmark-form'
 import type {
   BookmarkEditorError,
   BookmarkFormFieldKey,
-  BookmarkFormSubmitValues
+  BookmarkFormSubmitValues,
+  BookmarkTitleFetchAction
 } from './bookmark-form'
 
 export type { ExecuteUpdateBookmark }
+export type {
+  BookmarkTitleFetchAction,
+  BookmarkTitleFetchPayload,
+  BookmarkTitleFetchState
+} from './bookmark-form'
 
 export type BookmarkEditorProps = {
   readonly initialData: BookmarkEditorData
   readonly onUpdateBookmark: ExecuteUpdateBookmark
   readonly onCompleted: (bookmarkId: BookmarkId) => Promise<void>
-  readonly onFetchTitle?: (url: string) => Promise<string | null>
+  readonly fetchTitleAction?: BookmarkTitleFetchAction
 }
 
 /**
@@ -30,7 +36,7 @@ export function BookmarkEditor({
   initialData,
   onUpdateBookmark,
   onCompleted,
-  onFetchTitle
+  fetchTitleAction
 }: BookmarkEditorProps) {
   // 更新結果の server error は BookmarkEditor が唯一の所有者になる。
   // BookmarkForm へは表示用に serverError を渡し、Formisch store へはコピーしない。
@@ -106,7 +112,7 @@ export function BookmarkEditor({
       submitLabel='更新'
       pendingLabel='更新中…'
       onSubmit={handleSubmit}
-      {...(onFetchTitle != null ? { onFetchTitle } : {})}
+      {...(fetchTitleAction != null ? { fetchTitleAction } : {})}
     />
   )
 }

--- a/src/routes/_protected/bookmarks/$id/edit.tsx
+++ b/src/routes/_protected/bookmarks/$id/edit.tsx
@@ -22,6 +22,13 @@ const bookmarkEditSearchSchema = v.object({
 })
 
 /**
+ * タイトル取得失敗時のフォールバック文言。
+ * fetchBookmarkTitle の null と非 Error の throw はこれを表示し、
+ * Error の throw は error.message をそのまま表示する。
+ */
+const bookmarkTitleFetchFailedMessage = 'タイトルを取得できませんでした。手入力で続けられます'
+
+/**
  * タイトル取得 action。BookmarkForm の useActionState にそのまま渡される。
  * fetchBookmarkTitle の null / throw を表示用メッセージへ変換して返す。
  */
@@ -31,17 +38,14 @@ const fetchTitleAction: BookmarkTitleFetchAction = async (_previousState, { url 
     if (fetchedTitle === null) {
       return {
         status: 'error',
-        message: 'タイトルを取得できませんでした。手入力で続けられます'
+        message: bookmarkTitleFetchFailedMessage
       }
     }
     return { status: 'success', title: fetchedTitle }
   } catch (error: unknown) {
     return {
       status: 'error',
-      message:
-        error instanceof Error
-          ? error.message
-          : 'タイトルを取得できませんでした。手入力で続けられます'
+      message: error instanceof Error ? error.message : bookmarkTitleFetchFailedMessage
     }
   }
 }

--- a/src/routes/_protected/bookmarks/$id/edit.tsx
+++ b/src/routes/_protected/bookmarks/$id/edit.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, PackageOpen } from 'lucide-react'
 import * as v from 'valibot'
 
 import { BookmarkEditor } from '../../../../features/bookmarks/components/bookmark-editor'
+import type { BookmarkTitleFetchAction } from '../../../../features/bookmarks/components/bookmark-editor'
 import { fetchBookmarkTitle } from '../../../../features/bookmarks/functions/fetch-bookmark-title'
 import { loadBookmarkForEdit } from '../../../../features/bookmarks/functions/load-bookmark-for-edit'
 import { updateBookmark } from '../../../../features/bookmarks/functions/update-bookmark'
@@ -19,6 +20,31 @@ import {
 const bookmarkEditSearchSchema = v.object({
   tags: v.optional(v.array(v.string()))
 })
+
+/**
+ * タイトル取得 action。BookmarkForm の useActionState にそのまま渡される。
+ * fetchBookmarkTitle の null / throw を表示用メッセージへ変換して返す。
+ */
+const fetchTitleAction: BookmarkTitleFetchAction = async (_previousState, { url }) => {
+  try {
+    const fetchedTitle = await fetchBookmarkTitle({ data: { url } })
+    if (fetchedTitle === null) {
+      return {
+        status: 'error',
+        message: 'タイトルを取得できませんでした。手入力で続けられます'
+      }
+    }
+    return { status: 'success', title: fetchedTitle }
+  } catch (error: unknown) {
+    return {
+      status: 'error',
+      message:
+        error instanceof Error
+          ? error.message
+          : 'タイトルを取得できませんでした。手入力で続けられます'
+    }
+  }
+}
 
 /**
  * RouteComponent は編集画面の Screen 境界であり、Storybook の Route Story 起点でもある。
@@ -122,13 +148,7 @@ function RouteComponent() {
             return err({ code: 'unexpected-error' })
           }
         }}
-        onFetchTitle={async (url) => {
-          try {
-            return await fetchBookmarkTitle({ data: { url } })
-          } catch {
-            return null
-          }
-        }}
+        fetchTitleAction={fetchTitleAction}
         onCompleted={async (bookmarkId) => {
           await navigate({
             to: '/bookmarks/$id',

--- a/src/routes/_protected/bookmarks/$id/edit.tsx
+++ b/src/routes/_protected/bookmarks/$id/edit.tsx
@@ -21,16 +21,12 @@ const bookmarkEditSearchSchema = v.object({
   tags: v.optional(v.array(v.string()))
 })
 
-/**
- * タイトル取得失敗時のフォールバック文言。
- * fetchBookmarkTitle の null と非 Error の throw はこれを表示し、
- * Error の throw は error.message をそのまま表示する。
- */
+// タイトル取得失敗時のフォールバック文言 (null / 非 Error の throw で表示)
 const bookmarkTitleFetchFailedMessage = 'タイトルを取得できませんでした。手入力で続けられます'
 
 /**
- * タイトル取得 action。BookmarkForm 側のラッパーを経て useActionState に渡る。
- * fetchBookmarkTitle の null / throw を表示用メッセージへ変換して返す。
+ * タイトル取得 action。BookmarkForm 側のラッパーを経て useActionState に渡り、
+ * fetchBookmarkTitle の null / throw を表示用メッセージへ変換する。
  */
 const fetchTitleAction: BookmarkTitleFetchAction = async (_previousState, { url }) => {
   try {

--- a/src/routes/_protected/bookmarks/$id/edit.tsx
+++ b/src/routes/_protected/bookmarks/$id/edit.tsx
@@ -29,7 +29,7 @@ const bookmarkEditSearchSchema = v.object({
 const bookmarkTitleFetchFailedMessage = 'タイトルを取得できませんでした。手入力で続けられます'
 
 /**
- * タイトル取得 action。BookmarkForm の useActionState にそのまま渡される。
+ * タイトル取得 action。BookmarkForm 側のラッパーを経て useActionState に渡る。
  * fetchBookmarkTitle の null / throw を表示用メッセージへ変換して返す。
  */
 const fetchTitleAction: BookmarkTitleFetchAction = async (_previousState, { url }) => {

--- a/src/routes/_protected/bookmarks/$id/edit.tsx
+++ b/src/routes/_protected/bookmarks/$id/edit.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { ArrowLeft, PackageOpen } from 'lucide-react'
+import { ErrorBoundary } from 'react-error-boundary'
 import * as v from 'valibot'
 
 import { BookmarkEditor } from '../../../../features/bookmarks/components/bookmark-editor'
@@ -8,6 +9,7 @@ import { fetchBookmarkTitle } from '../../../../features/bookmarks/functions/fet
 import { loadBookmarkForEdit } from '../../../../features/bookmarks/functions/load-bookmark-for-edit'
 import { updateBookmark } from '../../../../features/bookmarks/functions/update-bookmark'
 import { buildListBackSearch } from '../../../../features/navigation/lib/bookmark-search-builders'
+import { createErrorFallback } from '../../../../shared/components/error-fallback'
 import { StyledLink } from '../../../../shared/components/styled-link'
 import { err } from '../../../../shared/domain/result'
 import {
@@ -45,6 +47,9 @@ const fetchTitleAction: BookmarkTitleFetchAction = async (_previousState, { url 
     }
   }
 }
+
+// 想定外エラー (action の reject など) の最終防衛線。想定内エラーは action の state 経由で表示される。
+const EditError = createErrorFallback('編集画面の表示に失敗しました')
 
 /**
  * RouteComponent は編集画面の Screen 境界であり、Storybook の Route Story 起点でもある。
@@ -130,34 +135,36 @@ function RouteComponent() {
       <h1 className={workbenchTitle}>ブックマークを並べ替える</h1>
       <p className={workbenchLead}>内容を直し、主ボタンで保存します。</p>
 
-      <BookmarkEditor
-        key={initialData.bookmarkId}
-        initialData={initialData}
-        onUpdateBookmark={async (command) => {
-          try {
-            return await updateBookmark({
-              data: {
-                id: command.bookmarkId,
-                url: command.url,
-                title: command.title,
-                note: command.note,
-                tags: [...command.tagIds]
-              }
+      <ErrorBoundary FallbackComponent={EditError}>
+        <BookmarkEditor
+          key={initialData.bookmarkId}
+          initialData={initialData}
+          onUpdateBookmark={async (command) => {
+            try {
+              return await updateBookmark({
+                data: {
+                  id: command.bookmarkId,
+                  url: command.url,
+                  title: command.title,
+                  note: command.note,
+                  tags: [...command.tagIds]
+                }
+              })
+            } catch {
+              return err({ code: 'unexpected-error' })
+            }
+          }}
+          fetchTitleAction={fetchTitleAction}
+          onCompleted={async (bookmarkId) => {
+            await navigate({
+              to: '/bookmarks/$id',
+              params: { id: bookmarkId },
+              search: detailSearch,
+              state: { bookmarkUpdated: true }
             })
-          } catch {
-            return err({ code: 'unexpected-error' })
-          }
-        }}
-        fetchTitleAction={fetchTitleAction}
-        onCompleted={async (bookmarkId) => {
-          await navigate({
-            to: '/bookmarks/$id',
-            params: { id: bookmarkId },
-            search: detailSearch,
-            state: { bookmarkUpdated: true }
-          })
-        }}
-      />
+          }}
+        />
+      </ErrorBoundary>
     </section>
   )
 }


### PR DESCRIPTION
## Summary

- `onFetchTitle`（素のコールバック）を `fetchTitleAction`（useActionState の action 型 `(previousState, { url }) => Promise<state>`）に変更。hook が prop をそのまま `useActionState` に渡し、成功時の form 反映は hook 側のラッパー action が所有する
- `fetchTitleAction` を必須 prop 化し、省略時用のデッドコード（noop フォールバック / undefined guard / ボタン表示分岐 / conditional spread）を削除
- 空 URL エラーを「表示フラグ（state）」と「メッセージ（表示時導出）」に分離し、URL 入力変更でエラーが自動で消えるように改善

## Test plan

- [x] `pnpm run format:check`
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] `pnpm run build`

さらに Storybook + Playwright の実ブラウザ検証を実施済み（タイトル取得の成功 / 失敗 / リトライ / pending の各フロー、空 URL エラーと入力変更での自動クリア、デスクトップ・モバイル幅）。

## UI

- [x] 一覧 / 登録 / 編集など触ったフローを手動確認した
- [x] デスクトップとモバイル幅で主要操作できる
- [x] エラーが利用者に見える
