### PR TITLE
refactor(ui): migrate from Base UI to React Aria Components

### DIFF
--- a/docs/superpowers/specs/2026-08-09-migrate-base-ui-to-react-aria-components-design.md
+++ b/docs/superpowers/specs/2026-08-09-migrate-base-ui-to-react-aria-components-design.md
@@ -1,0 +1,166 @@
+# Base UIからReact Aria Componentsへの移行設計
+
+## 目的
+
+PantryのUIコンポーネントライブラリを`@base-ui/react`から`react-aria-components`へ移行する。
+
+移行後も既存の画面構成、Panda CSSの見た目、Formischのフォーム状態管理、Storybookの検証方針を維持する。
+
+`@base-ui/react`の参照と依存関係をリポジトリからなくし、React Aria Componentsが提供するpress semantics、focus管理、modalのアクセシビリティ挙動を利用する。
+
+## 現状
+
+Base UIの利用箇所は次の範囲に限られる。
+
+- 共有の`StyledButton`
+- 共有の`StyledInput`
+- モバイル棚シートのDialog
+- ブックマーク削除確認のDialog
+- ブックマークフォーム、タグフォーム、タグのクイック追加フォームにあるInput
+
+フォームのvalidation、server error、タイトル取得、送信処理はBase UIの責務ではないため、移行対象に含めない。
+
+## 決定事項
+
+### 依存関係
+
+`react-aria-components`をアプリケーション依存関係へ追加する。
+
+`@base-ui/react`を`package.json`、`pnpm-workspace.yaml`、lockfileから削除する。
+
+ソース、Storybook、テスト、ドキュメントに残るBase UIのimportと名称も削除する。
+
+### 共有Button
+
+`src/shared/components/styled-button/index.tsx`の`StyledButton`は、React Aria Componentsの`Button`を基盤にする。
+
+既存の`visual`と`size`のPanda recipeは維持する。
+
+React Aria Componentsの状態属性を既存のrecipeへ接続し、次の挙動を保つ。
+
+- `type`の既定値は`button`
+- `visual`と`size`による外観
+- `isDisabled`時の操作抑止とdisabled表示
+- フォーム内のsubmit、cancel、danger操作
+- `className`とPanda style propsの受け渡し
+
+既存の呼び出し側がDOM属性の`disabled`を使っている場合は、React Aria ComponentsのAPIに合わせて`isDisabled`へ更新する。
+
+### 共有Input
+
+`src/shared/components/styled-input/index.tsx`の`StyledInput`は、React Aria Componentsの`Input`を基盤にする。
+
+現在のpadding、border、background、width、touch targetのスタイルを維持する。
+
+React Aria ComponentsのInputが提供する標準の`onChange`、`value`、`ref`、HTML input属性を利用する。
+
+### フォームInput
+
+Base UIの`Input`を直接importしているフォームをReact Aria Componentsまたは共有の`StyledInput`へ置き換える。
+
+`onValueChange`は使わず、`onChange`で受け取った文字列をFormischの`fieldProps.onChange`または既存のstate setterへ渡す。
+
+次の契約は変更しない。
+
+- `id`と`label`の関連付け
+- `name`とFormischのfield ref
+- `required`、`autocomplete`
+- `aria-invalid`、`aria-describedby`
+- フィールドエラーとserver errorの優先順位
+- URL入力からのタイトル取得
+
+### Dialog
+
+Base UIのDialogを、React Aria Componentsの次の構成へ置き換える。
+
+```tsx
+<DialogTrigger>
+  <Button>...</Button>
+  <ModalOverlay>
+    <Modal>
+      <Dialog>
+        <Heading slot='title'>...</Heading>
+        ...
+      </Dialog>
+    </Modal>
+  </ModalOverlay>
+</DialogTrigger>
+```
+
+モバイル棚シートと削除確認Dialogは、それぞれ既存のPanda CSSを使い続ける。
+
+React Aria Componentsへ次の挙動を委譲する。
+
+- Escapeによる閉じる操作
+- 外側クリックによる閉じる操作
+- 開いたときの初期フォーカス
+- 背景コンテンツの操作抑止
+- 閉じた後のtriggerへのフォーカス復帰
+
+削除処理中の`deleteError`、`isDeleting`、navigation、モバイル棚の`onNavigate`は既存の状態管理を維持する。
+
+### SSR
+
+TanStack StartのSSRを維持する。
+
+overlayはReact Aria Componentsの`ModalOverlay`と`Modal`を使い、windowやdocumentを参照する独自のclient-only処理は追加しない。
+
+## データフローとエラー
+
+ライブラリ移行によって、フォームのデータフローは変更しない。
+
+入力イベントは次の経路を通る。
+
+```text
+React Aria Input
+  -> onChange
+  -> Formisch fieldProps.onChange または state setter
+  -> 既存のvalidation / submit / server error処理
+```
+
+Buttonのpress処理はReact Aria Componentsへ移行するが、既存の非同期処理とエラー所有権は各feature componentに残す。
+
+削除確認のエラーはDialog内の`role="alert"`として表示し、棚シートのnavigation後にDialogが閉じる契約も維持する。
+
+## 検証
+
+### 静的検証
+
+- `@base-ui/react`のソース参照がゼロである
+- `pnpm run format:check`
+- `pnpm run lint`
+- `pnpm run lint:markup`
+- `pnpm run typecheck`
+
+### 自動検証
+
+- `pnpm run test`
+- `pnpm run build`
+- Storybook build
+
+### UI検証
+
+- Buttonのdefault、accent、danger、size、disabled表示
+- フォームの入力、validation error、server error、タイトル取得、送信
+- 削除Dialogの開閉、Escape、外側クリック、キャンセル、削除失敗、フォーカス復帰
+- モバイル棚シートの開閉、Escape、棚選択後の閉じる処理
+- デスクトップ幅とモバイル幅
+- キーボード操作とアクセシビリティツリー上のlabel、dialog title、error announcement
+
+## 完了条件
+
+次の条件をすべて満たしたとき、移行完了とする。
+
+1. `@base-ui/react`が依存関係、ソース、テスト、Storybook、ドキュメントから削除されている。
+2. `react-aria-components`を使ったButton、Input、Dialogが既存の画面で動作する。
+3. 既存の視覚スタイルとフォームのデータフローが維持されている。
+4. 静的検証、自動検証、Storybook buildが成功する。
+5. キーボード操作、focus管理、error announcementを確認できる。
+
+## 作業分離
+
+既存の`migrate-react-aria` worktreeと`aria-core`エージェントには触れない。
+
+実装はHerdrで新規worktreeを作成し、そのworktree上でCursorエージェントを起動して行う。
+
+実装完了後は、Cursorエージェントの差分を確認してから検証を実行する。

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@base-ui/react": "catalog:ui",
     "@better-auth/drizzle-adapter": "catalog:authentication",
     "@cloudflare/vite-plugin": "catalog:build",
     "@formisch/react": "catalog:form",
