### PR TITLE
[Security] Bound password input before authentication hashing

### DIFF
--- a/docs/superpowers/plans/2026-08-07-password-input-boundary.md
+++ b/docs/superpowers/plans/2026-08-07-password-input-boundary.md
@@ -4,7 +4,7 @@
 
 **Goal:** Reject passwords longer than 128 characters before Better Auth sign-in hashing while keeping the client and server password policies aligned.
 
-**Architecture:** Add a side-effect-free shared password policy constant. Use it in the Valibot client schema and Better Auth configuration, and add a narrow request guard at the existing auth catch-all route because the current Better Auth sign-in implementation does not apply `maxPasswordLength` before hash/verify. The guard inspects only `POST /api/auth/sign-in/email`, reads a cloned JSON body, and delegates all other requests unchanged.
+**Architecture:** Add side-effect-free shared password policy constants (`PASSWORD_MAX_LENGTH = 128`, `SIGN_IN_BODY_MAX_BYTES = 4096`). Use them in the Valibot client schema, Better Auth configuration, and a narrow request guard at the existing auth catch-all route because the current Better Auth sign-in implementation does not apply `maxPasswordLength` before hash/verify. The guard applies only to an exact `POST /api/auth/sign-in/email` path, accepts only `application/json`, reads the cloned body with a 4096-byte cap (Content-Length pre-check plus streaming cancel), and delegates all other requests unchanged. This closes the `application/x-www-form-urlencoded` bypass and bounds the guard's own memory/CPU use (hostile-review hardening, see commit history).
 
 **Tech Stack:** TanStack Start, Better Auth, Valibot, Cloudflare Workers, Vitest.
 
@@ -12,7 +12,7 @@
 
 ## File Map
 
-- Create: `src/features/auth/domain/password-policy.ts` — shared maximum password length.
+- Create: `src/features/auth/domain/password-policy.ts` — shared maximum password length and sign-in body byte cap.
 - Modify: `src/features/auth/lib/sign-in-schema.ts` — enforce the shared maximum in client validation.
 - Create: `src/features/auth/lib/sign-in-schema.test.ts` — client schema boundary tests.
 - Create: `src/features/auth/functions/guard-sign-in-request.server.ts` — server-side pre-handler guard.
@@ -130,12 +130,12 @@ git commit -m "fix(auth): bound client password input"
 
 - [ ] **Step 1: Write failing tests for server rejection and delegation**
 
-Create `src/features/auth/functions/guard-sign-in-request.server.test.ts`:
+Create `src/features/auth/functions/guard-sign-in-request.server.test.ts` covering rejection, delegation, content-type gating, byte-cap bounding, and body-readability (16 tests; the suite below reflects the hardened guard):
 
 ```ts
 import { expect, test, vi } from 'vitest'
 
-import { PASSWORD_MAX_LENGTH } from '../domain/password-policy'
+import { PASSWORD_MAX_LENGTH, SIGN_IN_BODY_MAX_BYTES } from '../domain/password-policy'
 import { guardSignInRequest } from './guard-sign-in-request.server'
 
 function makeRequest(path: string, password: string): Request {
@@ -143,6 +143,35 @@ function makeRequest(path: string, password: string): Request {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ email: 'user@example.com', password })
+  })
+}
+
+function makeFormRequest(path: string, password: string): Request {
+  return new Request(`https://pantry.example${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ email: 'user@example.com', password }).toString()
+  })
+}
+
+function makeStreamingRequest(body: string): Request {
+  const encoder = new TextEncoder()
+  const chunks: string[] = []
+  for (let offset = 0; offset < body.length; offset += 256) {
+    chunks.push(body.slice(offset, offset + 256))
+  }
+
+  return new Request('https://pantry.example/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: new ReadableStream({
+      async start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(encoder.encode(chunk))
+        }
+        controller.close()
+      }
+    })
   })
 }
 
@@ -183,9 +212,208 @@ test('does not apply the guard to another auth endpoint', async () => {
   expect(response).toBe(handled)
   expect(next).toHaveBeenCalledOnce()
 })
+
+test('rejects an over-limit form-urlencoded sign-in password', async () => {
+  const next = vi.fn(() => new Response('handled'))
+
+  const response = await guardSignInRequest(
+    makeFormRequest('/api/auth/sign-in/email', 'a'.repeat(PASSWORD_MAX_LENGTH + 1)),
+    next
+  )
+
+  expect(response.status).toBe(415)
+  expect(next).not.toHaveBeenCalled()
+})
+
+test('rejects a non-JSON content type', async () => {
+  const next = vi.fn(() => new Response('handled'))
+
+  const request = new Request('https://pantry.example/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: { 'content-type': 'text/plain' },
+    body: 'password=' + 'a'.repeat(PASSWORD_MAX_LENGTH + 1)
+  })
+
+  const response = await guardSignInRequest(request, next)
+
+  expect(response.status).toBe(415)
+  expect(next).not.toHaveBeenCalled()
+})
+
+test('accepts application/json with a charset parameter', async () => {
+  const handled = new Response('handled')
+  const next = vi.fn(() => handled)
+
+  const request = new Request('https://pantry.example/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+    body: JSON.stringify({ email: 'user@example.com', password: 'a'.repeat(PASSWORD_MAX_LENGTH) })
+  })
+
+  const response = await guardSignInRequest(request, next)
+
+  expect(response).toBe(handled)
+  expect(next).toHaveBeenCalledOnce()
+})
+
+test('rejects a body with an over-limit content-length', async () => {
+  const next = vi.fn(() => new Response('handled'))
+
+  const request = new Request('https://pantry.example/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body:
+      JSON.stringify({ email: 'user@example.com', password: 'a'.repeat(PASSWORD_MAX_LENGTH) }) +
+      ' '.repeat(SIGN_IN_BODY_MAX_BYTES)
+  })
+
+  const response = await guardSignInRequest(request, next)
+
+  expect(response.status).toBe(413)
+  expect(next).not.toHaveBeenCalled()
+})
+
+test('accepts a body at the exact byte limit', async () => {
+  const handled = new Response('handled')
+  const next = vi.fn(() => handled)
+
+  const password = 'a'.repeat(PASSWORD_MAX_LENGTH)
+  const emailPadding = SIGN_IN_BODY_MAX_BYTES - JSON.stringify({ email: '', password }).length
+  const body = JSON.stringify({ email: 'a'.repeat(emailPadding), password })
+  expect(body.length).toBe(SIGN_IN_BODY_MAX_BYTES)
+
+  const request = new Request('https://pantry.example/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body
+  })
+
+  const response = await guardSignInRequest(request, next)
+
+  expect(response).toBe(handled)
+  expect(next).toHaveBeenCalledOnce()
+})
+
+test('rejects an over-limit streaming body without a content-length', async () => {
+  const next = vi.fn(() => new Response('handled'))
+
+  const request = makeStreamingRequest(
+    JSON.stringify({
+      email: 'user@example.com',
+      password: 'a'.repeat(SIGN_IN_BODY_MAX_BYTES + 1)
+    })
+  )
+  expect(request.headers.get('content-length')).toBeNull()
+
+  const response = await guardSignInRequest(request, next)
+
+  expect(response.status).toBe(413)
+  expect(next).not.toHaveBeenCalled()
+})
+
+test('delegates malformed JSON', async () => {
+  const handled = new Response('handled')
+  const next = vi.fn(() => handled)
+
+  const request = new Request('https://pantry.example/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: '{"email":'
+  })
+
+  const response = await guardSignInRequest(request, next)
+
+  expect(response).toBe(handled)
+  expect(next).toHaveBeenCalledOnce()
+})
+
+test('delegates a body without a password field', async () => {
+  const handled = new Response('handled')
+  const next = vi.fn(() => handled)
+
+  const request = new Request('https://pantry.example/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email: 'user@example.com' })
+  })
+
+  const response = await guardSignInRequest(request, next)
+
+  expect(response).toBe(handled)
+  expect(next).toHaveBeenCalledOnce()
+})
+
+test('delegates a body with a non-string password', async () => {
+  const handled = new Response('handled')
+  const next = vi.fn(() => handled)
+
+  const request = new Request('https://pantry.example/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email: 'user@example.com', password: 123 })
+  })
+
+  const response = await guardSignInRequest(request, next)
+
+  expect(response).toBe(handled)
+  expect(next).toHaveBeenCalledOnce()
+})
+
+test('leaves the original request body readable for the delegated handler', async () => {
+  const request = makeRequest('/api/auth/sign-in/email', 'a'.repeat(PASSWORD_MAX_LENGTH))
+  const next = vi.fn(async (req: Request) => {
+    const body = (await req.json()) as { password: string }
+    return new Response(body.password.length.toString())
+  })
+
+  const response = await guardSignInRequest(request, () => next(request))
+
+  expect(response.status).toBe(200)
+  expect(await response.text()).toBe(String(PASSWORD_MAX_LENGTH))
+})
+
+test('applies the length boundary in UTF-16 code units', async () => {
+  const emoji = '😀'
+  const handled = new Response('handled')
+  const next = vi.fn(() => handled)
+
+  const response = await guardSignInRequest(
+    makeRequest('/api/auth/sign-in/email', emoji.repeat(64)),
+    next
+  )
+
+  expect(response).toBe(handled)
+  expect(next).toHaveBeenCalledOnce()
+})
+
+test('rejects a password over 128 UTF-16 code units', async () => {
+  const emoji = '😀'
+  const next = vi.fn(() => new Response('handled'))
+
+  const response = await guardSignInRequest(
+    makeRequest('/api/auth/sign-in/email', emoji.repeat(65)),
+    next
+  )
+
+  expect(response.status).toBe(400)
+  expect(next).not.toHaveBeenCalled()
+})
+
+test('does not apply the guard to a sign-in path with a trailing slash', async () => {
+  const handled = new Response('handled')
+  const next = vi.fn(() => handled)
+
+  const response = await guardSignInRequest(
+    makeRequest('/api/auth/sign-in/email/', 'a'.repeat(PASSWORD_MAX_LENGTH + 1)),
+    next
+  )
+
+  expect(response).toBe(handled)
+  expect(next).toHaveBeenCalledOnce()
+})
 ```
 
-The first test is the hash/verify boundary test: the fake `next` represents `getAuth().handler(request)`, so it must not be called for an oversized password.
+The first test is the hash/verify boundary test: the fake `next` represents `getAuth().handler(request)`, so it must not be called for an oversized password. The form-urlencoded, non-JSON, and byte-cap tests are the hostile-review regression tests.
 
 - [ ] **Step 2: Run the guard tests to verify they fail before the guard exists**
 
@@ -195,52 +423,126 @@ Run:
 pnpm vitest run src/features/auth/functions/guard-sign-in-request.server.test.ts
 ```
 
