### PR TITLE
refactor(ui): migrate from Base UI to React Aria Components

### DIFF
--- a/REACT-ARIA-MIGRATION-NOTES.md
+++ b/REACT-ARIA-MIGRATION-NOTES.md
@@ -1,0 +1,221 @@
+# React Aria Components 移行ノート（Base UI → react-aria-components）
+
+このノートは Base UI (`@base-ui/react`) から React Aria Components
+(`react-aria-components@1.20.0`) への移行で得た勘所をまとめたものです。
+Button / Input / Dialog を移行するエージェントは先にこれを読んでください。
+
+- 対象バージョン: `react-aria-components@1.20.0`（`react-aria@3.51.0` が依存に入る）
+- catalog: `pnpm-workspace.yaml` の `catalogs.ui` に `react-aria-components: 1.20.0`
+- 依存: `package.json` の dependencies に `"react-aria-components": "catalog:ui"`
+- インポートは**サブパス**推奨（ツリーシェイキングのため）:
+  - `react-aria-components/Button`
+  - `react-aria-components/Input`
+  - `react-aria-components/Dialog`（`Dialog`, `DialogTrigger`）
+  - `react-aria-components/Modal`（`Modal`, `ModalOverlay`）
+  - `react-aria-components/Heading`
+  - `react-aria-components/Text`
+
+---
+
+## 0. 全体共通の注意点
+
+### `exactOptionalPropertyTypes` が有効
+
+`tsconfig` が `exactOptionalPropertyTypes: true`。RAC の props は
+`undefined` を許容しない任意プロパティが多いため、`undefined` になり得る値を
+そのまま `onClick={maybeUndef}` のように渡すと型エラーになる。
+回避策: `?? false` / `?? 既定値` で確定値にするか、条件付きで spread する。
+（`StyledButton` では `isDisabled={disabled ?? false}` にしている。）
+
+### Panda の `styled()` は RAC コンポーネントをそのまま包める
+
+`styled(AriaButton, recipe)` は動作する。Panda の styled factory は
+variant キー（`visual`, `size`）と CSS プロパティ以外をそのまま本体へ転送し、
+`ref` も転送する（RAC 側は `forwardRef` 済み）。`className` は文字列で渡れば
+問題ない（RAC は関数も受け取るが、styled が計算した文字列をそのまま使える）。
+
+### SSR（Cloudflare Workers）での挙動
+
+- RAC の各モジュールは `client-only` を import するが、これは
+  `react-server` export 条件でのみ throw する。本プロジェクト（TanStack Start +
+  Vite + workerd）は `react-server` 条件を使わないため SSR でも import できる。
+- `Modal` / `ModalOverlay` は SSR 中は `null` を返す（`useIsSSR`）。クライアント
+  でハイドレート後に描画される。したがって SSR レンダリング結果にダイアログ本体が
+  出なくても正常。
+- `Button` / `Input` は SSR でもそのまま `<button>` / `<input>` として描画される。
+
+---
+
+## 1. Button（`styled-button/index.tsx`）
+
+### Base UI との API 差
+
+| Base UI    | React Aria                   | 備考                                                                       |
+| ---------- | ---------------------------- | -------------------------------------------------------------------------- |
+| `disabled` | `isDisabled`                 | RAC はネイティブ `disabled` 属性を `isDisabled` から生成する               |
+| `onClick`  | `onPress`（推奨）/ `onClick` | RAC の `onClick` は `onPress` の別名として**型・実行時ともサポート**される |
+| `type`     | `type`                       | デフォルトは同じく `'button'`                                              |
+
+### やったこと
+
+`StyledButton` は既存呼び出し側（`disabled` / `onClick` / `type` / `visual` /
+`size` を使う多数のファイル）を壊さないよう、**公開 API を維持**した:
+
+- 型に `disabled?: boolean` を追加し、本体で `isDisabled={disabled ?? false}` に変換。
+- `onClick` は RAC 側が元々型付けしているので**追加の型宣言は不要**。
+  （自分で `onClick?: MouseEventHandler` を足すと RAC 側の `onClick` 型と交差して
+  `exactOptionalPropertyTypes` でエラーになる。足さないこと。）
+- `type = 'button'` を既定のまま転送。
+
+### 動作確認済み
+
+- `disabled` → 実際の DOM に `disabled` 属性が出る（Panda の `_disabled`
+  (= `:is(:disabled, [disabled], [data-disabled], [aria-disabled=true])`) と
+  CSS `:disabled` が引き続き効く）。
+- `type="submit"` はフォーム送信を壊さない。RAC の `usePress` は
+  `type="submit"` / `type="reset"` のボタンで `preventDefault` しない
+  （`shouldPreventDefaultUp` 参照）。`bookmark-list-toolbar.tsx` の
+  `<StyledButton type="submit">` がこれに依存している。
+- ダイアログのトリガーとして使う場合、`DialogTrigger` 内なら
+  `PressResponder` コンテキストを `usePress` が購読して自動的に
+  トリガーとして接続される（`aria-expanded` / `aria-controls` が付く）。
+
+---
+
+## 2. Input（`styled-input/index.tsx`）
+
+### Base UI との API 差
+
+| Base UI                                        | React Aria                    | 備考                                        |
+| ---------------------------------------------- | ----------------------------- | ------------------------------------------- |
+| `onValueChange(value, details)`                | 無し（ネイティブ `onChange`） | Base UI 独自コールバック                    |
+| `value` / `defaultValue` / `disabled` / `type` | 同名でそのまま                | RAC `Input` は `InputHTMLAttributes` を継承 |
+
+### やったこと
+
+既存呼び出し側が `onValueChange={(newValue) => ...}` を使っているため、
+`StyledInput` で `onValueChange?: (value: string) => void` を受け続け、
+ネイティブ `onChange` から `event.currentTarget.value` を渡して互換にした。
+呼び出し側の `onChange` も併せて呼ぶ。
+
+```tsx
+const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+  onChange?.(event)
+  onValueChange?.(event.currentTarget.value)
+}
+```
+
+### 注意
+
+- RAC の `Input` は単体でも動く（`TextField` 内なら `InputContext` から
+  props をもらう）。今回は単体利用。
+- `aria-invalid` はネイティブ属性としてそのまま DOM に出る。RAC は
+  `aria-invalid` が truthy かつ `'false'` でないときに `data-invalid` を付与する。
+
+---
+
+## 3. Dialog（`mobile-shelf-dialog.tsx`, `bookmark-delete-dialog.tsx`）
+
+### 構造のマッピング
+
+Base UI と RAC では部品構成が異なる。RAC は「トリガー + オーバーレイ」を
+`DialogTrigger` で包み、オーバーレイは `ModalOverlay`（背景）> `Modal`
+（フォーカス閉じ込め・スクロールロックの箱）> `Dialog`（`role="dialog"` の
+意味的コンテナ）の 3 層になる。
+
+| Base UI                         | React Aria                                | 備考                                                                         |
+| ------------------------------- | ----------------------------------------- | ---------------------------------------------------------------------------- |
+| `Dialog.Root open onOpenChange` | `DialogTrigger isOpen onOpenChange`       | 制御状態はトリガーに置く                                                     |
+| `Dialog.Trigger`                | `Button`（`DialogTrigger` の最初の子）    | 押下可能な RAC コンポーネントである必要がある                                |
+| `Dialog.Portal`                 | （不要）                                  | `Modal`/`ModalOverlay` が自動でポータルする                                  |
+| `Dialog.Backdrop`               | `ModalOverlay`                            | 背景。`isDismissable` をここに付ける                                         |
+| `Dialog.Popup`                  | `Modal` + `Dialog`                        | 配置・見た目は `Dialog` に寄せると flex/gap が子に効く                       |
+| `Dialog.Title`                  | `Heading slot="title"`                    | Base UI は `<h2>` を出力するので `level={2}` を明示（RAC の既定 level は 3） |
+| `Dialog.Description`            | `Text slot="description" elementType="p"` | Base UI は `<p>` を出力するので `elementType="p"`                            |
+| `Dialog.Close`                  | `Button slot="close"`                     | `close()` を自動で呼ぶ（`children` render prop の `close` でも可）           |
+
+### 重要な挙動差・判断
+
+1. **`isDismissable` を必ず付ける。**
+   Base UI の `Dialog.Root` は既定で `dismissible`（背景クリック・Escape で閉じる）。
+   RAC の `ModalOverlay` は `isDismissable` の既定が `false`（背景クリックで閉じない）。
+   従来挙動を守るため `ModalOverlay` に `isDismissable` を渡した。
+   （Escape は RAC でも閉じるが、背景クリック dismissal は `isDismissable` が必要。）
+
+2. **見た目・余白は `Dialog`（`section`）に付ける。**
+   `dialog` / `shelfSheet` の CSS は `flex` / `gap` / `padding` を子
+   （見出し・説明・ボタン群）に直接効かせている。`Modal`（`div`）に付けると
+   `Dialog` という単一の子を介すため `gap` が効かなくなる。よって配置・箱・
+   内側レイアウトを丸ごと `Dialog` の `className` に渡した。
+   `Dialog` は `position: fixed` + `margin: auto` でセンタリング
+   （`dialog`）、あるいは下端固定（`shelfSheet`）になる。
+
+3. **トリガーは RAC の `Button`（または `Pressable`）である必要がある。**
+   素の `<button>` を `DialogTrigger` の子にすると
+   `PressResponder` に登録されず開発時に警告が出る。
+   トリガーに `button()` レシピを当てる場合は `className={button({...})}` を
+   RAC `Button` に渡す。
+
+4. **`aria-haspopup` は意図的に付かない。**
+   RAC の `useOverlayTrigger` はダイアログに `aria-haspopup` を付けない
+   （スクリーンリーダーがメニューと誤読するため、menu/listbox のみ付与）。
+   トリガーには `aria-expanded` / `aria-controls` が付く。これは Base UI との
+   意図的な差であり、修正しないこと。
+
+5. **`slot="close"` は v1.20 で使える。**
+   `Dialog` が `ButtonContext` に `close: { onPress }` を提供するため、
+   `<Button slot="close">` で閉じる。`children` の render prop
+   `{({ close }) => ...}` も使えるが、単純な閉じるボタンなら `slot="close"` が簡潔。
+
+6. **フォーカス時のアウトラインは既存グローバル CSS が処理する。**
+   `panda.config.ts` の `globalCss` に `[tabindex="-1"]:focus { outline: none !important }`
+   がある。RAC の `Dialog`（`section`）は開いたときにフォーカスされ
+   `tabindex="-1"` を持つため、このルールでアウトラインが消える。
+   個別に `outline: none` を足す必要はない。
+
+### `Dialog` に `aria-label` / 見出しが必要な点
+
+RAC は `Dialog` 内に `<Heading slot="title">`（または `aria-label`）が無いと
+開発時に警告を出す。本プロジェクトの両ダイアログは見出しがあるため問題なし。
+
+---
+
+## 4. テスト・検証
+
+- `pnpm run test`（Vitest / workers pool）はドメインロジック中心で UI を
+  レンダリングしないため、本移行で壊れない。
+- `pnpm run typecheck`（tsc）は、**本フェーズ担当ファイル起因のエラーが無い**
+  ことを確認済み。残るエラーは別エージェント担当ファイル
+  （`bookmark-workbench-form.tsx`, `bookmark-editor/`, `src/features/tags/`）が
+  まだ `@base-ui/react` を import していることによるもの。
+- `pnpm run build` / `pnpm run dev` は、上記の別担当ファイルが
+  `@base-ui/react` を解決できないため**現時点で失敗する**。これは本フェーズの
+  責務外であり、別エージェントが移行し次第通るようになる。
+- `markuplint`（a11y/マークアップ検査）は担当 4 ファイルとも pass。
+- `oxlint` の `jsx-props-no-spreading` 警告は移行前から存在する既存警告。
+
+### 動作確認（SSR スモークテストで検証済み、その後ファイルは削除）
+
+- `StyledButton disabled` → DOM に `disabled` 属性が出る。
+- `StyledButton type="submit"` → `type="submit"` が維持される。
+- `StyledInput value/type/onValueChange` → ネイティブ `<input>` として描画。
+- `DialogTrigger isOpen` + `ModalOverlay` + `Modal` + `Dialog` → クラッシュせず、
+  トリガーに `aria-expanded` / `aria-controls` が付く（SSR では Modal は null）。
+
+---
+
+## 5. 後続エージェントへの引き継ぎ
+
+- 未移行の `@base-ui/react` 直接 import は以下（別エージェント担当）。
+  これらは RAC の `Input` / `Button` 等へ置き換える必要がある:
+  - `src/features/bookmarks/components/bookmark-workbench-form.tsx`
+  - `src/features/bookmarks/components/bookmark-editor/bookmark-form/fields.tsx`
+  - `src/features/tags/components/inline-add-tag.tsx`
+  - `src/features/tags/components/tag-form.tsx`
+- 上記が `Input` を `onValueChange` 付きで使う場合は、
+  `StyledInput` を使うと `onValueChange` 互換がそのまま使える。
+  素の RAC `Input` に置き換えるなら `onValueChange` → `onChange`
+  （`event.currentTarget.value`）への書き換えが必要。
+- `disabled` を使うボタンは `isDisabled` へ。`onClick` は RAC でも動くが
+  新規コードは `onPress` 推奨。
+- ダイアログは本ノートの構造マッピングと `isDismissable` の項を参照。

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -4,22 +4,21 @@
   "provider": {
     "balian-token-plan-personal": {
       "npm": "@ai-sdk/anthropic",
-      "name": "Alibaba Cloud Model Studio",
+      "name": "QwenCloud",
       "options": {
         "baseURL": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/apps/anthropic/v1",
         "apiKey": "{env:QWEN_API_KEY}"
       },
       "models": {
-        "qwen3.8-max-preview": {
-          "name": "Qwen3.8 Max Preview",
+        "qwen3.8-max": {
+          "name": "Qwen3.8 Max",
           "contextWindow": 983616,
           "maxOutputTokens": 131072,
           "options": {
             "thinking": {
               "type": "enabled",
-              "budgetTokens": 99072
+              "budgetTokens": 262144
             },
-            "temperature": 0.6,
             "reasoning": true
           }
         }
@@ -38,7 +37,7 @@
     },
     "[QwenCloud] Qwen 3.8 Max": {
       "mode": "primary",
-      "model": "balian-token-plan-personal/qwen3.8-max-preview",
+      "model": "balian-token-plan-personal/qwen3.8-max",
       "tools": {
         "write": true,
         "edit": true,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@base-ui/react": "catalog:ui",
     "@better-auth/drizzle-adapter": "catalog:authentication",
     "@cloudflare/vite-plugin": "catalog:build",
     "@formisch/react": "catalog:form",
@@ -42,6 +41,7 @@
     "drizzle-orm": "catalog:database",
     "lucide-react": "catalog:ui",
     "react": "catalog:react",
+    "react-aria-components": "catalog:ui",
     "react-dom": "catalog:react",
     "react-error-boundary": "catalog:errors",
     "uuidv7": "catalog:uuid",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,9 +168,6 @@ catalogs:
       specifier: 7.0.2
       version: 7.0.2
   ui:
-    '@base-ui/react':
-      specifier: 1.6.0
-      version: 1.6.0
     '@pandacss/dev':
       specifier: 1.12.0
       version: 1.12.0
@@ -180,6 +177,9 @@ catalogs:
     postcss:
       specifier: 8.5.25
       version: 8.5.25
+    react-aria-components:
+      specifier: 1.20.0
+      version: 1.20.0
   uuid:
     uuidv7:
       specifier: 1.2.1
@@ -203,9 +203,6 @@ importers:
 
   .:
     dependencies:
-      '@base-ui/react':
-        specifier: catalog:ui
-        version: 1.6.0(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@better-auth/drizzle-adapter':
         specifier: catalog:authentication
         version: 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@tursodatabase/database-common@0.7.2)(@tursodatabase/database@0.7.2)(valibot@1.4.2(typescript@7.0.2))(zod@4.4.3))
@@ -254,6 +251,9 @@ importers:
       react:
         specifier: catalog:react
         version: 19.2.8
+      react-aria-components:
+        specifier: catalog:ui
+        version: 1.20.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-dom:
         specifier: catalog:react
         version: 19.2.8(react@19.2.8)
@@ -460,33 +460,6 @@ packages:
   '@babel/types@7.29.8':
     resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
-
-  '@base-ui/react@1.6.0':
-    resolution: {integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@date-fns/tz': ^1.2.0
-      '@types/react': ^17 || ^18 || ^19
-      date-fns: ^4.0.0
-      react: ^17 || ^18 || ^19
-      react-dom: ^17 || ^18 || ^19
-    peerDependenciesMeta:
-      '@date-fns/tz':
-        optional: true
-      '@types/react':
-        optional: true
-      date-fns:
-        optional: true
-
-  '@base-ui/utils@0.3.1':
-    resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
-    peerDependencies:
-      '@types/react': ^17 || ^18 || ^19
-      react: ^17 || ^18 || ^19
-      react-dom: ^17 || ^18 || ^19
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
 
   '@better-auth/core@1.6.25':
     resolution: {integrity: sha512-lMTlhtwyK4NpY9kPF+2rQCRKYpg136d3gM2xl8esxT1PjJx5Nh5YwZvxcYCIjDuO759sx6TCloJTuwcZGG6ZBw==}
@@ -868,21 +841,6 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@floating-ui/core@1.8.0':
-    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
-
-  '@floating-ui/dom@1.8.0':
-    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
-
-  '@floating-ui/react-dom@2.1.9':
-    resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-
-  '@floating-ui/utils@0.2.12':
-    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
-
   '@formisch/react@0.8.0':
     resolution: {integrity: sha512-ftuh+gnCP/82J0FQxYzzgENg5gIv0ZBQNmtu2/SQ9XuyfA8zBJIACGqtBdnCjReZdM76MxP6E/T0VbvwvZQ20A==}
     peerDependencies:
@@ -1078,6 +1036,15 @@ packages:
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
+
+  '@internationalized/date@3.12.3':
+    resolution: {integrity: sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==}
+
+  '@internationalized/number@3.6.7':
+    resolution: {integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==}
+
+  '@internationalized/string@3.2.10':
+    resolution: {integrity: sha512-PDx6//vHSpRnHfxqMqto11zQvhsaU74O3mKv2F/0eicGZcl9NLjQmGlbHz/LsJh5tLKp4A4L7ZVTzN1/MmMTvA==}
 
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0':
     resolution: {integrity: sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==}
@@ -2311,6 +2278,11 @@ packages:
     resolution: {integrity: sha512-Px/Hwhhyk2PubCA4ZaRFsfvwxhbxXsetJyvqC6aFFi8WhJhA+oVC33aTzuAeWmM3fhb4/8ce8YsHXI1d6ChcKg==}
     hasBin: true
 
+  '@react-types/shared@3.36.1':
+    resolution: {integrity: sha512-AzsuD9OfxTOZMMvTRhlN3oHBwOmFN7tDh27LzqmHt4+uOgPhJT7ZM7/kVs/8/o0WxayMUIk3hBmCFRHv1FUoag==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   '@rolldown/binding-android-arm64@1.2.2':
     resolution: {integrity: sha512-l7x215OGvo1s52JWmR8U/DAVzEDWBCIbTm28aeJV/WDTSHgcKXaZTuBT0hJMs5NggilfJTW3clZVvd24yfKJxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2602,6 +2574,9 @@ packages:
         optional: true
       '@tanstack/start-client-core':
         optional: true
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@t3-oss/env-core@0.13.11':
     resolution: {integrity: sha512-sM7GYY+KL7H/Hl0BE0inWfk3nRHZOLhmVn7sHGxaZt9FAR6KqREXAE+6TqKfiavfXmpRxO/OZ2QgKRd+oiBYRQ==}
@@ -3268,6 +3243,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -3462,6 +3441,9 @@ packages:
     resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
     engines: {node: '>=18.20'}
 
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -3591,8 +3573,8 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  deslop-js@0.9.5:
-    resolution: {integrity: sha512-PzxOcLcU/k1crrgjjxKcYH09ZILME0bnDgb0tToXjhIRhJT8e1e8i0/FL7kt6iMVVptFelws0tX/UQRgUoo2qg==}
+  deslop-js@0.9.6:
+    resolution: {integrity: sha512-ADY8/3JsK0epUcdXez54MhY4CGWeppT032Ko1fJkwFfmHog5hBJtMeihUeHs5PF7eG6Y17YbKcNQXSp3B67GRA==}
 
   detect-installed@2.0.4:
     resolution: {integrity: sha512-IpGo06Ff/rMGTKjFvVPbY9aE4mRT2XP3eYHC/ZS25LKDr2h8Gbv74Ez2q/qd7IYDqD9ZjI/VGedHNXsbKZ/Eig==}
@@ -4757,8 +4739,8 @@ packages:
       vite-plus:
         optional: true
 
-  oxlint-plugin-react-doctor@0.9.5:
-    resolution: {integrity: sha512-fwFrQy/93dqN+n873buCc+GsfPZznemW/X3dUtVClckB63amby+nA0xcz398vRFist7GQMXeNz1lYaxlE6sd5Q==}
+  oxlint-plugin-react-doctor@0.9.6:
+    resolution: {integrity: sha512-kk39ffbDFaL0UfAx7ndltBsxal1hRkr+qYYsSv57PsD+9DnjcV0Y0jZ6NYMhBmHuvPC7so2CN6dNml+fOGrpxw==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint-tsgolint@0.25.0:
@@ -4973,6 +4955,18 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  react-aria-components@1.20.0:
+    resolution: {integrity: sha512-BMbpIgoV9aELeBrB0Y120NgoigHb5OdcJwc+4e7uSnbTbamea6lo+gqcc4LAxzMaK3Jf+7LI1oCDE6yANsmxIQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react-aria@3.51.0:
+    resolution: {integrity: sha512-AyWLw0XR38cFPwBu/ErgGaVrc5dupLEKmRlMXTGvFKOtbaGRQ2+yQJkjVhpdHhoRhU4+G+tJDFeHDTS8tK3bfQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   react-docgen-typescript@2.4.0:
     resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
     peerDependencies:
@@ -4982,8 +4976,8 @@ packages:
     resolution: {integrity: sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==}
     engines: {node: ^20.9.0 || >=22}
 
-  react-doctor@0.9.5:
-    resolution: {integrity: sha512-RQPueMP8kdmJj0jryjmWtsmQAq8ZGFVprgGK6Hkdy1SozkGBJXL6zkzIsZ7ZTrIvETJIoPOa4maY1IlTXchhSw==}
+  react-doctor@0.9.6:
+    resolution: {integrity: sha512-X3ZLL6UQfzqIyY1HDKEgUOnoxKreEfy9KphiV2aYhiotgCsR81LBl92XgyZUbZeRgpQuwbIDOiyxQnRRkcX42A==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -5020,6 +5014,11 @@ packages:
       esbuild:
         optional: true
 
+  react-stately@3.49.0:
+    resolution: {integrity: sha512-13iNq2KzBrRAzxRc+n53hgROfIistiYY/sPtIhCw1qUB7/kmo+X1xEU2uiS5zcCIrc55AUPwoHqOIIpKWSwB9A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
@@ -5043,9 +5042,6 @@ packages:
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
-
-  reselect@5.2.0:
-    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resolve-dir@1.0.1:
     resolution: {integrity: sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==}
@@ -5863,29 +5859,6 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@base-ui/react@1.6.0(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@base-ui/utils': 0.3.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@floating-ui/utils': 0.2.12
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      use-sync-external-store: 1.6.0(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@base-ui/utils@0.3.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@floating-ui/utils': 0.2.12
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      reselect: 5.2.0
-      use-sync-external-store: 1.6.0(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.17
-
   '@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2)':
     dependencies:
       '@better-auth/utils': 0.4.2
@@ -6190,23 +6163,6 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@floating-ui/core@1.8.0':
-    dependencies:
-      '@floating-ui/utils': 0.2.12
-
-  '@floating-ui/dom@1.8.0':
-    dependencies:
-      '@floating-ui/core': 1.8.0
-      '@floating-ui/utils': 0.2.12
-
-  '@floating-ui/react-dom@2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@floating-ui/dom': 1.8.0
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-
-  '@floating-ui/utils@0.2.12': {}
-
   '@formisch/react@0.8.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(valibot@1.4.2(typescript@7.0.2))':
     dependencies:
       react: 19.2.8
@@ -6338,6 +6294,18 @@ snapshots:
 
   '@img/sharp-win32-x64@0.35.2':
     optional: true
+
+  '@internationalized/date@3.12.3':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
+  '@internationalized/number@3.6.7':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
+  '@internationalized/string@3.2.10':
+    dependencies:
+      '@swc/helpers': 0.5.23
 
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@7.0.2)(vite@8.2.0(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
@@ -7385,6 +7353,10 @@ snapshots:
       prompts: 2.4.2
       tinyexec: 1.3.0
 
+  '@react-types/shared@3.36.1(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+
   '@rolldown/binding-android-arm64@1.2.2':
     optional: true
 
@@ -7645,6 +7617,10 @@ snapshots:
       - supports-color
       - typescript
       - webpack
+
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
 
   '@t3-oss/env-core@0.13.11(typescript@7.0.2)(valibot@1.4.2(typescript@7.0.2))(zod@4.4.3)':
     optionalDependencies:
@@ -8396,6 +8372,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -8544,6 +8524,8 @@ snapshots:
 
   cli-spinners@3.4.0: {}
 
+  client-only@0.0.1: {}
+
   clsx@2.1.1: {}
 
   code-block-writer@13.0.3: {}
@@ -8658,7 +8640,7 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  deslop-js@0.9.5:
+  deslop-js@0.9.6:
     dependencies:
       '@oxc-project/types': 0.142.0
       fast-glob: 3.3.3
@@ -9733,7 +9715,7 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.61.0
       '@oxfmt/binding-win32-x64-msvc': 0.61.0
 
-  oxlint-plugin-react-doctor@0.9.5:
+  oxlint-plugin-react-doctor@0.9.6:
     dependencies:
       '@shaderfrog/glsl-parser': 7.0.1
       '@typescript-eslint/types': 8.66.0
@@ -9933,6 +9915,32 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  react-aria-components@1.20.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      '@internationalized/date': 3.12.3
+      '@internationalized/string': 3.2.10
+      '@react-types/shared': 3.36.1(react@19.2.8)
+      '@swc/helpers': 0.5.23
+      client-only: 0.0.1
+      react: 19.2.8
+      react-aria: 3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
+      react-stately: 3.49.0(react@19.2.8)
+
+  react-aria@3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      '@internationalized/date': 3.12.3
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.10
+      '@react-types/shared': 3.36.1(react@19.2.8)
+      '@swc/helpers': 0.5.23
+      aria-hidden: 1.2.6
+      clsx: 2.1.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-stately: 3.49.0(react@19.2.8)
+      use-sync-external-store: 1.6.0(react@19.2.8)
+
   react-docgen-typescript@2.4.0(typescript@7.0.2):
     dependencies:
       typescript: 7.0.2
@@ -9952,7 +9960,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-doctor@0.9.5(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint-tsgolint@0.25.0)(supports-color@10.2.2):
+  react-doctor@0.9.6(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint-tsgolint@0.25.0)(supports-color@10.2.2):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@babel/code-frame': 7.29.7
@@ -9960,14 +9968,14 @@ snapshots:
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.9.5
+      deslop-js: 0.9.6
       eslint-plugin-react-hooks: 7.1.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
       figures: 6.1.0
       jiti: 2.7.0
       magicast: 0.5.4
       oxc-resolver: 11.24.2
       oxlint: 1.76.0(oxlint-tsgolint@0.25.0)
-      oxlint-plugin-react-doctor: 0.9.5
+      oxlint-plugin-react-doctor: 0.9.6
       prompts: 2.4.2
       typescript: 5.9.3
       vscode-languageserver: 9.0.1
@@ -10013,7 +10021,7 @@ snapshots:
       preact: 10.29.8
       prompts: 2.4.2
       react: 19.2.8
-      react-doctor: 0.9.5(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint-tsgolint@0.25.0)(supports-color@10.2.2)
+      react-doctor: 0.9.6(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint-tsgolint@0.25.0)(supports-color@10.2.2)
       react-dom: 19.2.8(react@19.2.8)
       react-grab: 0.1.50(react@19.2.8)
     optionalDependencies:
@@ -10035,6 +10043,16 @@ snapshots:
       - vite
       - vite-plus
       - webpack
+
+  react-stately@3.49.0(react@19.2.8):
+    dependencies:
+      '@internationalized/date': 3.12.3
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.10
+      '@react-types/shared': 3.36.1(react@19.2.8)
+      '@swc/helpers': 0.5.23
+      react: 19.2.8
+      use-sync-external-store: 1.6.0(react@19.2.8)
 
   react@19.2.8: {}
 
@@ -10061,8 +10079,6 @@ snapshots:
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
-
-  reselect@5.2.0: {}
 
   resolve-dir@1.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -75,8 +75,8 @@ catalogs:
     storybook-device-viewports: 0.1.2
     storybook: 10.5.5
   ui:
-    '@base-ui/react': 1.6.0
     '@pandacss/dev': 1.12.0
+    react-aria-components: 1.20.0
     lucide-react: 1.28.0
     postcss: 8.5.25
   uuid:

--- a/src/features/app-shell/components/mobile-shelf-dialog.tsx
+++ b/src/features/app-shell/components/mobile-shelf-dialog.tsx
@@ -1,6 +1,9 @@
-import { Dialog } from '@base-ui/react/dialog'
 import { Menu, X } from 'lucide-react'
 import { useState } from 'react'
+import { Button } from 'react-aria-components/Button'
+import { Dialog, DialogTrigger } from 'react-aria-components/Dialog'
+import { Heading } from 'react-aria-components/Heading'
+import { Modal, ModalOverlay } from 'react-aria-components/Modal'
 import { css } from 'styled-system/css'
 
 import type { ShelfNavSelection } from '../../tags/components/shelf-nav'
@@ -92,36 +95,46 @@ export function MobileShelfDialog({
   }
 
   return (
-    <Dialog.Root
-      open={shelfOpen}
+    <DialogTrigger
+      isOpen={shelfOpen}
       onOpenChange={setShelfOpen}>
-      <Dialog.Trigger className={shelfChanger}>
+      <Button className={shelfChanger}>
         <Menu
           size={16}
           aria-hidden
         />{' '}
         棚を変える
-      </Dialog.Trigger>
-      <Dialog.Portal>
-        <Dialog.Backdrop className={shelfSheetBackdrop} />
-        <Dialog.Popup className={shelfSheet}>
-          <div className={shelfSheetHeader}>
-            <Dialog.Title className={shelfSheetTitle}>棚を選ぶ</Dialog.Title>
-            <Dialog.Close className={shelfSheetClose}>
-              <X
-                size={16}
-                aria-hidden
-              />{' '}
-              閉じる
-            </Dialog.Close>
-          </div>
-          <ShelfNavPanel
-            shelfTagsPromise={shelfTagsPromise}
-            selection={selection}
-            onNavigate={closeShelf}
-          />
-        </Dialog.Popup>
-      </Dialog.Portal>
-    </Dialog.Root>
+      </Button>
+      <ModalOverlay
+        className={shelfSheetBackdrop}
+        isDismissable>
+        <Modal>
+          <Dialog className={shelfSheet}>
+            <div className={shelfSheetHeader}>
+              <Heading
+                slot='title'
+                level={2}
+                className={shelfSheetTitle}>
+                棚を選ぶ
+              </Heading>
+              <Button
+                slot='close'
+                className={shelfSheetClose}>
+                <X
+                  size={16}
+                  aria-hidden
+                />{' '}
+                閉じる
+              </Button>
+            </div>
+            <ShelfNavPanel
+              shelfTagsPromise={shelfTagsPromise}
+              selection={selection}
+              onNavigate={closeShelf}
+            />
+          </Dialog>
+        </Modal>
+      </ModalOverlay>
+    </DialogTrigger>
   )
 }

--- a/src/features/bookmarks/components/bookmark-delete-dialog.tsx
+++ b/src/features/bookmarks/components/bookmark-delete-dialog.tsx
@@ -1,7 +1,11 @@
-import { Dialog } from '@base-ui/react/dialog'
 import { useNavigate } from '@tanstack/react-router'
 import { Trash2, X } from 'lucide-react'
 import { useState, useTransition } from 'react'
+import { Button } from 'react-aria-components/Button'
+import { Dialog, DialogTrigger } from 'react-aria-components/Dialog'
+import { Heading } from 'react-aria-components/Heading'
+import { Modal, ModalOverlay } from 'react-aria-components/Modal'
+import { Text } from 'react-aria-components/Text'
 
 import { StyledButton } from '../../../shared/components/styled-button'
 import { button } from '../../../styles/button'
@@ -39,60 +43,71 @@ export function BookmarkDeleteDialog({
   }
 
   return (
-    <Dialog.Root
-      open={deleteOpen}
+    <DialogTrigger
+      isOpen={deleteOpen}
       onOpenChange={(open) => {
         setDeleteOpen(open)
         if (!open) {
           setDeleteError(null)
         }
       }}>
-      <Dialog.Trigger
+      <Button
         className={button({ visual: 'danger' })}
-        disabled={isDeleting}>
+        isDisabled={isDeleting}>
         <Trash2
           size={16}
           aria-hidden
         />{' '}
         削除
-      </Dialog.Trigger>
-      <Dialog.Portal>
-        <Dialog.Backdrop className={dialogBackdrop} />
-        <Dialog.Popup className={dialog}>
-          <Dialog.Title className={dialogTitle}>このブックマークを削除しますか？</Dialog.Title>
-          <Dialog.Description>
-            「{bookmark.title}」を削除します。一覧からは見えなくなります。
-          </Dialog.Description>
-          {deleteError ? (
-            <p
-              className={fieldError}
-              role='alert'>
-              {deleteError}
-            </p>
-          ) : null}
-          <div className={dialogActions}>
-            <Dialog.Close
-              className={button()}
-              disabled={isDeleting}>
-              <X
-                size={16}
-                aria-hidden
-              />{' '}
-              キャンセル
-            </Dialog.Close>
-            <StyledButton
-              visual='danger'
-              onClick={handleDelete}
-              disabled={isDeleting}>
-              <Trash2
-                size={16}
-                aria-hidden
-              />{' '}
-              {isDeleting ? '削除中…' : '削除を確認'}
-            </StyledButton>
-          </div>
-        </Dialog.Popup>
-      </Dialog.Portal>
-    </Dialog.Root>
+      </Button>
+      <ModalOverlay
+        className={dialogBackdrop}
+        isDismissable>
+        <Modal>
+          <Dialog className={dialog}>
+            <Heading
+              slot='title'
+              level={2}
+              className={dialogTitle}>
+              このブックマークを削除しますか？
+            </Heading>
+            <Text
+              slot='description'
+              elementType='p'>
+              「{bookmark.title}」を削除します。一覧からは見えなくなります。
+            </Text>
+            {deleteError ? (
+              <p
+                className={fieldError}
+                role='alert'>
+                {deleteError}
+              </p>
+            ) : null}
+            <div className={dialogActions}>
+              <Button
+                slot='close'
+                className={button()}
+                isDisabled={isDeleting}>
+                <X
+                  size={16}
+                  aria-hidden
+                />{' '}
+                キャンセル
+              </Button>
+              <StyledButton
+                visual='danger'
+                onClick={handleDelete}
+                disabled={isDeleting}>
+                <Trash2
+                  size={16}
+                  aria-hidden
+                />{' '}
+                {isDeleting ? '削除中…' : '削除を確認'}
+              </StyledButton>
+            </div>
+          </Dialog>
+        </Modal>
+      </ModalOverlay>
+    </DialogTrigger>
   )
 }

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/fields.tsx
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/fields.tsx
@@ -1,8 +1,8 @@
-import { Input } from '@base-ui/react'
 import { Field, setErrors } from '@formisch/react'
 import { Download } from 'lucide-react'
 
 import { StyledButton } from '../../../../../shared/components/styled-button'
+import { StyledInput } from '../../../../../shared/components/styled-input'
 import { field, fieldError, fieldInput, fieldLabel, fieldUrlRow } from '../../../../../styles/form'
 import type { BookmarkFormFieldKey, BookmarkFormServerError, BookmarkFormStore } from './types'
 
@@ -71,7 +71,7 @@ export function BookmarkFormFields({
                 URL
               </label>
               <div className={fieldUrlRow}>
-                <Input
+                <StyledInput
                   id={ids.url}
                   name={fieldProps.props.name}
                   ref={(element) => {
@@ -126,7 +126,7 @@ export function BookmarkFormFields({
                 className={fieldLabel}>
                 タイトル
               </label>
-              <Input
+              <StyledInput
                 id={ids.title}
                 name={fieldProps.props.name}
                 ref={(element) => {
@@ -169,7 +169,7 @@ export function BookmarkFormFields({
                 className={fieldLabel}>
                 メモ
               </label>
-              <Input
+              <StyledInput
                 id={ids.note}
                 name={fieldProps.props.name}
                 ref={(element) => {

--- a/src/features/bookmarks/components/bookmark-workbench-form.tsx
+++ b/src/features/bookmarks/components/bookmark-workbench-form.tsx
@@ -1,10 +1,10 @@
-import { Input } from '@base-ui/react'
 import { Field, getErrors, getInput, useForm, validate } from '@formisch/react'
 import { CircleAlert, Download } from 'lucide-react'
 import { useActionState, useState } from 'react'
 import * as v from 'valibot'
 
 import { StyledButton } from '../../../shared/components/styled-button'
+import { StyledInput } from '../../../shared/components/styled-input'
 import {
   field,
   fieldError,
@@ -128,7 +128,7 @@ export function BookmarkWorkbenchForm({
                 URL
               </label>
               <div className={fieldUrlRow}>
-                <Input
+                <StyledInput
                   id={f.props.name}
                   className={fieldInput}
                   value={f.input}
@@ -166,7 +166,7 @@ export function BookmarkWorkbenchForm({
                 className={fieldLabel}>
                 タイトル
               </label>
-              <Input
+              <StyledInput
                 id={f.props.name}
                 className={fieldInput}
                 value={f.input}
@@ -192,7 +192,7 @@ export function BookmarkWorkbenchForm({
                 className={fieldLabel}>
                 メモ
               </label>
-              <Input
+              <StyledInput
                 id={f.props.name}
                 className={fieldInput}
                 value={f.input ?? ''}

--- a/src/features/tags/components/inline-add-tag.tsx
+++ b/src/features/tags/components/inline-add-tag.tsx
@@ -1,4 +1,3 @@
-import { Input } from '@base-ui/react'
 import { useNavigate } from '@tanstack/react-router'
 import { Plus } from 'lucide-react'
 import { useState } from 'react'
@@ -6,7 +5,8 @@ import { css } from 'styled-system/css'
 import * as v from 'valibot'
 
 import { StyledButton } from '../../../shared/components/styled-button'
-import { field, fieldError, fieldInput, fieldLabel, fieldUrlRow } from '../../../styles/form'
+import { StyledInput } from '../../../shared/components/styled-input'
+import { field, fieldError, fieldLabel, fieldUrlRow } from '../../../styles/form'
 import { addTag } from '../functions/add-tag'
 import { tagNameSchema } from '../lib/tag-name-schema'
 
@@ -61,11 +61,9 @@ export function InlineAddTag() {
           クイック追加
         </label>
         <div className={fieldUrlRow}>
-          <Input
-            className={fieldInput}
+          <StyledInput
             id='inline-add-tag-name'
             value={name}
-            type='text'
             onValueChange={(newValue) => {
               setName(newValue)
             }}

--- a/src/features/tags/components/tag-form.tsx
+++ b/src/features/tags/components/tag-form.tsx
@@ -1,11 +1,11 @@
-import { Input } from '@base-ui/react'
 import { Field, getInput, useForm } from '@formisch/react'
 import { CircleAlert } from 'lucide-react'
 import { useActionState, useState } from 'react'
 import * as v from 'valibot'
 
 import { StyledButton } from '../../../shared/components/styled-button'
-import { field, fieldInput, fieldLabel, formSummary } from '../../../styles/form'
+import { StyledInput } from '../../../shared/components/styled-input'
+import { field, fieldLabel, formSummary } from '../../../styles/form'
 import { srOnly } from '../../../styles/sr-only'
 import { workbenchFields, workbenchForm } from '../../../styles/workbench'
 import { TagEditFields } from './tag-edit-fields'
@@ -93,11 +93,9 @@ export function TagForm({
                 htmlFor={fieldProps.props.name}>
                 タグ名
               </label>
-              <Input
-                className={fieldInput}
+              <StyledInput
                 id={fieldProps.props.name}
                 value={fieldProps.input}
-                type='text'
                 onValueChange={(newValue) => {
                   fieldProps.onChange(newValue)
                 }}

--- a/src/shared/components/styled-button/index.tsx
+++ b/src/shared/components/styled-button/index.tsx
@@ -1,17 +1,18 @@
 /**
  * @file index.tsx
  *
- * Input:    Base UI `Button`, Panda `styled` factory
+ * Input:    React Aria Components `Button`, Panda `styled` factory
  * Output:   StyledButton component
  * Position: Shared UI primitive; documented by index.stories.tsx
  *
  * SYNC: When modified, update these files to stay in sync:
  * - ./index.stories.tsx (stories for new/changed variants)
  *
- * Last synced props: visual, size, type, className, css, plus every Panda style prop
+ * Last synced props: visual, size, type, disabled, onClick, className, css,
+ * plus every Panda style prop and React Aria Button prop
  */
 
-import { Button as BaseButton } from '@base-ui/react/button'
+import { Button as AriaButton } from 'react-aria-components/Button'
 import { styled } from 'styled-system/jsx'
 import type { HTMLStyledProps } from 'styled-system/types'
 
@@ -19,27 +20,34 @@ import { button } from '../../../styles/button'
 
 /**
  * Intentionally not exported. Consumers get `StyledButton` (or the `button`
- * recipe for className composition) instead of a bare styled Base UI Button.
+ * recipe for className composition) instead of a bare styled React Aria Button.
  */
-const RawButton = styled(BaseButton, button)
+const RawButton = styled(AriaButton, button)
 
 /**
  * NOT `StyledVariantProps`: that helper resolves to the recipe's variant record
- * alone and drops both Base UI / native button props and `JsxStyleProps`.
+ * alone and drops both React Aria / native button props and `JsxStyleProps`.
  * `HTMLStyledProps` keeps those attributes and style props while still
  * carrying the recipe variants.
+ *
+ * `disabled` is re-declared because React Aria spells it `isDisabled`, but
+ * existing call sites rely on the native `disabled` attribute spelling. It is
+ * forwarded as `isDisabled` below. `onClick` already exists on the React Aria
+ * Button props (as an alias of `onPress`) and flows through untouched.
  */
-type StyledButtonProps = HTMLStyledProps<typeof RawButton>
+type StyledButtonProps = HTMLStyledProps<typeof RawButton> & {
+  disabled?: boolean
+}
 
 /**
- * Deliberately a plain pass-through (plus a safe `type` default).
+ * Deliberately a thin pass-through over the styled React Aria Button.
  *
- * NOT the `splitCssProps` + `css()` wrapper from the Panda docs: `RawButton`
- * is already a styled component, so it performs that split internally and
- * folds the caller's `className` via `cx(...)`. Repeating the split one layer
- * up would overwrite `props.className`.
+ * `disabled` is mapped to React Aria's `isDisabled` (React Aria renders the
+ * native `disabled` attribute from it, so `_disabled` recipe styles and CSS
+ * `:disabled` selectors keep working).
  *
- * No `forwardRef`: React 19 delivers `ref` as an ordinary prop.
+ * No `forwardRef`: React 19 delivers `ref` as an ordinary prop and the Panda
+ * styled factory already forwards it.
  *
  * Defaults `type` to `"button"` when unset so forms do not accidentally submit.
  *
@@ -51,10 +59,11 @@ type StyledButtonProps = HTMLStyledProps<typeof RawButton>
  * <StyledButton type="submit" visual="accent">送信</StyledButton>
  * ```
  */
-export function StyledButton({ type = 'button', ...props }: StyledButtonProps) {
+export function StyledButton({ type = 'button', disabled, ...props }: StyledButtonProps) {
   return (
     <RawButton
       type={type}
+      isDisabled={disabled ?? false}
       {...props}
     />
   )

--- a/src/shared/components/styled-input/index.tsx
+++ b/src/shared/components/styled-input/index.tsx
@@ -1,8 +1,9 @@
-import { Input as BaseInput } from '@base-ui/react/input'
+import type { ChangeEvent } from 'react'
+import { Input as AriaInput } from 'react-aria-components/Input'
 import { styled } from 'styled-system/jsx'
 import type { HTMLStyledProps } from 'styled-system/types'
 
-const RawInput = styled(BaseInput, {
+const RawInput = styled(AriaInput, {
   base: {
     minBlockSize: 'touch',
     borderWidth: 'thin',
@@ -17,12 +18,40 @@ const RawInput = styled(BaseInput, {
   }
 })
 
-type StyledInputProps = HTMLStyledProps<typeof RawInput>
+/**
+ * `HTMLStyledProps` keeps the native input attributes (including `disabled`,
+ * `value`, `onChange`) and the Panda style props. `onValueChange` is re-added
+ * because it is the Base UI spelling that existing call sites rely on; React
+ * Aria's `Input` only exposes the native `onChange`.
+ */
+type StyledInputProps = HTMLStyledProps<typeof RawInput> & {
+  onValueChange?: (value: string) => void
+}
 
-export function StyledInput({ type = 'text', ...props }: StyledInputProps) {
+/**
+ * Thin adapter over the styled React Aria `Input`.
+ *
+ * Maps the Base UI-style `onValueChange(value)` callback onto the native
+ * `onChange` event so existing controlled call sites keep working unchanged.
+ * Any caller-provided `onChange` is invoked as well.
+ *
+ * Defaults `type` to `"text"` when unset.
+ */
+export function StyledInput({
+  type = 'text',
+  onValueChange,
+  onChange,
+  ...props
+}: StyledInputProps) {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange?.(event)
+    onValueChange?.(event.currentTarget.value)
+  }
+
   return (
     <RawInput
       type={type}
+      onChange={handleChange}
       {...props}
     />
   )


### PR DESCRIPTION
## 概要

UIコンポーネントライブラリを Base UI (`@base-ui/react`) から React Aria Components (`react-aria-components`) に移行する。

## 変更内容

| ファイル | 内容 |
| --- | --- |
| `pnpm-workspace.yaml` / `package.json` | `@base-ui/react: 1.6.0` → `react-aria-components: 1.20.0`（pnpm catalog `ui`） |
| `styled-button/index.tsx` | RAC `Button` に置換。公開API維持のため `disabled` を `isDisabled` に変換するアダプタ方式 |
| `styled-input/index.tsx` | RAC `Input` に置換。`onValueChange(value)` コールバックをネイティブ `onChange` に接続するアダプタ方式 |
| `mobile-shelf-dialog.tsx` / `bookmark-delete-dialog.tsx` | `Dialog.*` → `DialogTrigger` + `ModalOverlay`(`isDismissable`) + `Modal` + `Dialog` + `Heading slot="title"` / `Text slot="description"` / `Button slot="close"` |
| bookmarks / tags のフォーム4ファイル | 素の Base UI `Input` を `StyledInput` に置き換え（`onValueChange` 互換のため呼び出し側は無変更） |

## 設計上の判断

- `StyledButton` / `StyledInput` は薄いアダプタとして公開API（`disabled` / `onValueChange`）を維持し、呼び出し側への波及を最小化した
- ダイアログは Base UI 既定の「背景クリック・Escapeで閉じる」を `isDismissable` で再現
- RAC の仕様上、ダイアログトリガーに `aria-haspopup` は付かない（`aria-expanded` / `aria-controls` のみ）
- ツリーシェイキングのためサブパス import（`react-aria-components/Button` 等）を採用
- 詳細な移行勘所は `REACT-ARIA-MIGRATION-NOTES.md` を参照

## 検証

- `pnpm run typecheck`: エラー0件
- `pnpm run test`: 23ファイル / 80テスト pass
- `pnpm run build`: 成功
- `markuplint`: 変更ファイル全て pass
- pre-commit hook（oxfmt / oxlint / markuplint / tsc）pass（oxlint警告は移行前から存在するもののみ）