@@ -42,6 +41,7 @@
     "drizzle-orm": "catalog:database",
     "lucide-react": "catalog:ui",
     "react": "catalog:react",
+    "react-aria-components": "catalog:ui",
     "react-dom": "catalog:react",
     "react-error-boundary": "catalog:errors",
     "uuidv7": "catalog:uuid",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,9 +168,6 @@ catalogs:
       specifier: 7.0.2
       version: 7.0.2
   ui:
-    '@base-ui/react':
-      specifier: 1.6.0
-      version: 1.6.0
     '@pandacss/dev':
       specifier: 1.12.0
       version: 1.12.0
@@ -180,6 +177,9 @@ catalogs:
     postcss:
       specifier: 8.5.25
       version: 8.5.25
+    react-aria-components:
+      specifier: 1.20.0
+      version: 1.20.0
   uuid:
     uuidv7:
       specifier: 1.2.1
@@ -203,9 +203,6 @@ importers:
 
   .:
     dependencies:
-      '@base-ui/react':
-        specifier: catalog:ui
-        version: 1.6.0(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@better-auth/drizzle-adapter':
         specifier: catalog:authentication
         version: 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@tursodatabase/database-common@0.7.2)(@tursodatabase/database@0.7.2)(valibot@1.4.2(typescript@7.0.2))(zod@4.4.3))
@@ -254,6 +251,9 @@ importers:
       react:
         specifier: catalog:react
         version: 19.2.8
+      react-aria-components:
+        specifier: catalog:ui
+        version: 1.20.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-dom:
         specifier: catalog:react
         version: 19.2.8(react@19.2.8)
@@ -460,33 +460,6 @@ packages:
   '@babel/types@7.29.8':
     resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