-Expected: the test file fails because `guard-sign-in-request.server.ts` and `guardSignInRequest` do not exist yet.
+Expected: the test file fails because `guard-sign-in-request.server.ts` and `guardSignInRequest` do not exist yet (initially also because `SIGN_IN_BODY_MAX_BYTES` is missing from the policy module). After adding the constants, the remaining failures must be behavioral only: form-urlencoded/non-JSON delegation (415 expected), and unbounded body acceptance (413 expected).
 
 - [ ] **Step 3: Implement the request guard**
 
 Create `src/features/auth/functions/guard-sign-in-request.server.ts`:
 
 ```ts
-import { PASSWORD_MAX_LENGTH } from '../domain/password-policy'
+import { PASSWORD_MAX_LENGTH, SIGN_IN_BODY_MAX_BYTES } from '../domain/password-policy'
 
 type NextHandler = () => Response | Promise<Response>
+
+const SIGN_IN_EMAIL_PATH = '/api/auth/sign-in/email'
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
 }
 
+function isJsonContentType(contentType: string | null): boolean {
+  return contentType?.split(';')[0]?.trim().toLowerCase() === 'application/json'
+}
+
+function errorResponse(code: string, message: string, status: number): Response {
+  return Response.json({ code, message }, { status })
+}
+
+function hasOverLimitContentLength(request: Request): boolean {
+  const contentLength = Number(request.headers.get('content-length'))
+  return Number.isFinite(contentLength) && contentLength > SIGN_IN_BODY_MAX_BYTES
+}
+
+function decodeChunks(chunks: Uint8Array[], totalBytes: number): string {
+  const merged = new Uint8Array(totalBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    merged.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return new TextDecoder().decode(merged)
+}
+
+async function readNextChunk(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  chunks: Uint8Array[],
+  totalBytes: number
+): Promise<string | 'TOO_LARGE'> {
+  const { done, value } = await reader.read()
+  if (done) {
+    return decodeChunks(chunks, totalBytes)
+  }
+  const nextTotal = totalBytes + value.byteLength
+  if (nextTotal > SIGN_IN_BODY_MAX_BYTES) {
+    await reader.cancel()
+    return 'TOO_LARGE'
+  }
+  chunks.push(value)
+  return readNextChunk(reader, chunks, nextTotal)
+}
+
+async function readBodyBounded(request: Request): Promise<string | 'TOO_LARGE'> {
+  if (hasOverLimitContentLength(request)) {
+    return 'TOO_LARGE'
+  }
+
+  const stream = request.clone().body
+  if (stream === null) {
+    return ''
+  }
+
+  return readNextChunk(stream.getReader(), [], 0)
+}
+
+function parsePassword(bodyText: string): unknown {
+  try {
+    return JSON.parse(bodyText)
+  } catch {
+    return undefined
+  }
+}
+
+function isOverLimitPassword(body: unknown): boolean {
+  if (!isRecord(body) || typeof body['password'] !== 'string') {
+    return false
+  }
+  return body['password'].length > PASSWORD_MAX_LENGTH
+}
+
+function isSignInEmailRequest(request: Request): boolean {
+  if (request.method !== 'POST') {
+    return false
+  }
+  return new URL(request.url).pathname === SIGN_IN_EMAIL_PATH
+}
+
+async function runSignInEmailGuard(request: Request, next: NextHandler): Promise<Response> {
+  if (!isJsonContentType(request.headers.get('content-type'))) {
+    return errorResponse('INVALID_CONTENT_TYPE', 'Content type must be application/json.', 415)
+  }
+
+  const bodyText = await readBodyBounded(request)
+  if (bodyText === 'TOO_LARGE') {
+    return errorResponse('REQUEST_TOO_LARGE', 'Request body exceeds the maximum size.', 413)
+  }
+
+  const body = parsePassword(bodyText)
+  if (isOverLimitPassword(body)) {
+    return errorResponse('PASSWORD_TOO_LONG', 'Password exceeds the maximum length.', 400)
+  }
+
+  return next()
+}
+
 export async function guardSignInRequest(request: Request, next: NextHandler): Promise<Response> {
-  const pathname = new URL(request.url).pathname
-
-  if (request.method !== 'POST' || !pathname.endsWith('/sign-in/email')) {
+  if (!isSignInEmailRequest(request)) {
     return next()
   }
-
-  const body = await request
-    .clone()
-    .json()
-    .catch(() => undefined)
-
-  if (!isRecord(body) || typeof body.password !== 'string') {
-    return next()
-  }
-
-  if (body.password.length <= PASSWORD_MAX_LENGTH) {
-    return next()
-  }
-
-  return Response.json(
-    {
-      code: 'BAD_REQUEST',
-      message: 'Password exceeds the maximum length.'
-    },
-    { status: 400 }
-  )
+  return runSignInEmailGuard(request, next)
 }
 ```
 
-Use the cloned request so a valid request remains readable by Better Auth. Only an over-limit string password is handled by this guard; malformed or structurally invalid requests continue to Better Auth's existing validation.
+The guard rejects non-JSON content types (`415`) before any body processing, checks `Content-Length` before reading, and cancels the cloned stream once it exceeds the byte cap (`413`) so the guard's own memory use is bounded. The clone keeps a valid request readable by Better Auth. Only an over-limit string password is rejected with `400` (`PASSWORD_TOO_LONG`); malformed or structurally invalid requests continue to Better Auth's existing validation. The sequential stream reads are written as a small recursive helper (`readNextChunk`) so the guard stays free of `no-await-in-loop` and `max-statements` warnings; the recursion depth is bounded by `SIGN_IN_BODY_MAX_BYTES / chunk size`.
 
 - [ ] **Step 4: Run the guard tests to verify they pass**
 
@@ -250,7 +552,7 @@ Run:
 pnpm vitest run src/features/auth/functions/guard-sign-in-request.server.test.ts
 ```
 
-Expected: 3 tests pass.
+Expected: 16 tests pass.
 
 - [ ] **Step 5: Configure Better Auth with the shared maximum**
 
@@ -308,7 +610,7 @@ Run:
 pnpm run test
 ```
 
