### PR TITLE
style: Oxfmtでフォーマットを適用

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -1,6 +1,11 @@
 pre-commit:
   piped: true
   jobs:
+    - name: Lint with Oxlint
+      run: |
+        pnpm oxlint {staged_files} --fix --no-error-on-unmatched-pattern
+      stage_fixed: true
+
     - name: Format with Oxfmt
       run: |
         pnpm oxfmt {staged_files} --write --no-error-on-unmatched-pattern
@@ -9,11 +14,6 @@ pre-commit:
     - group:
         parallel: true
         jobs:
-          - name: Lint with Oxlint
-            run: |
-              pnpm oxlint {staged_files} --fix --no-error-on-unmatched-pattern
-            stage_fixed: true
-
           - name: Lint markup with markuplint
             glob:
               - '**/*.{tsx,jsx}'

--- a/src/features/bookmarks/server/fetch-page-title.server.ts
+++ b/src/features/bookmarks/server/fetch-page-title.server.ts
@@ -129,15 +129,15 @@ function isBlockedIp(rawHostname: string): boolean {
 
   const [g0 = 0, g1 = 0, g2 = 0, g3 = 0, g4 = 0, g5 = 0, g6 = 0] = hextets
   // Fc00::/7 unique local、fe80::/10 link-local
-  if ((g0 & 0xFE_00) === 0xFC_00 || (g0 & 0xFFC0) === 0xFE80) {
+  if ((g0 & 0xfe_00) === 0xfc_00 || (g0 & 0xffc0) === 0xfe80) {
     return true
   }
 
   // 先頭 96bit がゼロ（::1、未指定 ::、廃止済み IPv4-compatible）または
   // IPv4-mapped（::ffff:0:0/96）なら、下位 32bit を IPv4 として再検査する。
   // ::ffff:127.0.0.1 は URL 正規化で ::ffff:7f00:1 になるため hex 形式での判定が必須。
-  if (g0 === 0 && g1 === 0 && g2 === 0 && g3 === 0 && g4 === 0 && (g5 === 0 || g5 === 0xFFFF)) {
-    return isBlockedIpv4Range(g6 >> 8, g6 & 0xFF)
+  if (g0 === 0 && g1 === 0 && g2 === 0 && g3 === 0 && g4 === 0 && (g5 === 0 || g5 === 0xffff)) {
+    return isBlockedIpv4Range(g6 >> 8, g6 & 0xff)
   }
 
   return false

--- a/src/routes/_protected/bookmarks/$id/edit.stories.tsx
+++ b/src/routes/_protected/bookmarks/$id/edit.stories.tsx
@@ -64,7 +64,7 @@ function installRpcFetchStub(): void {
   }
   const passthroughFetch = originalFetch
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-    const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url)
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
     if (new URL(url, window.location.origin).pathname === '/api/rpc') {
       return handleRpcRequest(new Request(url, init), buildRpcRouter())
     }


### PR DESCRIPTION
## 概要

Oxfmt でフォーマットをかけただけの変更です。ロジックの変更はありません。

- `fetch-page-title.server.ts`: 16進数リテラルの大文字→小文字正規化
- `edit.stories.tsx`: 三項演算子の冗長な括弧を除去