-
-  '@base-ui/react@1.6.0':
-    resolution: {integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@date-fns/tz': ^1.2.0
-      '@types/react': ^17 || ^18 || ^19
-      date-fns: ^4.0.0
-      react: ^17 || ^18 || ^19
-      react-dom: ^17 || ^18 || ^19
-    peerDependenciesMeta:
-      '@date-fns/tz':
-        optional: true
-      '@types/react':
-        optional: true
-      date-fns:
-        optional: true
-
-  '@base-ui/utils@0.3.1':
-    resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
-    peerDependencies:
-      '@types/react': ^17 || ^18 || ^19
-      react: ^17 || ^18 || ^19
-      react-dom: ^17 || ^18 || ^19
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
 
   '@better-auth/core@1.6.25':
     resolution: {integrity: sha512-lMTlhtwyK4NpY9kPF+2rQCRKYpg136d3gM2xl8esxT1PjJx5Nh5YwZvxcYCIjDuO759sx6TCloJTuwcZGG6ZBw==}
@@ -868,21 +841,6 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@floating-ui/core@1.8.0':
-    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
-
-  '@floating-ui/dom@1.8.0':
-    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
-
-  '@floating-ui/react-dom@2.1.9':
-    resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-
-  '@floating-ui/utils@0.2.12':
-    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
-
   '@formisch/react@0.8.0':
     resolution: {integrity: sha512-ftuh+gnCP/82J0FQxYzzgENg5gIv0ZBQNmtu2/SQ9XuyfA8zBJIACGqtBdnCjReZdM76MxP6E/T0VbvwvZQ20A==}
     peerDependencies:
@@ -1078,6 +1036,15 @@ packages:
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
+
+  '@internationalized/date@3.12.3':
+    resolution: {integrity: sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==}
+
+  '@internationalized/number@3.6.7':
+    resolution: {integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==}
+
+  '@internationalized/string@3.2.10':
+    resolution: {integrity: sha512-PDx6//vHSpRnHfxqMqto11zQvhsaU74O3mKv2F/0eicGZcl9NLjQmGlbHz/LsJh5tLKp4A4L7ZVTzN1/MmMTvA==}
 
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0':
     resolution: {integrity: sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==}
@@ -2311,6 +2278,11 @@ packages:
     resolution: {integrity: sha512-Px/Hwhhyk2PubCA4ZaRFsfvwxhbxXsetJyvqC6aFFi8WhJhA+oVC33aTzuAeWmM3fhb4/8ce8YsHXI1d6ChcKg==}
     hasBin: true
 
+  '@react-types/shared@3.36.1':
+    resolution: {integrity: sha512-AzsuD9OfxTOZMMvTRhlN3oHBwOmFN7tDh27LzqmHt4+uOgPhJT7ZM7/kVs/8/o0WxayMUIk3hBmCFRHv1FUoag==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   '@rolldown/binding-android-arm64@1.2.2':
     resolution: {integrity: sha512-l7x215OGvo1s52JWmR8U/DAVzEDWBCIbTm28aeJV/WDTSHgcKXaZTuBT0hJMs5NggilfJTW3clZVvd24yfKJxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2602,6 +2574,9 @@ packages:
         optional: true
       '@tanstack/start-client-core':
         optional: true
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@t3-oss/env-core@0.13.11':
     resolution: {integrity: sha512-sM7GYY+KL7H/Hl0BE0inWfk3nRHZOLhmVn7sHGxaZt9FAR6KqREXAE+6TqKfiavfXmpRxO/OZ2QgKRd+oiBYRQ==}
@@ -3268,6 +3243,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -3461,6 +3440,9 @@ packages:
   cli-spinners@3.4.0:
     resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
     engines: {node: '>=18.20'}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -4973,6 +4955,18 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  react-aria-components@1.20.0:
+    resolution: {integrity: sha512-BMbpIgoV9aELeBrB0Y120NgoigHb5OdcJwc+4e7uSnbTbamea6lo+gqcc4LAxzMaK3Jf+7LI1oCDE6yANsmxIQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react-aria@3.51.0:
+    resolution: {integrity: sha512-AyWLw0XR38cFPwBu/ErgGaVrc5dupLEKmRlMXTGvFKOtbaGRQ2+yQJkjVhpdHhoRhU4+G+tJDFeHDTS8tK3bfQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   react-docgen-typescript@2.4.0:
     resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
     peerDependencies:
@@ -5020,6 +5014,11 @@ packages:
       esbuild:
         optional: true
 
+  react-stately@3.49.0:
+    resolution: {integrity: sha512-13iNq2KzBrRAzxRc+n53hgROfIistiYY/sPtIhCw1qUB7/kmo+X1xEU2uiS5zcCIrc55AUPwoHqOIIpKWSwB9A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
@@ -5043,9 +5042,6 @@ packages:
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
-
-  reselect@5.2.0:
-    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resolve-dir@1.0.1:
     resolution: {integrity: sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==}
@@ -5863,29 +5859,6 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@base-ui/react@1.6.0(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@base-ui/utils': 0.3.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@floating-ui/utils': 0.2.12
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      use-sync-external-store: 1.6.0(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@base-ui/utils@0.3.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@floating-ui/utils': 0.2.12
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      reselect: 5.2.0
-      use-sync-external-store: 1.6.0(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.17
-
   '@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2)':
     dependencies:
       '@better-auth/utils': 0.4.2
@@ -6190,23 +6163,6 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@floating-ui/core@1.8.0':
-    dependencies:
-      '@floating-ui/utils': 0.2.12
-
-  '@floating-ui/dom@1.8.0':
-    dependencies:
-      '@floating-ui/core': 1.8.0
-      '@floating-ui/utils': 0.2.12
-
-  '@floating-ui/react-dom@2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@floating-ui/dom': 1.8.0
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-
-  '@floating-ui/utils@0.2.12': {}
-
   '@formisch/react@0.8.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(valibot@1.4.2(typescript@7.0.2))':
     dependencies:
       react: 19.2.8
@@ -6338,6 +6294,18 @@ snapshots:
 
   '@img/sharp-win32-x64@0.35.2':
     optional: true
+
+  '@internationalized/date@3.12.3':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
+  '@internationalized/number@3.6.7':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
+  '@internationalized/string@3.2.10':
+    dependencies:
+      '@swc/helpers': 0.5.23
 
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@7.0.2)(vite@8.2.0(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
@@ -7385,6 +7353,10 @@ snapshots:
       prompts: 2.4.2
       tinyexec: 1.3.0
 
+  '@react-types/shared@3.36.1(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+
   '@rolldown/binding-android-arm64@1.2.2':
     optional: true
 
@@ -7645,6 +7617,10 @@ snapshots:
       - supports-color
       - typescript
       - webpack
+
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
 
   '@t3-oss/env-core@0.13.11(typescript@7.0.2)(valibot@1.4.2(typescript@7.0.2))(zod@4.4.3)':
     optionalDependencies:
@@ -8396,6 +8372,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -8543,6 +8523,8 @@ snapshots:
       restore-cursor: 5.1.0
 
   cli-spinners@3.4.0: {}
+
+  client-only@0.0.1: {}
 
   clsx@2.1.1: {}
 
@@ -9933,6 +9915,32 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  react-aria-components@1.20.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      '@internationalized/date': 3.12.3
+      '@internationalized/string': 3.2.10
+      '@react-types/shared': 3.36.1(react@19.2.8)
+      '@swc/helpers': 0.5.23
+      client-only: 0.0.1
+      react: 19.2.8
+      react-aria: 3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
+      react-stately: 3.49.0(react@19.2.8)
+
+  react-aria@3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      '@internationalized/date': 3.12.3
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.10
+      '@react-types/shared': 3.36.1(react@19.2.8)
+      '@swc/helpers': 0.5.23
+      aria-hidden: 1.2.6
+      clsx: 2.1.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-stately: 3.49.0(react@19.2.8)
+      use-sync-external-store: 1.6.0(react@19.2.8)
+
   react-docgen-typescript@2.4.0(typescript@7.0.2):
     dependencies:
       typescript: 7.0.2
@@ -10036,6 +10044,16 @@ snapshots:
       - vite-plus
       - webpack
 
+  react-stately@3.49.0(react@19.2.8):
+    dependencies:
+      '@internationalized/date': 3.12.3
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.10
+      '@react-types/shared': 3.36.1(react@19.2.8)
+      '@swc/helpers': 0.5.23
+      react: 19.2.8
+      use-sync-external-store: 1.6.0(react@19.2.8)
+
   react@19.2.8: {}
 
   readdirp@5.0.0: {}
@@ -10061,8 +10079,6 @@ snapshots:
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
-
-  reselect@5.2.0: {}
 
   resolve-dir@1.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -75,10 +75,10 @@ catalogs:
     storybook-device-viewports: 0.1.2
     storybook: 10.5.5
   ui:
-    '@base-ui/react': 1.6.0
     '@pandacss/dev': 1.12.0
     lucide-react: 1.28.0
     postcss: 8.5.25
+    react-aria-components: 1.20.0
   uuid:
     uuidv7: 1.2.1
   validation:

--- a/src/features/app-shell/components/mobile-shelf-dialog.tsx
+++ b/src/features/app-shell/components/mobile-shelf-dialog.tsx
@@ -1,6 +1,6 @@
-import { Dialog } from '@base-ui/react/dialog'
 import { Menu, X } from 'lucide-react'
 import { useState } from 'react'
+import { Button, Dialog, DialogTrigger, Heading, Modal, ModalOverlay } from 'react-aria-components'
 import { css } from 'styled-system/css'
 
 import type { ShelfNavSelection } from '../../tags/components/shelf-nav'
@@ -92,36 +92,45 @@ export function MobileShelfDialog({
   }
 
   return (
-    <Dialog.Root
-      open={shelfOpen}
+    <DialogTrigger
+      isOpen={shelfOpen}
       onOpenChange={setShelfOpen}>
-      <Dialog.Trigger className={shelfChanger}>
+      <Button className={shelfChanger}>
         <Menu
           size={16}
           aria-hidden
         />{' '}
         棚を変える
-      </Dialog.Trigger>
-      <Dialog.Portal>
-        <Dialog.Backdrop className={shelfSheetBackdrop} />
-        <Dialog.Popup className={shelfSheet}>
-          <div className={shelfSheetHeader}>
-            <Dialog.Title className={shelfSheetTitle}>棚を選ぶ</Dialog.Title>
-            <Dialog.Close className={shelfSheetClose}>
-              <X
-                size={16}
-                aria-hidden
-              />{' '}
-              閉じる
-            </Dialog.Close>
-          </div>
-          <ShelfNavPanel
-            shelfTagsPromise={shelfTagsPromise}
-            selection={selection}
-            onNavigate={closeShelf}
-          />
-        </Dialog.Popup>
-      </Dialog.Portal>
-    </Dialog.Root>
+      </Button>
+      <ModalOverlay
+        className={shelfSheetBackdrop}
+        isDismissable>
+        <Modal className={shelfSheet}>
+          <Dialog>
+            <div className={shelfSheetHeader}>
+              <Heading
+                slot='title'
+                className={shelfSheetTitle}>
+                棚を選ぶ
+              </Heading>
+              <Button
+                slot='close'
+                className={shelfSheetClose}>
+                <X
+                  size={16}
+                  aria-hidden
+                />{' '}
+                閉じる
+              </Button>
+            </div>
+            <ShelfNavPanel
+              shelfTagsPromise={shelfTagsPromise}
+              selection={selection}
+              onNavigate={closeShelf}
+            />
+          </Dialog>
+        </Modal>
+      </ModalOverlay>
+    </DialogTrigger>
   )
 }

--- a/src/features/auth/components/sign-in-form.tsx
+++ b/src/features/auth/components/sign-in-form.tsx
@@ -99,8 +99,8 @@ export const SignInWithEmailAndPasswordForm = ({
                 id={fieldProps.props.name}
                 value={fieldProps.input}
                 type='email'
-                onValueChange={(newValue) => {
-                  fieldProps.onChange(newValue)
+                onChange={(event) => {
+                  fieldProps.onChange(event.target.value)
                 }}
                 autoComplete='email webauthn'
                 required
@@ -128,8 +128,8 @@ export const SignInWithEmailAndPasswordForm = ({
                 id={fieldProps.props.name}
                 value={fieldProps.input}
                 type='password'
-                onValueChange={(newValue) => {
-                  fieldProps.onChange(newValue)
+                onChange={(event) => {
+                  fieldProps.onChange(event.target.value)
                 }}
                 autoComplete='current-password webauthn'
                 required
@@ -144,7 +144,7 @@ export const SignInWithEmailAndPasswordForm = ({
       <StyledButton
         type='submit'
         visual='accent'
-        disabled={isPending}>
+        isDisabled={isPending}>
         <LogIn
           size={16}
           aria-hidden

--- a/src/features/bookmarks/components/bookmark-delete-dialog.tsx
+++ b/src/features/bookmarks/components/bookmark-delete-dialog.tsx
@@ -1,7 +1,15 @@
-import { Dialog } from '@base-ui/react/dialog'
 import { useNavigate } from '@tanstack/react-router'
 import { Trash2, X } from 'lucide-react'
 import { useState, useTransition } from 'react'
+import {
+  Button,
+  Dialog,
+  DialogTrigger,
+  Heading,
+  Modal,
+  ModalOverlay,
+  Text
+} from 'react-aria-components'
 
 import { StyledButton } from '../../../shared/components/styled-button'
 import { button } from '../../../styles/button'
@@ -39,60 +47,68 @@ export function BookmarkDeleteDialog({
   }
 
   return (
-    <Dialog.Root
-      open={deleteOpen}
+    <DialogTrigger
+      isOpen={deleteOpen}
       onOpenChange={(open) => {
         setDeleteOpen(open)
         if (!open) {
           setDeleteError(null)
         }
       }}>
-      <Dialog.Trigger
+      <Button
         className={button({ visual: 'danger' })}
-        disabled={isDeleting}>
+        isDisabled={isDeleting}>
         <Trash2
           size={16}
           aria-hidden
         />{' '}
         削除
-      </Dialog.Trigger>
-      <Dialog.Portal>
-        <Dialog.Backdrop className={dialogBackdrop} />
-        <Dialog.Popup className={dialog}>
-          <Dialog.Title className={dialogTitle}>このブックマークを削除しますか？</Dialog.Title>
-          <Dialog.Description>
-            「{bookmark.title}」を削除します。一覧からは見えなくなります。
-          </Dialog.Description>
-          {deleteError ? (
-            <p
-              className={fieldError}
-              role='alert'>
-              {deleteError}
-            </p>
-          ) : null}
-          <div className={dialogActions}>
-            <Dialog.Close
-              className={button()}
-              disabled={isDeleting}>
-              <X
-                size={16}
-                aria-hidden
-              />{' '}
-              キャンセル
-            </Dialog.Close>
-            <StyledButton
-              visual='danger'
-              onClick={handleDelete}
-              disabled={isDeleting}>
-              <Trash2
-                size={16}
-                aria-hidden
-              />{' '}
-              {isDeleting ? '削除中…' : '削除を確認'}
-            </StyledButton>
-          </div>
-        </Dialog.Popup>
-      </Dialog.Portal>
-    </Dialog.Root>
+      </Button>
+      <ModalOverlay
+        className={dialogBackdrop}
+        isDismissable={!isDeleting}>
+        <Modal className={dialog}>
+          <Dialog>
+            <Heading
+              slot='title'
+              className={dialogTitle}>
+              このブックマークを削除しますか？
+            </Heading>
+            <Text slot='description'>
+              「{bookmark.title}」を削除します。一覧からは見えなくなります。
+            </Text>
+            {deleteError ? (
+              <p
+                className={fieldError}
+                role='alert'>
+                {deleteError}
+              </p>
+            ) : null}
+            <div className={dialogActions}>
+              <Button
+                slot='close'
+                className={button()}
+                isDisabled={isDeleting}>
+                <X
+                  size={16}
+                  aria-hidden
+                />{' '}
+                キャンセル
+              </Button>
+              <StyledButton
+                visual='danger'
+                onPress={handleDelete}
+                isDisabled={isDeleting}>
+                <Trash2
+                  size={16}
+                  aria-hidden
+                />{' '}
+                {isDeleting ? '削除中…' : '削除を確認'}
+              </StyledButton>
+            </div>
+          </Dialog>
+        </Modal>
+      </ModalOverlay>
+    </DialogTrigger>
   )
 }

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/fields.tsx
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/fields.tsx
@@ -1,6 +1,6 @@
-import { Input } from '@base-ui/react'
 import { Field, setErrors } from '@formisch/react'
 import { Download } from 'lucide-react'
+import { Input } from 'react-aria-components'
 
 import { StyledButton } from '../../../../../shared/components/styled-button'
 import { field, fieldError, fieldInput, fieldLabel, fieldUrlRow } from '../../../../../styles/form'
@@ -84,15 +84,15 @@ export function BookmarkFormFields({
                   required
                   aria-invalid={errorMessage !== undefined}
                   aria-describedby={errorMessage !== undefined ? `${ids.url}-error` : undefined}
-                  onValueChange={(value) => {
-                    fieldProps.onChange(value)
+                  onChange={(event) => {
+                    fieldProps.onChange(event.target.value)
                     handleFieldChange('url')
                   }}
                 />
                 <StyledButton
                   type='button'
-                  onClick={handleFetchTitle}
-                  disabled={busy}
+                  onPress={handleFetchTitle}
+                  isDisabled={busy}
                   aria-busy={isFetchingTitle}>
                   <Download
                     size={16}
@@ -139,8 +139,8 @@ export function BookmarkFormFields({
                 required
                 aria-invalid={errorMessage !== undefined}
                 aria-describedby={errorMessage !== undefined ? `${ids.title}-error` : undefined}
-                onValueChange={(value) => {
-                  fieldProps.onChange(value)
+                onChange={(event) => {
+                  fieldProps.onChange(event.target.value)
                   handleFieldChange('title')
                 }}
               />
@@ -181,8 +181,8 @@ export function BookmarkFormFields({
                 autoComplete='off'
                 aria-invalid={errorMessage !== undefined}
                 aria-describedby={errorMessage !== undefined ? `${ids.note}-error` : undefined}
-                onValueChange={(value) => {
-                  fieldProps.onChange(value)
+                onChange={(event) => {
+                  fieldProps.onChange(event.target.value)
                   handleFieldChange('note')
                 }}
               />

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/index.tsx
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/index.tsx
@@ -121,7 +121,7 @@ export function BookmarkForm({
       <StyledButton
         type='submit'
         visual='accent'
-        disabled={busy}>
+        isDisabled={busy}>
         {pending ? pendingLabel : submitLabel}
       </StyledButton>
     </Form>

--- a/src/features/bookmarks/components/bookmark-workbench-form.tsx
+++ b/src/features/bookmarks/components/bookmark-workbench-form.tsx
@@ -1,7 +1,7 @@
-import { Input } from '@base-ui/react'
 import { Field, getErrors, getInput, useForm, validate } from '@formisch/react'
 import { CircleAlert, Download } from 'lucide-react'
 import { useActionState, useState } from 'react'
+import { Input } from 'react-aria-components'
 import * as v from 'valibot'
 
 import { StyledButton } from '../../../shared/components/styled-button'
@@ -133,17 +133,17 @@ export function BookmarkWorkbenchForm({
                   className={fieldInput}
                   value={f.input}
                   type='url'
-                  onValueChange={(newValue) => {
-                    f.onChange(newValue)
+                  onChange={(event) => {
+                    f.onChange(event.target.value)
                   }}
                   required
                   disabled={busy}
                 />
                 <StyledButton
-                  onClick={() => {
+                  onPress={() => {
                     void handleFetchTitle()
                   }}
-                  disabled={busy}>
+                  isDisabled={busy}>
                   <Download
                     size={16}
                     aria-hidden
@@ -171,8 +171,8 @@ export function BookmarkWorkbenchForm({
                 className={fieldInput}
                 value={f.input}
                 type='text'
-                onValueChange={(newValue) => {
-                  f.onChange(newValue)
+                onChange={(event) => {
+                  f.onChange(event.target.value)
                 }}
                 required
                 disabled={busy}
@@ -197,8 +197,8 @@ export function BookmarkWorkbenchForm({
                 className={fieldInput}
                 value={f.input ?? ''}
                 type='text'
-                onValueChange={(newValue) => {
-                  f.onChange(newValue)
+                onChange={(event) => {
+                  f.onChange(event.target.value)
                 }}
                 disabled={busy}
               />
@@ -211,7 +211,7 @@ export function BookmarkWorkbenchForm({
       <StyledButton
         type='submit'
         visual='accent'
-        disabled={busy}>
+        isDisabled={busy}>
         {isPending ? pendingLabel : submitLabel}
       </StyledButton>
     </form>

--- a/src/features/settings/components/settings-screen.tsx
+++ b/src/features/settings/components/settings-screen.tsx
@@ -91,8 +91,8 @@ export function SettingsScreen({ user }: SettingsScreenProps) {
         <h2 className={settingsHeading}>セッション</h2>
         <StyledButton
           visual='accent'
-          onClick={handleSignOut}
-          disabled={isPending}>
+          onPress={handleSignOut}
+          isDisabled={isPending}>
           <LogOut
             size={16}
             aria-hidden

--- a/src/features/tags/components/inline-add-tag.tsx
+++ b/src/features/tags/components/inline-add-tag.tsx
@@ -1,7 +1,7 @@
-import { Input } from '@base-ui/react'
 import { useNavigate } from '@tanstack/react-router'
 import { Plus } from 'lucide-react'
 import { useState } from 'react'
+import { Input } from 'react-aria-components'
 import { css } from 'styled-system/css'
 import * as v from 'valibot'
 
@@ -66,14 +66,14 @@ export function InlineAddTag() {
             id='inline-add-tag-name'
             value={name}
             type='text'
-            onValueChange={(newValue) => {
-              setName(newValue)
+            onChange={(event) => {
+              setName(event.target.value)
             }}
             disabled={isPending}
           />
           <StyledButton
             type='submit'
-            disabled={isPending}>
+            isDisabled={isPending}>
             <Plus
               size={16}
               aria-hidden

--- a/src/features/tags/components/tag-form.tsx
+++ b/src/features/tags/components/tag-form.tsx
@@ -1,7 +1,7 @@
-import { Input } from '@base-ui/react'
 import { Field, getInput, useForm } from '@formisch/react'
 import { CircleAlert } from 'lucide-react'
 import { useActionState, useState } from 'react'
+import { Input } from 'react-aria-components'
 import * as v from 'valibot'
 
 import { StyledButton } from '../../../shared/components/styled-button'
@@ -98,8 +98,8 @@ export function TagForm({
                 id={fieldProps.props.name}
                 value={fieldProps.input}
                 type='text'
-                onValueChange={(newValue) => {
-                  fieldProps.onChange(newValue)
+                onChange={(event) => {
+                  fieldProps.onChange(event.target.value)
                 }}
                 required
               />
@@ -121,7 +121,7 @@ export function TagForm({
       <StyledButton
         type='submit'
         visual='accent'
-        disabled={isPending}>
+        isDisabled={isPending}>
         {isPending ? pendingLabel : submitLabel}
       </StyledButton>
     </form>

--- a/src/features/tags/components/tag-pin-field.tsx
+++ b/src/features/tags/components/tag-pin-field.tsx
@@ -27,8 +27,8 @@ export function TagPinField({ pinned, onPinnedChange, disabled = false }: TagPin
       <StyledButton
         aria-pressed={pinned}
         aria-labelledby='tag-pinned-label'
-        disabled={disabled}
-        onClick={() => {
+        isDisabled={disabled}
+        onPress={() => {
           onPinnedChange(!pinned)
         }}>
         {pinned ? (

--- a/src/features/tags/components/tag-sort-order-field.tsx
+++ b/src/features/tags/components/tag-sort-order-field.tsx
@@ -40,8 +40,8 @@ export function TagSortOrderField({
       <div className={sortOrderRow}>
         <StyledButton
           aria-label='並び順を下げる'
-          disabled={disabled}
-          onClick={() => {
+          isDisabled={disabled}
+          onPress={() => {
             onSortOrderChange(sortOrder - 1)
           }}>
           <Minus
@@ -66,8 +66,8 @@ export function TagSortOrderField({
         />
         <StyledButton
           aria-label='並び順を上げる'
-          disabled={disabled}
-          onClick={() => {
+          isDisabled={disabled}
+          onPress={() => {
             onSortOrderChange(sortOrder + 1)
           }}>
           <Plus

--- a/src/shared/components/styled-button/index.tsx
+++ b/src/shared/components/styled-button/index.tsx
@@ -1,7 +1,7 @@
 /**
  * @file index.tsx
  *
- * Input:    Base UI `Button`, Panda `styled` factory
+ * Input:    React Aria Components `Button`, Panda `styled` factory
  * Output:   StyledButton component
  * Position: Shared UI primitive; documented by index.stories.tsx
  *
@@ -11,7 +11,7 @@
  * Last synced props: visual, size, type, className, css, plus every Panda style prop
  */
 
-import { Button as BaseButton } from '@base-ui/react/button'
+import { Button as AriaButton } from 'react-aria-components'
 import { styled } from 'styled-system/jsx'
 import type { HTMLStyledProps } from 'styled-system/types'
 
@@ -19,13 +19,13 @@ import { button } from '../../../styles/button'
 
 /**
  * Intentionally not exported. Consumers get `StyledButton` (or the `button`
- * recipe for className composition) instead of a bare styled Base UI Button.
+ * recipe for className composition) instead of a bare styled RAC Button.
  */
-const RawButton = styled(BaseButton, button)
+const RawButton = styled(AriaButton, button)
 
 /**
  * NOT `StyledVariantProps`: that helper resolves to the recipe's variant record
- * alone and drops both Base UI / native button props and `JsxStyleProps`.
+ * alone and drops both React Aria / native button props and `JsxStyleProps`.
  * `HTMLStyledProps` keeps those attributes and style props while still
  * carrying the recipe variants.
  */

--- a/src/shared/components/styled-input/index.tsx
+++ b/src/shared/components/styled-input/index.tsx
@@ -1,8 +1,8 @@
-import { Input as BaseInput } from '@base-ui/react/input'
+import { Input as AriaInput } from 'react-aria-components'
 import { styled } from 'styled-system/jsx'
 import type { HTMLStyledProps } from 'styled-system/types'
 
-const RawInput = styled(BaseInput, {
+const RawInput = styled(AriaInput, {
   base: {
     minBlockSize: 'touch',
     borderWidth: 'thin',

--- a/src/shared/components/ui-error.tsx
+++ b/src/shared/components/ui-error.tsx
@@ -16,7 +16,7 @@ export function UiError({ message, onRetry }: { message: string; onRetry?: () =>
       {onRetry ? (
         <StyledButton
           visual='accent'
-          onClick={onRetry}>
+          onPress={onRetry}>
           <RefreshCw
             size={16}
             aria-hidden

--- a/src/shared/components/ui-library-migration.test.ts
+++ b/src/shared/components/ui-library-migration.test.ts
@@ -1,0 +1,22 @@
+import {
+  Button,
+  Dialog,
+  DialogTrigger,
+  Heading,
+  Input,
+  Modal,
+  ModalOverlay
+} from 'react-aria-components'
+import { describe, expect, test } from 'vitest'
+
+describe('react-aria-components', () => {
+  test('exports the primitives used by the app', () => {
+    expect(Button).toBeTypeOf('object')
+    expect(Input).toBeTypeOf('object')
+    expect(DialogTrigger).toBeTypeOf('function')
+    expect(ModalOverlay).toBeTypeOf('object')
+    expect(Modal).toBeTypeOf('object')
+    expect(Dialog).toBeTypeOf('object')
+    expect(Heading).toBeTypeOf('object')
+  })
+})


### PR DESCRIPTION
## Summary
- Replace Base UI Button, Input, and Dialog usage with React Aria Components.
- Preserve Panda CSS styles, Formisch form behavior, SSR, and existing dialog flows.
- Remove the Base UI dependency and add a migration contract test.

## Test Plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run format:check`
- [x] `pnpm run lint`
- [x] `pnpm run lint:markup`
- [x] `pnpm run typecheck`
- [x] `pnpm run test` (24 files, 81 tests)
- [x] `pnpm run build`
- [x] `pnpm run build-storybook`
- [x] Browser-checked the sign-in RAC inputs and button
- [ ] Browser-check authenticated Dialog Escape, outside-click dismissal, and focus restoration

## Notes
- Implementation changes are in the Herdr worktree `/Users/koralle/.worktrees/pantry/migrate-base-ui-react-aria-cursor`.
- Existing `migrate-react-aria` worktree was left untouched.