-Expected: the baseline 80 tests plus the new schema and guard tests pass with zero failures.
+Expected: the baseline 80 tests plus the new schema and guard tests pass with zero failures (98 tests total).
 
 - [ ] **Step 2: Run formatting, lint, markup lint, and typecheck**
 

--- a/docs/superpowers/plans/2026-08-07-password-input-boundary.md
+++ b/docs/superpowers/plans/2026-08-07-password-input-boundary.md
@@ -1,0 +1,344 @@
+# Password Input Boundary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reject passwords longer than 128 characters before Better Auth sign-in hashing while keeping the client and server password policies aligned.
+
+**Architecture:** Add a side-effect-free shared password policy constant. Use it in the Valibot client schema and Better Auth configuration, and add a narrow request guard at the existing auth catch-all route because the current Better Auth sign-in implementation does not apply `maxPasswordLength` before hash/verify. The guard inspects only `POST /api/auth/sign-in/email`, reads a cloned JSON body, and delegates all other requests unchanged.
+
+**Tech Stack:** TanStack Start, Better Auth, Valibot, Cloudflare Workers, Vitest.
+
+---
+
+## File Map
+
+- Create: `src/features/auth/domain/password-policy.ts` — shared maximum password length.
+- Modify: `src/features/auth/lib/sign-in-schema.ts` — enforce the shared maximum in client validation.
+- Create: `src/features/auth/lib/sign-in-schema.test.ts` — client schema boundary tests.
+- Create: `src/features/auth/functions/guard-sign-in-request.server.ts` — server-side pre-handler guard.
+- Create: `src/features/auth/functions/guard-sign-in-request.server.test.ts` — guard delegation and rejection tests.
+- Modify: `src/features/auth/functions/get-auth.server.ts` — configure Better Auth with the shared maximum.
+- Modify: `src/routes/api/auth/$.ts` — apply the guard before the Better Auth handler.
+
+### Task 1: Add the Shared Policy and Client Boundary
+
+**Files:**
+
+- Create: `src/features/auth/domain/password-policy.ts`
+- Modify: `src/features/auth/lib/sign-in-schema.ts:1-15`
+- Test: `src/features/auth/lib/sign-in-schema.test.ts`
+
+- [ ] **Step 1: Write the failing schema boundary tests**
+
+Create `src/features/auth/lib/sign-in-schema.test.ts` with tests for the accepted and rejected boundary:
+
+```ts
+import { expect, test } from 'vitest'
+import { parse } from 'valibot'
+
+import { PASSWORD_MAX_LENGTH } from '../domain/password-policy'
+import { passwordSchema } from './sign-in-schema'
+
+test('accepts a password at the maximum length', () => {
+  const password = 'a'.repeat(PASSWORD_MAX_LENGTH)
+
+  expect(parse(passwordSchema, password)).toBe(password)
+})
+
+test('rejects a password over the maximum length', () => {
+  const password = 'a'.repeat(PASSWORD_MAX_LENGTH + 1)
+
+  expect(() => parse(passwordSchema, password)).toThrow()
+})
+```
+
+- [ ] **Step 2: Run the new test to verify it fails for the missing maximum**
+
+Run:
+
+```bash
+pnpm vitest run src/features/auth/lib/sign-in-schema.test.ts
+```
+
+Expected: the over-limit test fails because `passwordSchema` currently has no `maxLength` action. The test file may also fail to compile until the shared policy module is created in the next step.
+
+- [ ] **Step 3: Add the shared password policy constant**
+
+Create `src/features/auth/domain/password-policy.ts`:
+
+```ts
+export const PASSWORD_MAX_LENGTH = 128
+```
+
+Keep this module free of framework, environment, and validation-library imports so it can be consumed by both browser and Worker code.
+
+- [ ] **Step 4: Apply the shared maximum to the client schema**
+
+Update `src/features/auth/lib/sign-in-schema.ts` to import `maxLength` from Valibot and the shared constant, then add the maximum after the existing minimum:
+
+```ts
+import {
+  brand,
+  email,
+  InferOutput,
+  maxLength,
+  minLength,
+  nonEmpty,
+  object,
+  pipe,
+  string
+} from 'valibot'
+
+import { PASSWORD_MAX_LENGTH } from '../domain/password-policy'
+
+export const passwordSchema = pipe(
+  string('Please enter your password.'),
+  nonEmpty('Please enter your password.'),
+  minLength(8, 'Your password must have 8 characters or more.'),
+  maxLength(PASSWORD_MAX_LENGTH, 'Your password must have 128 characters or fewer.'),
+  brand('Password')
+)
+```
+
+Preserve the existing email schema, password brand, minimum length, and exported types.
+
+- [ ] **Step 5: Run the schema tests to verify the boundary passes**
+
+Run:
+
+```bash
+pnpm vitest run src/features/auth/lib/sign-in-schema.test.ts
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 6: Commit the shared policy and client validation**
+
+```bash
+git add src/features/auth/domain/password-policy.ts src/features/auth/lib/sign-in-schema.ts src/features/auth/lib/sign-in-schema.test.ts
+git commit -m "fix(auth): bound client password input"
+```
+
+### Task 2: Guard the Server Sign-In Request Before Better Auth
+
+**Files:**
+
+- Create: `src/features/auth/functions/guard-sign-in-request.server.ts`
+- Test: `src/features/auth/functions/guard-sign-in-request.server.test.ts`
+- Modify: `src/routes/api/auth/$.ts:1-12`
+- Modify: `src/features/auth/functions/get-auth.server.ts:7-26`
+
+- [ ] **Step 1: Write failing tests for server rejection and delegation**
+
+Create `src/features/auth/functions/guard-sign-in-request.server.test.ts`:
+
+```ts
+import { expect, test, vi } from 'vitest'
+
+import { PASSWORD_MAX_LENGTH } from '../domain/password-policy'
+import { guardSignInRequest } from './guard-sign-in-request.server'
+
+function makeRequest(path: string, password: string): Request {
+  return new Request(`https://pantry.example${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email: 'user@example.com', password })
+  })
+}
+
+test('rejects an over-limit sign-in password without calling the handler', async () => {
+  const next = vi.fn(() => new Response('handled'))
+
+  const response = await guardSignInRequest(
+    makeRequest('/api/auth/sign-in/email', 'a'.repeat(PASSWORD_MAX_LENGTH + 1)),
+    next
+  )
+
+  expect(response.status).toBe(400)
+  expect(next).not.toHaveBeenCalled()
+})
+
+test('delegates a password at the maximum length', async () => {
+  const handled = new Response('handled')
+  const next = vi.fn(() => handled)
+
+  const response = await guardSignInRequest(
+    makeRequest('/api/auth/sign-in/email', 'a'.repeat(PASSWORD_MAX_LENGTH)),
+    next
+  )
+
+  expect(response).toBe(handled)
+  expect(next).toHaveBeenCalledOnce()
+})
+
+test('does not apply the guard to another auth endpoint', async () => {
+  const handled = new Response('handled')
+  const next = vi.fn(() => handled)
+
+  const response = await guardSignInRequest(
+    makeRequest('/api/auth/sign-up/email', 'a'.repeat(PASSWORD_MAX_LENGTH + 1)),
+    next
+  )
+
+  expect(response).toBe(handled)
+  expect(next).toHaveBeenCalledOnce()
+})
+```
+
+The first test is the hash/verify boundary test: the fake `next` represents `getAuth().handler(request)`, so it must not be called for an oversized password.
+
+- [ ] **Step 2: Run the guard tests to verify they fail before the guard exists**
+
+Run:
+
+```bash
+pnpm vitest run src/features/auth/functions/guard-sign-in-request.server.test.ts
+```
+
+Expected: the test file fails because `guard-sign-in-request.server.ts` and `guardSignInRequest` do not exist yet.
+
+- [ ] **Step 3: Implement the request guard**
+
+Create `src/features/auth/functions/guard-sign-in-request.server.ts`:
+
+```ts
+import { PASSWORD_MAX_LENGTH } from '../domain/password-policy'
+
+type NextHandler = () => Response | Promise<Response>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+export async function guardSignInRequest(request: Request, next: NextHandler): Promise<Response> {
+  const pathname = new URL(request.url).pathname
+
+  if (request.method !== 'POST' || !pathname.endsWith('/sign-in/email')) {
+    return next()
+  }
+
+  const body = await request
+    .clone()
+    .json()
+    .catch(() => undefined)
+
+  if (!isRecord(body) || typeof body.password !== 'string') {
+    return next()
+  }
+
+  if (body.password.length <= PASSWORD_MAX_LENGTH) {
+    return next()
+  }
+
+  return Response.json(
+    {
+      code: 'BAD_REQUEST',
+      message: 'Password exceeds the maximum length.'
+    },
+    { status: 400 }
+  )
+}
+```
+
+Use the cloned request so a valid request remains readable by Better Auth. Only an over-limit string password is handled by this guard; malformed or structurally invalid requests continue to Better Auth's existing validation.
+
+- [ ] **Step 4: Run the guard tests to verify they pass**
+
+Run:
+
+```bash
+pnpm vitest run src/features/auth/functions/guard-sign-in-request.server.test.ts
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Configure Better Auth with the shared maximum**
+
+In `src/features/auth/functions/get-auth.server.ts`, import `PASSWORD_MAX_LENGTH` from `../domain/password-policy` and configure:
+
+```ts
+emailAndPassword: {
+  enabled: true,
+  maxPasswordLength: PASSWORD_MAX_LENGTH
+}
+```
+
+Do not remove the existing `enabled: true` setting or alter the database and plugin configuration.
+
+- [ ] **Step 6: Connect the guard to the existing POST auth handler**
+
+In `src/routes/api/auth/$.ts`, import `guardSignInRequest` and replace the inline POST delegation with:
+
+```ts
+POST: async ({ request }: { request: Request }) =>
+  guardSignInRequest(request, () => getAuth().handler(request))
+```
+
+Keep the GET handler unchanged. The guard itself checks the endpoint path, so the catch-all route remains compatible with other POST auth endpoints.
+
+- [ ] **Step 7: Run the auth-related tests and typecheck**
+
+Run:
+
+```bash
+pnpm vitest run src/features/auth
+pnpm run typecheck
+```
+
+Expected: all auth tests pass and TypeScript exits successfully.
+
+- [ ] **Step 8: Commit the server boundary**
+
+```bash
+git add src/features/auth/functions/guard-sign-in-request.server.ts src/features/auth/functions/guard-sign-in-request.server.test.ts src/features/auth/functions/get-auth.server.ts src/routes/api/auth/\$.ts
+git commit -m "fix(auth): reject oversized sign-in passwords"
+```
+
+### Task 3: Run the Repository Verification Suite
+
+**Files:**
+
+- No additional files; verify the changes from Tasks 1 and 2.
+
+- [ ] **Step 1: Run the complete test suite**
+
+Run:
+
+```bash
+pnpm run test
+```
+
+Expected: the baseline 80 tests plus the new schema and guard tests pass with zero failures.
+
+- [ ] **Step 2: Run formatting, lint, markup lint, and typecheck**
+
+Run:
+
+```bash
+pnpm run format:check
+pnpm run lint
+pnpm run lint:markup
+pnpm run typecheck
+```
+
+Expected: all commands exit with status 0.
+
+- [ ] **Step 3: Run the production build**
+
+Run:
+
+```bash
+pnpm run build
+```
+
+Expected: Vite produces the Worker build without TypeScript, route, or bundling errors.
+
+- [ ] **Step 4: Inspect the final diff and status**
+
+Run:
+
+```bash
+git status --short --branch
+```
+
+Confirm that only the shared password policy, client schema, server guard, Better Auth configuration, route wiring, and their tests changed. Do not stage unrelated files.

--- a/docs/superpowers/specs/2026-08-07-password-input-boundary-design.md
+++ b/docs/superpowers/specs/2026-08-07-password-input-boundary-design.md
@@ -1,0 +1,66 @@
+# パスワード入力上限の認証境界設計
+
+## 背景
+
+現在のサインインではclient側のschemaに最大長がなく、巨大なパスワードがBetter Authのsign-in処理まで到達する。現行Better Authはsign-in時に`maxPasswordLength`をhash/verify前の検証へ適用しないため、巨大入力でもhash/verifyが実行され、WorkersのCPU・メモリを消費し得る。
+
+## 目的
+
+- client schemaとserverのsign-in APIが同じ明示的な最大長を使う。
+- 最大長を超えるパスワードをBetter Auth handlerへ渡す前に拒否する。
+- 上限ちょうどと上限超過の境界を自動テストで固定する。
+
+## 非目的
+
+- 認証経路をServer Functionへ置き換えない。
+- Better Authのhashアルゴリズムやrate limit設定を変更しない。
+- パスワード要件の下限や既存の認証エラー仕様を変更しない。
+
+## 設計
+
+### 共有ポリシー
+
+認証機能内の副作用のない共有モジュールに`PASSWORD_MAX_LENGTH = 128`を定義する。128はBetter Authの`maxPasswordLength`標準値と一致する。client schemaとserver側のrequest guard、Better Auth設定はこの定数を参照し、数値の重複を避ける。
+
+### Client validation
+
+既存の`passwordSchema`へ共有定数による`maxLength`を追加する。これにより通常の画面操作では送信前に129文字以上を拒否する。ただしclient validationは攻撃者が回避できるため、セキュリティ上の最終防御にはしない。
+
+### Server validation
+
+`/api/auth/sign-in/email`を処理するcatch-all routeで、Better Auth handlerへ委譲する前にrequest bodyを検査する。`request.clone()`を使ってJSONを読み取り、passwordが文字列で共有上限を超えている場合は400を返す。それ以外のrequestは元のrequestをそのまま`getAuth().handler(request)`へ渡す。
+
+JSONが壊れている場合、passwordが欠落している場合、passwordの型が違う場合はguardで独自処理せず、既存どおりBetter Authへ委譲する。guardはsign-in email endpointにだけ適用し、他の認証endpointの挙動を変えない。
+
+Better Authの`emailAndPassword.maxPasswordLength`にも共有定数を設定する。これはsign-upなどBetter Auth自身が上限検証する処理との整合性を保つためであり、sign-inの事前拒否はroute guardが担う。
+
+### データフロー
+
+```text
+POST /api/auth/sign-in/email
+  -> request cloneのJSONを検査
+  -> password.length > 128: 400を返す
+  -> その他: getAuth().handler(request)
+  -> Better Authの通常処理
+```
+
+リクエストのbodyをcloneから読むため、正常なリクエストのbodyは消費されず、Better Authは元のrequestを受け取れる。
+
+## テスト
+
+- password schemaは128文字ちょうどを受け入れる。
+- password schemaは129文字を拒否する。
+- server guardは129文字のrequestでhandlerを呼ばず、400を返す。
+- server guardは128文字のrequestをhandlerへ委譲する。
+- 既存の認証schemaの下限（8文字）と認証テストは維持する。
+
+server guardはBetter AuthやDBを起動しない単体テストにし、fake handlerの呼び出し有無でhash/verify前の拒否を検証する。
+
+## エラーと互換性
+
+上限超過時は400系のJSON responseを返す。画面側は既存の汎用サインインエラー表示にフォールバックでき、認証成功・失敗のアカウント列挙防止方針を変更しない。正常なsign-in requestとsign-in以外のauth requestは既存handlerへ委譲する。
+
+## 代替案と採否
+
+- Better Authの設定とclient schemaだけを変更する案は、現行sign-inでhash/verify前に拒否できないため不採用。
+- Server Functionへ認証経路を移行する案は防御可能だが、Issueの範囲を超えるため不採用。

--- a/docs/superpowers/specs/2026-08-07-password-input-boundary-design.md
+++ b/docs/superpowers/specs/2026-08-07-password-input-boundary-design.md
@@ -28,23 +28,32 @@
 
 ### Server validation
 
-`/api/auth/sign-in/email`を処理するcatch-all routeで、Better Auth handlerへ委譲する前にrequest bodyを検査する。`request.clone()`を使ってJSONを読み取り、passwordが文字列で共有上限を超えている場合は400を返す。それ以外のrequestは元のrequestをそのまま`getAuth().handler(request)`へ渡す。
+`/api/auth/sign-in/email`を処理するcatch-all routeで、Better Auth handlerへ委譲する前にrequest bodyを検査する。guardは以下の順で処理する。
+
+1. pathが`/api/auth/sign-in/email`に完全一致する`POST`だけを対象にする。
+2. `Content-Type`が`application/json`（charset付きを許容）以外なら`415`を返す。Better Authのsign-in/emailは`application/x-www-form-urlencoded`も受け付けるが、guardはJSONのみを許可し、form経路で巨大なpasswordがhash/verifyへ到達することを防ぐ。
+3. bodyを上限バイト数`SIGN_IN_BODY_MAX_BYTES = 4096`で読み取る。`Content-Length`が上限を超えていれば読み取り前に`413`を返し、`Content-Length`がないstream bodyは上限を超えた時点でcancelする。正常なbodyは上限を超えないため、guard自身のメモリ・CPU消費もboundedになる。
+4. 上限内ならJSONをparseし、passwordが文字列で`PASSWORD_MAX_LENGTH`を超えていれば`400`とcode `PASSWORD_TOO_LONG`を返す。codeはBetter Authのsign-upが上限超過で返す語彙と一致させる。
 
 JSONが壊れている場合、passwordが欠落している場合、passwordの型が違う場合はguardで独自処理せず、既存どおりBetter Authへ委譲する。guardはsign-in email endpointにだけ適用し、他の認証endpointの挙動を変えない。
 
 Better Authの`emailAndPassword.maxPasswordLength`にも共有定数を設定する。これはsign-upなどBetter Auth自身が上限検証する処理との整合性を保つためであり、sign-inの事前拒否はroute guardが担う。
 
+パスワード長の境界はJS文字列の`length`（UTF-16 code unit）で判定し、client schema（Valibotの`maxLength`）と同じ基準にする。
+
 ### データフロー
 
 ```text
 POST /api/auth/sign-in/email
-  -> request cloneのJSONを検査
-  -> password.length > 128: 400を返す
+  -> path完全一致かつPOSTのみ対象
+  -> Content-Typeがapplication/json以外: 415を返す
+  -> Content-Lengthが上限超過 / stream読取で上限超過: 413を返す
+  -> password.length > 128: 400 (code: PASSWORD_TOO_LONG)を返す
   -> その他: getAuth().handler(request)
   -> Better Authの通常処理
 ```
 
-リクエストのbodyをcloneから読むため、正常なリクエストのbodyは消費されず、Better Authは元のrequestを受け取れる。
+リクエストのbodyはcloneからboundedに読むため、正常なリクエストのbodyは消費されず、Better Authは元のrequestを受け取れる。
 
 ## テスト
 
@@ -52,13 +61,26 @@ POST /api/auth/sign-in/email
 - password schemaは129文字を拒否する。
 - server guardは129文字のrequestでhandlerを呼ばず、400を返す。
 - server guardは128文字のrequestをhandlerへ委譲する。
+- form-urlencodedや`text/plain`のrequestは415で拒否し、handlerを呼ばない。
+- `Content-Length`が上限超過のrequestは413で拒否し、handlerを呼ばない。
+- `Content-Length`のないstream bodyが上限を超えたら413で拒否する。
+- bodyが上限バイト数ちょうどなら委譲する。
+- `application/json; charset=utf-8`は受け付ける。
+- malformed JSON、password欠落、password非stringは既存どおり委譲する。
+- 委譲後も元のrequest bodyをhandlerが読める。
+- 上限境界はUTF-16 code unitで判定される（絵文字2単位相当のケース）。
+- 完全一致以外のpath（他endpoint、trailing slash）にはguardを適用しない。
 - 既存の認証schemaの下限（8文字）と認証テストは維持する。
 
 server guardはBetter AuthやDBを起動しない単体テストにし、fake handlerの呼び出し有無でhash/verify前の拒否を検証する。
 
 ## エラーと互換性
 
-上限超過時は400系のJSON responseを返す。画面側は既存の汎用サインインエラー表示にフォールバックでき、認証成功・失敗のアカウント列挙防止方針を変更しない。正常なsign-in requestとsign-in以外のauth requestは既存handlerへ委譲する。
+上限超過時は400系のJSON response（400 / 413 / 415）を返す。画面側は既存の汎用サインインエラー表示にフォールバックでき、認証成功・失敗のアカウント列挙防止方針を変更しない。正常なsign-in requestとsign-in以外のauth requestは既存handlerへ委譲する。
+
+## 残余リスク
+
+guardが拒否するrequestはBetter Authの内部rate limiterを経由しないため、guardの拒否path自体のレート制限はこのIssueの範囲外である。body処理は上限バイトでboundedになるため、1 requestあたりの資源消費は抑えられるが、繰り返しの過大入力にはWAF・rate limitなどの別層が必要になる。
 
 ## 代替案と採否
 

--- a/src/features/auth/domain/password-policy.ts
+++ b/src/features/auth/domain/password-policy.ts
@@ -1,1 +1,3 @@
 export const PASSWORD_MAX_LENGTH = 128
+
+export const SIGN_IN_BODY_MAX_BYTES = 4096

--- a/src/features/auth/domain/password-policy.ts
+++ b/src/features/auth/domain/password-policy.ts
@@ -1,0 +1,1 @@
+export const PASSWORD_MAX_LENGTH = 128

--- a/src/features/auth/functions/get-auth.server.ts
+++ b/src/features/auth/functions/get-auth.server.ts
@@ -6,6 +6,7 @@ import { env } from 'cloudflare:workers'
 
 import { getDB } from '../../../db/get-db.server'
 import * as schema from '../../../db/schema/auth-schema'
+import { PASSWORD_MAX_LENGTH } from '../domain/password-policy'
 
 type Auth = ReturnType<typeof createAuth>
 
@@ -20,7 +21,8 @@ function createAuth() {
       }
     }),
     emailAndPassword: {
-      enabled: true
+      enabled: true,
+      maxPasswordLength: PASSWORD_MAX_LENGTH
     },
     plugins: [admin()]
   })

--- a/src/features/auth/functions/guard-sign-in-request.server.test.ts
+++ b/src/features/auth/functions/guard-sign-in-request.server.test.ts
@@ -96,7 +96,7 @@ test('rejects a non-JSON content type', async () => {
   const request = new Request('https://pantry.example/api/auth/sign-in/email', {
     method: 'POST',
     headers: { 'content-type': 'text/plain' },
-    body: `password=${  'a'.repeat(PASSWORD_MAX_LENGTH + 1)}`
+    body: `password=${'a'.repeat(PASSWORD_MAX_LENGTH + 1)}`
   })
 
   const response = await guardSignInRequest(request, next)

--- a/src/features/auth/functions/guard-sign-in-request.server.test.ts
+++ b/src/features/auth/functions/guard-sign-in-request.server.test.ts
@@ -102,7 +102,53 @@ test('rejects a non-JSON content type', async () => {
   const response = await guardSignInRequest(request, next)
 
   expect(response.status).toBe(415)
+  expect(await response.json()).toMatchObject({ code: 'UNSUPPORTED_MEDIA_TYPE' })
   expect(next).not.toHaveBeenCalled()
+})
+
+test('rejects a missing content type', async () => {
+  const next = vi.fn(() => new Response('handled'))
+
+  const request = new Request('https://pantry.example/api/auth/sign-in/email', {
+    method: 'POST',
+    body: JSON.stringify({ email: 'user@example.com', password: 'a'.repeat(PASSWORD_MAX_LENGTH) })
+  })
+
+  const response = await guardSignInRequest(request, next)
+
+  expect(response.status).toBe(415)
+  expect(next).not.toHaveBeenCalled()
+})
+
+test('rejects a vendor-prefixed JSON content type', async () => {
+  const next = vi.fn(() => new Response('handled'))
+
+  const request = new Request('https://pantry.example/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: { 'content-type': 'application/problem+json' },
+    body: JSON.stringify({ email: 'user@example.com', password: 'a'.repeat(PASSWORD_MAX_LENGTH) })
+  })
+
+  const response = await guardSignInRequest(request, next)
+
+  expect(response.status).toBe(415)
+  expect(next).not.toHaveBeenCalled()
+})
+
+test('accepts an uppercased JSON content type', async () => {
+  const handled = new Response('handled')
+  const next = vi.fn(() => handled)
+
+  const request = new Request('https://pantry.example/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: { 'content-type': 'Application/JSON' },
+    body: JSON.stringify({ email: 'user@example.com', password: 'a'.repeat(PASSWORD_MAX_LENGTH) })
+  })
+
+  const response = await guardSignInRequest(request, next)
+
+  expect(response).toBe(handled)
+  expect(next).toHaveBeenCalledOnce()
 })
 
 test('accepts application/json with a charset parameter', async () => {
@@ -275,4 +321,69 @@ test('does not apply the guard to a sign-in path with a trailing slash', async (
 
   expect(response).toBe(handled)
   expect(next).toHaveBeenCalledOnce()
+})
+
+test('returns 413 even when the stream cancel rejects', async () => {
+  const encoder = new TextEncoder()
+  const next = vi.fn(() => new Response('handled'))
+
+  const request = new Request('https://pantry.example/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('a'.repeat(SIGN_IN_BODY_MAX_BYTES + 1)))
+      },
+      cancel() {
+        return Promise.reject(new Error('cancel failed'))
+      }
+    })
+  })
+
+  const response = await guardSignInRequest(request, next)
+
+  expect(response.status).toBe(413)
+  expect(next).not.toHaveBeenCalled()
+})
+
+test('decodes multi-byte characters split across chunk boundaries', async () => {
+  const encoder = new TextEncoder()
+  const handled = new Response('handled')
+  const next = vi.fn(() => handled)
+
+  const body = JSON.stringify({ email: 'user@example.com', password: 'あ'.repeat(64) })
+  const bytes = encoder.encode(body)
+  const chunks: Uint8Array[] = []
+  for (let offset = 0; offset < bytes.length; offset += 2) {
+    chunks.push(bytes.slice(offset, offset + 2))
+  }
+
+  const request = new Request('https://pantry.example/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(chunk)
+        }
+        controller.close()
+      }
+    })
+  })
+
+  const response = await guardSignInRequest(request, next)
+
+  expect(response).toBe(handled)
+  expect(next).toHaveBeenCalledOnce()
+})
+
+test('keeps the maximum legitimate sign-in body under the byte cap', () => {
+  const body = JSON.stringify({
+    email: `${'a'.repeat(243)}@example.com`,
+    password: 'a'.repeat(PASSWORD_MAX_LENGTH),
+    rememberMe: true,
+    callbackURL: `https://pantry.example/redirect/${'a'.repeat(512)}`
+  })
+
+  expect(body.length).toBeLessThan(SIGN_IN_BODY_MAX_BYTES)
 })

--- a/src/features/auth/functions/guard-sign-in-request.server.test.ts
+++ b/src/features/auth/functions/guard-sign-in-request.server.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, vi } from 'vitest'
 
-import { PASSWORD_MAX_LENGTH } from '../domain/password-policy'
+import { PASSWORD_MAX_LENGTH, SIGN_IN_BODY_MAX_BYTES } from '../domain/password-policy'
 import { guardSignInRequest } from './guard-sign-in-request.server'
 
 function makeRequest(path: string, password: string): Request {
@@ -8,6 +8,35 @@ function makeRequest(path: string, password: string): Request {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ email: 'user@example.com', password })
+  })
+}
+
+function makeFormRequest(path: string, password: string): Request {
+  return new Request(`https://pantry.example${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ email: 'user@example.com', password }).toString()
+  })
+}
+
+function makeStreamingRequest(body: string): Request {
+  const encoder = new TextEncoder()
+  const chunks: string[] = []
+  for (let offset = 0; offset < body.length; offset += 256) {
+    chunks.push(body.slice(offset, offset + 256))
+  }
+
+  return new Request('https://pantry.example/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: new ReadableStream({
+      async start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(encoder.encode(chunk))
+        }
+        controller.close()
+      }
+    })
   })
 }
 
@@ -42,6 +71,205 @@ test('does not apply the guard to another auth endpoint', async () => {
 
   const response = await guardSignInRequest(
     makeRequest('/api/auth/sign-up/email', 'a'.repeat(PASSWORD_MAX_LENGTH + 1)),
+    next
+  )
+
+  expect(response).toBe(handled)
+  expect(next).toHaveBeenCalledOnce()
+})
+
+test('rejects an over-limit form-urlencoded sign-in password', async () => {
+  const next = vi.fn(() => new Response('handled'))
+
+  const response = await guardSignInRequest(
+    makeFormRequest('/api/auth/sign-in/email', 'a'.repeat(PASSWORD_MAX_LENGTH + 1)),
+    next
+  )
+
+  expect(response.status).toBe(415)
+  expect(next).not.toHaveBeenCalled()
+})
+
+test('rejects a non-JSON content type', async () => {
+  const next = vi.fn(() => new Response('handled'))
+
+  const request = new Request('https://pantry.example/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: { 'content-type': 'text/plain' },
+    body: `password=${  'a'.repeat(PASSWORD_MAX_LENGTH + 1)}`
+  })
+
+  const response = await guardSignInRequest(request, next)
+
+  expect(response.status).toBe(415)
+  expect(next).not.toHaveBeenCalled()
+})
+
+test('accepts application/json with a charset parameter', async () => {
+  const handled = new Response('handled')
+  const next = vi.fn(() => handled)
+
+  const request = new Request('https://pantry.example/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+    body: JSON.stringify({ email: 'user@example.com', password: 'a'.repeat(PASSWORD_MAX_LENGTH) })
+  })
+
+  const response = await guardSignInRequest(request, next)
+
+  expect(response).toBe(handled)
+  expect(next).toHaveBeenCalledOnce()
+})
+
+test('rejects a body with an over-limit content-length', async () => {
+  const next = vi.fn(() => new Response('handled'))
+
+  const request = new Request('https://pantry.example/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body:
+      JSON.stringify({ email: 'user@example.com', password: 'a'.repeat(PASSWORD_MAX_LENGTH) }) +
+      ' '.repeat(SIGN_IN_BODY_MAX_BYTES)
+  })
+
+  const response = await guardSignInRequest(request, next)
+
+  expect(response.status).toBe(413)
+  expect(next).not.toHaveBeenCalled()
+})
+
+test('accepts a body at the exact byte limit', async () => {
+  const handled = new Response('handled')
+  const next = vi.fn(() => handled)
+
+  const password = 'a'.repeat(PASSWORD_MAX_LENGTH)
+  const emailPadding = SIGN_IN_BODY_MAX_BYTES - JSON.stringify({ email: '', password }).length
+  const body = JSON.stringify({ email: 'a'.repeat(emailPadding), password })
+  expect(body.length).toBe(SIGN_IN_BODY_MAX_BYTES)
+
+  const request = new Request('https://pantry.example/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body
+  })
+
+  const response = await guardSignInRequest(request, next)
+
+  expect(response).toBe(handled)
+  expect(next).toHaveBeenCalledOnce()
+})
+
+test('rejects an over-limit streaming body without a content-length', async () => {
+  const next = vi.fn(() => new Response('handled'))
+
+  const request = makeStreamingRequest(
+    JSON.stringify({
+      email: 'user@example.com',
+      password: 'a'.repeat(SIGN_IN_BODY_MAX_BYTES + 1)
+    })
+  )
+  expect(request.headers.get('content-length')).toBeNull()
+
+  const response = await guardSignInRequest(request, next)
+
+  expect(response.status).toBe(413)
+  expect(next).not.toHaveBeenCalled()
+})
+
+test('delegates malformed JSON', async () => {
+  const handled = new Response('handled')
+  const next = vi.fn(() => handled)
+
+  const request = new Request('https://pantry.example/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: '{"email":'
+  })
+
+  const response = await guardSignInRequest(request, next)
+
+  expect(response).toBe(handled)
+  expect(next).toHaveBeenCalledOnce()
+})
+
+test('delegates a body without a password field', async () => {
+  const handled = new Response('handled')
+  const next = vi.fn(() => handled)
+
+  const request = new Request('https://pantry.example/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email: 'user@example.com' })
+  })
+
+  const response = await guardSignInRequest(request, next)
+
+  expect(response).toBe(handled)
+  expect(next).toHaveBeenCalledOnce()
+})
+
+test('delegates a body with a non-string password', async () => {
+  const handled = new Response('handled')
+  const next = vi.fn(() => handled)
+
+  const request = new Request('https://pantry.example/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email: 'user@example.com', password: 123 })
+  })
+
+  const response = await guardSignInRequest(request, next)
+
+  expect(response).toBe(handled)
+  expect(next).toHaveBeenCalledOnce()
+})
+
+test('leaves the original request body readable for the delegated handler', async () => {
+  const request = makeRequest('/api/auth/sign-in/email', 'a'.repeat(PASSWORD_MAX_LENGTH))
+  const next = vi.fn(async (req: Request) => {
+    const body = (await req.json()) as { password: string }
+    return new Response(body.password.length.toString())
+  })
+
+  const response = await guardSignInRequest(request, () => next(request))
+
+  expect(response.status).toBe(200)
+  expect(await response.text()).toBe(String(PASSWORD_MAX_LENGTH))
+})
+
+test('applies the length boundary in UTF-16 code units', async () => {
+  const emoji = '😀'
+  const handled = new Response('handled')
+  const next = vi.fn(() => handled)
+
+  const response = await guardSignInRequest(
+    makeRequest('/api/auth/sign-in/email', emoji.repeat(64)),
+    next
+  )
+
+  expect(response).toBe(handled)
+  expect(next).toHaveBeenCalledOnce()
+})
+
+test('rejects a password over 128 UTF-16 code units', async () => {
+  const emoji = '😀'
+  const next = vi.fn(() => new Response('handled'))
+
+  const response = await guardSignInRequest(
+    makeRequest('/api/auth/sign-in/email', emoji.repeat(65)),
+    next
+  )
+
+  expect(response.status).toBe(400)
+  expect(next).not.toHaveBeenCalled()
+})
+
+test('does not apply the guard to a sign-in path with a trailing slash', async () => {
+  const handled = new Response('handled')
+  const next = vi.fn(() => handled)
+
+  const response = await guardSignInRequest(
+    makeRequest('/api/auth/sign-in/email/', 'a'.repeat(PASSWORD_MAX_LENGTH + 1)),
     next
   )
 

--- a/src/features/auth/functions/guard-sign-in-request.server.test.ts
+++ b/src/features/auth/functions/guard-sign-in-request.server.test.ts
@@ -1,0 +1,50 @@
+import { expect, test, vi } from 'vitest'
+
+import { PASSWORD_MAX_LENGTH } from '../domain/password-policy'
+import { guardSignInRequest } from './guard-sign-in-request.server'
+
+function makeRequest(path: string, password: string): Request {
+  return new Request(`https://pantry.example${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email: 'user@example.com', password })
+  })
+}
+
+test('rejects an over-limit sign-in password without calling the handler', async () => {
+  const next = vi.fn(() => new Response('handled'))
+
+  const response = await guardSignInRequest(
+    makeRequest('/api/auth/sign-in/email', 'a'.repeat(PASSWORD_MAX_LENGTH + 1)),
+    next
+  )
+
+  expect(response.status).toBe(400)
+  expect(next).not.toHaveBeenCalled()
+})
+
+test('delegates a password at the maximum length', async () => {
+  const handled = new Response('handled')
+  const next = vi.fn(() => handled)
+
+  const response = await guardSignInRequest(
+    makeRequest('/api/auth/sign-in/email', 'a'.repeat(PASSWORD_MAX_LENGTH)),
+    next
+  )
+
+  expect(response).toBe(handled)
+  expect(next).toHaveBeenCalledOnce()
+})
+
+test('does not apply the guard to another auth endpoint', async () => {
+  const handled = new Response('handled')
+  const next = vi.fn(() => handled)
+
+  const response = await guardSignInRequest(
+    makeRequest('/api/auth/sign-up/email', 'a'.repeat(PASSWORD_MAX_LENGTH + 1)),
+    next
+  )
+
+  expect(response).toBe(handled)
+  expect(next).toHaveBeenCalledOnce()
+})

--- a/src/features/auth/functions/guard-sign-in-request.server.ts
+++ b/src/features/auth/functions/guard-sign-in-request.server.ts
@@ -1,0 +1,36 @@
+import { PASSWORD_MAX_LENGTH } from '../domain/password-policy'
+
+type NextHandler = () => Response | Promise<Response>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+export async function guardSignInRequest(request: Request, next: NextHandler): Promise<Response> {
+  const { pathname } = new URL(request.url)
+
+  if (request.method !== 'POST' || !pathname.endsWith('/sign-in/email')) {
+    return next()
+  }
+
+  const body = await request
+    .clone()
+    .json()
+    .catch(() => undefined)
+
+  if (!isRecord(body) || typeof body['password'] !== 'string') {
+    return next()
+  }
+
+  if (body['password'].length <= PASSWORD_MAX_LENGTH) {
+    return next()
+  }
+
+  return Response.json(
+    {
+      code: 'BAD_REQUEST',
+      message: 'Password exceeds the maximum length.'
+    },
+    { status: 400 }
+  )
+}

--- a/src/features/auth/functions/guard-sign-in-request.server.ts
+++ b/src/features/auth/functions/guard-sign-in-request.server.ts
@@ -86,7 +86,7 @@ function isSignInEmailRequest(request: Request): boolean {
 
 async function runSignInEmailGuard(request: Request, next: NextHandler): Promise<Response> {
   if (!isJsonContentType(request.headers.get('content-type'))) {
-    return errorResponse('INVALID_CONTENT_TYPE', 'Content type must be application/json.', 415)
+    return errorResponse('UNSUPPORTED_MEDIA_TYPE', 'Content type must be application/json.', 415)
   }
 
   const bodyText = await readBodyBounded(request)

--- a/src/features/auth/functions/guard-sign-in-request.server.ts
+++ b/src/features/auth/functions/guard-sign-in-request.server.ts
@@ -2,6 +2,8 @@ import { PASSWORD_MAX_LENGTH, SIGN_IN_BODY_MAX_BYTES } from '../domain/password-
 
 type NextHandler = () => Response | Promise<Response>
 
+const SIGN_IN_EMAIL_PATH = '/api/auth/sign-in/email'
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
 }
@@ -10,44 +12,16 @@ function isJsonContentType(contentType: string | null): boolean {
   return contentType?.split(';')[0]?.trim().toLowerCase() === 'application/json'
 }
 
-function tooLargeResponse(): Response {
-  return Response.json(
-    {
-      code: 'REQUEST_TOO_LARGE',
-      message: 'Request body exceeds the maximum size.'
-    },
-    { status: 413 }
-  )
+function errorResponse(code: string, message: string, status: number): Response {
+  return Response.json({ code, message }, { status })
 }
 
-async function readBodyBounded(request: Request): Promise<string | 'TOO_LARGE'> {
+function hasOverLimitContentLength(request: Request): boolean {
   const contentLength = Number(request.headers.get('content-length'))
-  if (Number.isFinite(contentLength) && contentLength > SIGN_IN_BODY_MAX_BYTES) {
-    return 'TOO_LARGE'
-  }
+  return Number.isFinite(contentLength) && contentLength > SIGN_IN_BODY_MAX_BYTES
+}
 
-  const stream = request.clone().body
-  if (stream === null) {
-    return ''
-  }
-
-  const reader = stream.getReader()
-  const chunks: Uint8Array[] = []
-  let totalBytes = 0
-
-  for (;;) {
-    const { done, value } = await reader.read()
-    if (done) {
-      break
-    }
-    totalBytes += value.byteLength
-    if (totalBytes > SIGN_IN_BODY_MAX_BYTES) {
-      await reader.cancel()
-      return 'TOO_LARGE'
-    }
-    chunks.push(value)
-  }
-
+function decodeChunks(chunks: Uint8Array[], totalBytes: number): string {
   const merged = new Uint8Array(totalBytes)
   let offset = 0
   for (const chunk of chunks) {
@@ -57,48 +31,80 @@ async function readBodyBounded(request: Request): Promise<string | 'TOO_LARGE'> 
   return new TextDecoder().decode(merged)
 }
 
-export async function guardSignInRequest(request: Request, next: NextHandler): Promise<Response> {
-  const {pathname} = new URL(request.url)
+async function readNextChunk(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  chunks: Uint8Array[],
+  totalBytes: number
+): Promise<string | 'TOO_LARGE'> {
+  const { done, value } = await reader.read()
+  if (done) {
+    return decodeChunks(chunks, totalBytes)
+  }
+  const nextTotal = totalBytes + value.byteLength
+  if (nextTotal > SIGN_IN_BODY_MAX_BYTES) {
+    await reader.cancel()
+    return 'TOO_LARGE'
+  }
+  chunks.push(value)
+  return readNextChunk(reader, chunks, nextTotal)
+}
 
-  if (request.method !== 'POST' || pathname !== '/api/auth/sign-in/email') {
-    return next()
+async function readBodyBounded(request: Request): Promise<string | 'TOO_LARGE'> {
+  if (hasOverLimitContentLength(request)) {
+    return 'TOO_LARGE'
   }
 
+  const stream = request.clone().body
+  if (stream === null) {
+    return ''
+  }
+
+  return readNextChunk(stream.getReader(), [], 0)
+}
+
+function parsePassword(bodyText: string): unknown {
+  try {
+    return JSON.parse(bodyText)
+  } catch {
+    return undefined
+  }
+}
+
+function isOverLimitPassword(body: unknown): boolean {
+  if (!isRecord(body) || typeof body['password'] !== 'string') {
+    return false
+  }
+  return body['password'].length > PASSWORD_MAX_LENGTH
+}
+
+function isSignInEmailRequest(request: Request): boolean {
+  if (request.method !== 'POST') {
+    return false
+  }
+  return new URL(request.url).pathname === SIGN_IN_EMAIL_PATH
+}
+
+async function runSignInEmailGuard(request: Request, next: NextHandler): Promise<Response> {
   if (!isJsonContentType(request.headers.get('content-type'))) {
-    return Response.json(
-      {
-        code: 'INVALID_CONTENT_TYPE',
-        message: 'Content type must be application/json.'
-      },
-      { status: 415 }
-    )
+    return errorResponse('INVALID_CONTENT_TYPE', 'Content type must be application/json.', 415)
   }
 
   const bodyText = await readBodyBounded(request)
   if (bodyText === 'TOO_LARGE') {
-    return tooLargeResponse()
+    return errorResponse('REQUEST_TOO_LARGE', 'Request body exceeds the maximum size.', 413)
   }
 
-  let body: unknown
-  try {
-    body = JSON.parse(bodyText)
-  } catch {
-    return next()
-  }
-
-  if (!isRecord(body) || typeof body['password'] !== 'string') {
-    return next()
-  }
-
-  if (body['password'].length > PASSWORD_MAX_LENGTH) {
-    return Response.json(
-      {
-        code: 'PASSWORD_TOO_LONG',
-        message: 'Password exceeds the maximum length.'
-      },
-      { status: 400 }
-    )
+  const body = parsePassword(bodyText)
+  if (isOverLimitPassword(body)) {
+    return errorResponse('PASSWORD_TOO_LONG', 'Password exceeds the maximum length.', 400)
   }
 
   return next()
+}
+
+export async function guardSignInRequest(request: Request, next: NextHandler): Promise<Response> {
+  if (!isSignInEmailRequest(request)) {
+    return next()
+  }
+  return runSignInEmailGuard(request, next)
 }

--- a/src/features/auth/functions/guard-sign-in-request.server.ts
+++ b/src/features/auth/functions/guard-sign-in-request.server.ts
@@ -1,4 +1,4 @@
-import { PASSWORD_MAX_LENGTH } from '../domain/password-policy'
+import { PASSWORD_MAX_LENGTH, SIGN_IN_BODY_MAX_BYTES } from '../domain/password-policy'
 
 type NextHandler = () => Response | Promise<Response>
 
@@ -6,31 +6,99 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
 }
 
-export async function guardSignInRequest(request: Request, next: NextHandler): Promise<Response> {
-  const { pathname } = new URL(request.url)
+function isJsonContentType(contentType: string | null): boolean {
+  return contentType?.split(';')[0]?.trim().toLowerCase() === 'application/json'
+}
 
-  if (request.method !== 'POST' || !pathname.endsWith('/sign-in/email')) {
+function tooLargeResponse(): Response {
+  return Response.json(
+    {
+      code: 'REQUEST_TOO_LARGE',
+      message: 'Request body exceeds the maximum size.'
+    },
+    { status: 413 }
+  )
+}
+
+async function readBodyBounded(request: Request): Promise<string | 'TOO_LARGE'> {
+  const contentLength = Number(request.headers.get('content-length'))
+  if (Number.isFinite(contentLength) && contentLength > SIGN_IN_BODY_MAX_BYTES) {
+    return 'TOO_LARGE'
+  }
+
+  const stream = request.clone().body
+  if (stream === null) {
+    return ''
+  }
+
+  const reader = stream.getReader()
+  const chunks: Uint8Array[] = []
+  let totalBytes = 0
+
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) {
+      break
+    }
+    totalBytes += value.byteLength
+    if (totalBytes > SIGN_IN_BODY_MAX_BYTES) {
+      await reader.cancel()
+      return 'TOO_LARGE'
+    }
+    chunks.push(value)
+  }
+
+  const merged = new Uint8Array(totalBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    merged.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return new TextDecoder().decode(merged)
+}
+
+export async function guardSignInRequest(request: Request, next: NextHandler): Promise<Response> {
+  const {pathname} = new URL(request.url)
+
+  if (request.method !== 'POST' || pathname !== '/api/auth/sign-in/email') {
     return next()
   }
 
-  const body = await request
-    .clone()
-    .json()
-    .catch(() => undefined)
+  if (!isJsonContentType(request.headers.get('content-type'))) {
+    return Response.json(
+      {
+        code: 'INVALID_CONTENT_TYPE',
+        message: 'Content type must be application/json.'
+      },
+      { status: 415 }
+    )
+  }
+
+  const bodyText = await readBodyBounded(request)
+  if (bodyText === 'TOO_LARGE') {
+    return tooLargeResponse()
+  }
+
+  let body: unknown
+  try {
+    body = JSON.parse(bodyText)
+  } catch {
+    return next()
+  }
 
   if (!isRecord(body) || typeof body['password'] !== 'string') {
     return next()
   }
 
-  if (body['password'].length <= PASSWORD_MAX_LENGTH) {
-    return next()
+  if (body['password'].length > PASSWORD_MAX_LENGTH) {
+    return Response.json(
+      {
+        code: 'PASSWORD_TOO_LONG',
+        message: 'Password exceeds the maximum length.'
+      },
+      { status: 400 }
+    )
   }
 
-  return Response.json(
-    {
-      code: 'BAD_REQUEST',
-      message: 'Password exceeds the maximum length.'
-    },
-    { status: 400 }
-  )
+  return next()
 }

--- a/src/features/auth/lib/sign-in-schema.test.ts
+++ b/src/features/auth/lib/sign-in-schema.test.ts
@@ -1,0 +1,17 @@
+import { parse } from 'valibot'
+import { expect, test } from 'vitest'
+
+import { PASSWORD_MAX_LENGTH } from '../domain/password-policy'
+import { passwordSchema } from './sign-in-schema'
+
+test('accepts a password at the maximum length', () => {
+  const password = 'a'.repeat(PASSWORD_MAX_LENGTH)
+
+  expect(parse(passwordSchema, password)).toBe(password)
+})
+
+test('rejects a password over the maximum length', () => {
+  const password = 'a'.repeat(PASSWORD_MAX_LENGTH + 1)
+
+  expect(() => parse(passwordSchema, password)).toThrow()
+})

--- a/src/features/auth/lib/sign-in-schema.ts
+++ b/src/features/auth/lib/sign-in-schema.ts
@@ -1,4 +1,16 @@
-import { brand, object, email, nonEmpty, string, minLength, pipe, InferOutput } from 'valibot'
+import {
+  brand,
+  email,
+  InferOutput,
+  maxLength,
+  minLength,
+  nonEmpty,
+  object,
+  pipe,
+  string
+} from 'valibot'
+
+import { PASSWORD_MAX_LENGTH } from '../domain/password-policy'
 
 export const emailSchema = pipe(
   string('Please enter your email.'),
@@ -11,6 +23,7 @@ export const passwordSchema = pipe(
   string('Please enter your password.'),
   nonEmpty('Please enter your password.'),
   minLength(8, 'Your password must have 8 characters or more.'),
+  maxLength(PASSWORD_MAX_LENGTH, 'Your password must have 128 characters or fewer.'),
   brand('Password')
 )
 

--- a/src/routes/api/auth/$.ts
+++ b/src/routes/api/auth/$.ts
@@ -1,12 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import { getAuth } from '../../../features/auth/functions/get-auth.server'
+import { guardSignInRequest } from '../../../features/auth/functions/guard-sign-in-request.server'
 
 export const Route = createFileRoute('/api/auth/$')({
   server: {
     handlers: {
       GET: async ({ request }: { request: Request }) => getAuth().handler(request),
-      POST: async ({ request }: { request: Request }) => getAuth().handler(request)
+      POST: async ({ request }: { request: Request }) =>
+        guardSignInRequest(request, () => getAuth().handler(request))
     }
   }
 })


### PR DESCRIPTION
## Summary

- Add a shared 128-character password limit to the client schema and Better Auth configuration.
- Reject oversized sign-in requests before Better Auth hash/verify, including bounded request-body handling.
- Add boundary, streaming, content-type, Unicode, delegation, and malformed-input tests.

Closes #181

## Security Validation

A separate DeepSeek V4 Flash agent performed adversarial validation. It identified and helped close the form-urlencoded bypass and unbounded JSON parsing paths. A second audit found no remaining High/Medium findings.

## Test Plan

- [x] `pnpm run test` (104 tests passed)
- [x] `pnpm run format:check`
- [x] `pnpm run lint`
- [x] `pnpm run lint:markup`
- [x] `pnpm run typecheck`
- [x] `pnpm run build`
