### PR TITLE
refactor: migrate forms from Formisch to Conform

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
   "dependencies": {
     "@better-auth/drizzle-adapter": "catalog:authentication",
     "@cloudflare/vite-plugin": "catalog:build",
+    "@conform-to/react": "catalog:form",
+    "@conform-to/valibot": "catalog:form",
     "@fontsource/noto-sans-jp": "catalog:ui",
-    "@formisch/react": "catalog:form",
     "@libsql/client": "catalog:database",
     "@orpc/client": "catalog:rpc",
     "@orpc/server": "catalog:rpc",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,9 +70,12 @@ catalogs:
       specifier: 6.1.2
       version: 6.1.2
   form:
-    '@formisch/react':
-      specifier: 0.8.0
-      version: 0.8.0
+    '@conform-to/react':
+      specifier: 1.21.1
+      version: 1.21.1
+    '@conform-to/valibot':
+      specifier: 1.21.1
+      version: 1.21.1
   format:
     oxfmt:
       specifier: 0.63.0
@@ -222,12 +225,15 @@ importers:
       '@cloudflare/vite-plugin':
         specifier: catalog:build
         version: 1.52.1(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.123.0)
+      '@conform-to/react':
+        specifier: catalog:form
+        version: 1.21.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@conform-to/valibot':
+        specifier: catalog:form
+        version: 1.21.1(valibot@1.4.2(typescript@7.0.2))
       '@fontsource/noto-sans-jp':
         specifier: catalog:ui
         version: 5.3.0
-      '@formisch/react':
-        specifier: catalog:form
-        version: 0.8.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(valibot@1.4.2(typescript@7.0.2))
       '@libsql/client':
         specifier: catalog:database
         version: 0.17.4
@@ -650,6 +656,20 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@conform-to/dom@1.21.1':
+    resolution: {integrity: sha512-pYnhrJoM1xDbAx36rVxxm4643TFWwquTDoI8abtgnC40XIHDZDUhy3pIrZrv+QjwtLEgSWGP5GX/LqJ+IDfe/Q==}
+
+  '@conform-to/react@1.21.1':
+    resolution: {integrity: sha512-q0kzC5dEHL4okfmdbih95OfuelXw6xlLeN9WvtxQ7CP047D6A5lRK+0DykZZHCFP4idsQzC8NUBQd/tkKXPukg==}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  '@conform-to/valibot@1.21.1':
+    resolution: {integrity: sha512-CWMdCk7WzYmMsWPF+nKRwkw4EKBRCoTIiqJa8sb8uDGGNbgbLd62PBeHvIh4mQuoGHT31SQ6QSUhbCUjV52Rqw==}
+    peerDependencies:
+      valibot: '>= 0.32.0'
+
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
@@ -885,17 +905,6 @@ packages:
 
   '@fontsource/noto-sans-jp@5.3.0':
     resolution: {integrity: sha512-OZbBzZ8LrFRs2RFT2Cc0HUV2C2ZeSfyEXhDJWR0EZuZaraJfRubpvrFmUnCljuBDEkw8Vn6CE/+nf9dj9b+0lg==}
-
-  '@formisch/react@0.8.0':
-    resolution: {integrity: sha512-ftuh+gnCP/82J0FQxYzzgENg5gIv0ZBQNmtu2/SQ9XuyfA8zBJIACGqtBdnCjReZdM76MxP6E/T0VbvwvZQ20A==}
-    peerDependencies:
-      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      typescript: '>=5'
-      valibot: ^1.4.1
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -6111,6 +6120,19 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260811.1':
     optional: true
 
+  '@conform-to/dom@1.21.1': {}
+
+  '@conform-to/react@1.21.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@conform-to/dom': 1.21.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
+  '@conform-to/valibot@1.21.1(valibot@1.4.2(typescript@7.0.2))':
+    dependencies:
+      '@conform-to/dom': 1.21.1
+      valibot: 1.4.2(typescript@7.0.2)
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -6294,14 +6316,6 @@ snapshots:
       levn: 0.4.1
 
   '@fontsource/noto-sans-jp@5.3.0': {}
-
-  '@formisch/react@0.8.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(valibot@1.4.2(typescript@7.0.2))':
-    dependencies:
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      valibot: 1.4.2(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
 
   '@humanfs/core@0.19.2':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,8 @@ catalogs:
     '@praha/error-factory': 1.4.1
     'react-error-boundary': 6.1.2
   form:
-    '@formisch/react': 0.8.0
+    '@conform-to/react': 1.21.1
+    '@conform-to/valibot': 1.21.1
   format:
     oxfmt: 0.63.0
   framework:

--- a/src/features/auth/components/sign-in-form.tsx
+++ b/src/features/auth/components/sign-in-form.tsx
@@ -1,8 +1,8 @@
-import { Field, getInput, useForm } from '@formisch/react'
+import { getFormProps, getInputProps, useForm } from '@conform-to/react'
+import { parseWithValibot } from '@conform-to/valibot'
 import { CircleAlert, Lock, LogIn, Mail } from 'lucide-react'
-import { useActionState } from 'react'
+import { startTransition, useActionState } from 'react'
 import { css, cx } from 'styled-system/css'
-import { parseAsync } from 'valibot'
 
 import { StyledButton } from '../../../shared/components/styled-button'
 import { StyledInput } from '../../../shared/components/styled-input'
@@ -11,7 +11,7 @@ import { field, fieldError, formSummary } from '../../../styles/form'
 import { srOnly } from '../../../styles/sr-only'
 import { workbenchFields, workbenchForm } from '../../../styles/workbench'
 import { SignInError } from '../lib/sign-in-error'
-import { emailSchema, passwordSchema, signInSchema } from '../lib/sign-in-schema'
+import { signInSchema } from '../lib/sign-in-schema'
 import type { SignInSchema } from '../lib/sign-in-schema'
 
 const signInForm = css({
@@ -32,36 +32,54 @@ function signInErrorMessage(error: SignInError): string {
 export const SignInWithEmailAndPasswordForm = ({
   onSignIn
 }: SignInWithEmailAndPasswordFormProps) => {
-  const signInFormInstance = useForm({
-    initialInput: {
+  const [signInError, throwError, isPending] = useActionState(
+    async (_previous: SignInError | null, formData: FormData) => {
+      const submission = parseWithValibot(formData, {
+        disableAutoCoercion: true,
+        schema: signInSchema
+      })
+      if (submission.status !== 'success') {
+        return null
+      }
+
+      return await onSignIn(submission.value)
+    },
+    null
+  )
+
+  const [form, fields] = useForm<SignInSchema>({
+    defaultValue: {
       email: '',
       password: ''
     },
-    schema: signInSchema
+    onSubmit(event, { formData, submission }) {
+      event.preventDefault()
+      if (submission?.status !== 'success') {
+        return
+      }
+      startTransition(() => {
+        throwError(formData)
+      })
+    },
+    onValidate({ formData }) {
+      return parseWithValibot(formData, { disableAutoCoercion: true, schema: signInSchema })
+    },
+    shouldRevalidate: 'onInput',
+    shouldValidate: 'onSubmit'
   })
-
-  const [signInError, throwError, isPending] = useActionState(async () => {
-    const currentRawEmail = getInput(signInFormInstance, { path: ['email'] }) ?? ''
-    const currentRawPassword = getInput(signInFormInstance, { path: ['password'] }) ?? ''
-
-    const verifiedCurrentEmail = await parseAsync(emailSchema, currentRawEmail)
-    const verifiedCurrentPassword = await parseAsync(passwordSchema, currentRawPassword)
-
-    const error = await onSignIn({ email: verifiedCurrentEmail, password: verifiedCurrentPassword })
-
-    return error
-  }, null)
 
   const fieldErrorText =
     signInError?.code === 'INVALID_EMAIL_OR_PASSWORD'
       ? 'メールまたはパスワードを確認してください'
       : null
+  const emailError = fields.email.errors?.[0] ?? fieldErrorText
+  const passwordError = fields.password.errors?.[0] ?? fieldErrorText
 
   return (
     <form
       className={cx(workbenchForm, signInForm)}
-      action={throwError}
-      noValidate>
+      {...getFormProps(form)}
+      action={throwError}>
       {signInError != null ? (
         <div
           className={formSummary}
@@ -82,63 +100,41 @@ export const SignInWithEmailAndPasswordForm = ({
         disabled={isPending}>
         <legend className={srOnly}>サインイン</legend>
 
-        <Field
-          of={signInFormInstance}
-          path={['email']}>
-          {(fieldProps) => (
-            <div className={field}>
-              <StyledLabel htmlFor={fieldProps.props.name}>
-                <Mail
-                  size={16}
-                  aria-hidden
-                />
-                メール
-              </StyledLabel>
+        <div className={field}>
+          <StyledLabel htmlFor={fields.email.id}>
+            <Mail
+              size={16}
+              aria-hidden
+            />
+            メール
+          </StyledLabel>
 
-              <StyledInput
-                id={fieldProps.props.name}
-                value={fieldProps.input}
-                type='email'
-                onChange={(event) => {
-                  fieldProps.onChange(event.target.value)
-                }}
-                autoComplete='email webauthn'
-                required
-                aria-invalid={fieldErrorText != null}
-              />
-              {fieldErrorText != null ? <p className={fieldError}>{fieldErrorText}</p> : null}
-            </div>
-          )}
-        </Field>
+          <StyledInput
+            {...getInputProps(fields.email, { type: 'email' })}
+            autoComplete='email webauthn'
+            required
+            aria-invalid={emailError != null}
+          />
+          {emailError != null ? <p className={fieldError}>{emailError}</p> : null}
+        </div>
 
-        <Field
-          of={signInFormInstance}
-          path={['password']}>
-          {(fieldProps) => (
-            <div className={field}>
-              <StyledLabel htmlFor={fieldProps.props.name}>
-                <Lock
-                  size={16}
-                  aria-hidden
-                />
-                パスワード
-              </StyledLabel>
+        <div className={field}>
+          <StyledLabel htmlFor={fields.password.id}>
+            <Lock
+              size={16}
+              aria-hidden
+            />
+            パスワード
+          </StyledLabel>
 
-              <StyledInput
-                id={fieldProps.props.name}
-                value={fieldProps.input}
-                type='password'
-                onChange={(event) => {
-                  fieldProps.onChange(event.target.value)
-                }}
-                autoComplete='current-password webauthn'
-                required
-                aria-invalid={fieldErrorText != null}
-              />
-              {fieldErrorText != null ? <p className={fieldError}>{fieldErrorText}</p> : null}
-            </div>
-          )}
-        </Field>
+          <StyledInput
+            {...getInputProps(fields.password, { type: 'password' })}
+            autoComplete='current-password webauthn'
+            required
+            aria-invalid={passwordError != null}
+          />
+          {passwordError != null ? <p className={fieldError}>{passwordError}</p> : null}
+        </div>
       </fieldset>
 
       <StyledButton

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/fields.tsx
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/fields.tsx
@@ -1,21 +1,19 @@
-import { Field, setErrors } from '@formisch/react'
+import { getInputProps } from '@conform-to/react'
+import type { FieldMetadata } from '@conform-to/react'
 import { Download } from 'lucide-react'
 
 import { StyledButton } from '../../../../../shared/components/styled-button'
 import { StyledInput } from '../../../../../shared/components/styled-input'
 import { StyledLabel } from '../../../../../shared/components/styled-label'
 import { field, fieldError, fieldUrlRow } from '../../../../../styles/form'
-import type { BookmarkFormFieldKey, BookmarkFormServerError, BookmarkFormStore } from './types'
-
-export type BookmarkFormFieldIds = {
-  readonly url: string
-  readonly title: string
-  readonly note: string
-}
+import type { BookmarkFormFieldKey, BookmarkFormServerError } from './types'
 
 type BookmarkFormFieldsProps = {
-  readonly form: BookmarkFormStore
-  readonly ids: BookmarkFormFieldIds
+  readonly fields: {
+    readonly url: FieldMetadata
+    readonly title: FieldMetadata
+    readonly note: FieldMetadata
+  }
   readonly serverFieldErrors?: BookmarkFormServerError['fields']
   readonly busy: boolean
   readonly isFetchingTitle: boolean
@@ -23,8 +21,8 @@ type BookmarkFormFieldsProps = {
   readonly onClearServerFieldError: (key: BookmarkFormFieldKey) => void
 }
 
-// Field に表示するメッセージの優先順位を「Formisch の validation error → server error」に固定する。
-// Formisch は現在の入力値に対する結果、server error は直前の送信時点の入力値に対する結果なので、
+// Field に表示するメッセージの優先順位を「Conform の validation error → server error」に固定する。
+// Conform は現在の入力値に対する結果、server error は直前の送信時点の入力値に対する結果なので、
 // 現在値へのフィードバックを優先する方が入力者の認知と一致する。
 // また serverError は入力変更時に onClearServerFieldError で clear されるため、
 // この優先順位は過渡状態や race condition に対する最終的な解決ルールでもある。
@@ -32,157 +30,105 @@ function resolveFieldMessage(
   formErrors: readonly string[] | null | undefined,
   serverMessage: string | undefined
 ): string | undefined {
-  const formismError = formErrors?.[0]
-  if (formismError !== undefined) {
-    return formismError
+  const formError = formErrors?.[0]
+  if (formError !== undefined) {
+    return formError
   }
   return serverMessage
 }
 
 export function BookmarkFormFields({
-  form,
-  ids,
+  fields,
   serverFieldErrors,
   busy,
   isFetchingTitle,
   handleFetchTitle,
   onClearServerFieldError
 }: BookmarkFormFieldsProps) {
-  // 入力変更時に Formisch 側の field error と server 側の field error を「同時に」clear する。
-  // 所有者は別 (Formisch store / BookmarkEditor) だが、
-  // 入力の変化に対して両者が古い判断を残さないという契約を、この一関数で表現する。
   function handleFieldChange(key: BookmarkFormFieldKey) {
-    setErrors(form, { path: [key], errors: null })
     onClearServerFieldError(key)
   }
 
+  const urlError = resolveFieldMessage(fields.url.errors, serverFieldErrors?.url)
+  const titleError = resolveFieldMessage(fields.title.errors, serverFieldErrors?.title)
+  const noteError = resolveFieldMessage(fields.note.errors, serverFieldErrors?.note)
+
   return (
     <>
-      <Field
-        of={form}
-        path={['url']}>
-        {(fieldProps) => {
-          const errorMessage = resolveFieldMessage(fieldProps.errors, serverFieldErrors?.url)
+      <div className={field}>
+        <StyledLabel htmlFor={fields.url.id}>URL</StyledLabel>
+        <div className={fieldUrlRow}>
+          <StyledInput
+            {...getInputProps(fields.url, { type: 'url' })}
+            autoComplete='url'
+            required
+            aria-invalid={urlError !== undefined}
+            aria-describedby={urlError !== undefined ? fields.url.errorId : undefined}
+            onChange={() => {
+              handleFieldChange('url')
+            }}
+          />
+          <StyledButton
+            type='button'
+            onPress={handleFetchTitle}
+            isDisabled={busy}
+            aria-busy={isFetchingTitle}>
+            <Download
+              size={16}
+              aria-hidden
+            />
+            {isFetchingTitle ? '取得中…' : 'タイトルを取得'}
+          </StyledButton>
+        </div>
+        {urlError !== undefined ? (
+          <p
+            id={fields.url.errorId}
+            className={fieldError}>
+            {urlError}
+          </p>
+        ) : null}
+      </div>
 
-          return (
-            <div className={field}>
-              <StyledLabel htmlFor={ids.url}>URL</StyledLabel>
-              <div className={fieldUrlRow}>
-                <StyledInput
-                  id={ids.url}
-                  name={fieldProps.props.name}
-                  ref={(element) => {
-                    fieldProps.props.ref(element as HTMLInputElement | null)
-                  }}
-                  value={fieldProps.input ?? ''}
-                  type='url'
-                  autoComplete='url'
-                  required
-                  aria-invalid={errorMessage !== undefined}
-                  aria-describedby={errorMessage !== undefined ? `${ids.url}-error` : undefined}
-                  onChange={(event) => {
-                    fieldProps.onChange(event.target.value)
-                    handleFieldChange('url')
-                  }}
-                />
-                <StyledButton
-                  type='button'
-                  onPress={handleFetchTitle}
-                  isDisabled={busy}
-                  aria-busy={isFetchingTitle}>
-                  <Download
-                    size={16}
-                    aria-hidden
-                  />
-                  {isFetchingTitle ? '取得中…' : 'タイトルを取得'}
-                </StyledButton>
-              </div>
-              {errorMessage !== undefined ? (
-                <p
-                  id={`${ids.url}-error`}
-                  className={fieldError}>
-                  {errorMessage}
-                </p>
-              ) : null}
-            </div>
-          )
-        }}
-      </Field>
+      <div className={field}>
+        <StyledLabel htmlFor={fields.title.id}>タイトル</StyledLabel>
+        <StyledInput
+          {...getInputProps(fields.title, { type: 'text' })}
+          autoComplete='off'
+          required
+          aria-invalid={titleError !== undefined}
+          aria-describedby={titleError !== undefined ? fields.title.errorId : undefined}
+          onChange={() => {
+            handleFieldChange('title')
+          }}
+        />
+        {titleError !== undefined ? (
+          <p
+            id={fields.title.errorId}
+            className={fieldError}>
+            {titleError}
+          </p>
+        ) : null}
+      </div>
 
-      <Field
-        of={form}
-        path={['title']}>
-        {(fieldProps) => {
-          const errorMessage = resolveFieldMessage(fieldProps.errors, serverFieldErrors?.title)
-
-          return (
-            <div className={field}>
-              <StyledLabel htmlFor={ids.title}>タイトル</StyledLabel>
-              <StyledInput
-                id={ids.title}
-                name={fieldProps.props.name}
-                ref={(element) => {
-                  fieldProps.props.ref(element as HTMLInputElement | null)
-                }}
-                value={fieldProps.input ?? ''}
-                type='text'
-                autoComplete='off'
-                required
-                aria-invalid={errorMessage !== undefined}
-                aria-describedby={errorMessage !== undefined ? `${ids.title}-error` : undefined}
-                onChange={(event) => {
-                  fieldProps.onChange(event.target.value)
-                  handleFieldChange('title')
-                }}
-              />
-              {errorMessage !== undefined ? (
-                <p
-                  id={`${ids.title}-error`}
-                  className={fieldError}>
-                  {errorMessage}
-                </p>
-              ) : null}
-            </div>
-          )
-        }}
-      </Field>
-
-      <Field
-        of={form}
-        path={['note']}>
-        {(fieldProps) => {
-          const errorMessage = resolveFieldMessage(fieldProps.errors, serverFieldErrors?.note)
-
-          return (
-            <div className={field}>
-              <StyledLabel htmlFor={ids.note}>メモ</StyledLabel>
-              <StyledInput
-                id={ids.note}
-                name={fieldProps.props.name}
-                ref={(element) => {
-                  fieldProps.props.ref(element as HTMLInputElement | null)
-                }}
-                value={fieldProps.input ?? ''}
-                type='text'
-                autoComplete='off'
-                aria-invalid={errorMessage !== undefined}
-                aria-describedby={errorMessage !== undefined ? `${ids.note}-error` : undefined}
-                onChange={(event) => {
-                  fieldProps.onChange(event.target.value)
-                  handleFieldChange('note')
-                }}
-              />
-              {errorMessage !== undefined ? (
-                <p
-                  id={`${ids.note}-error`}
-                  className={fieldError}>
-                  {errorMessage}
-                </p>
-              ) : null}
-            </div>
-          )
-        }}
-      </Field>
+      <div className={field}>
+        <StyledLabel htmlFor={fields.note.id}>メモ</StyledLabel>
+        <StyledInput
+          {...getInputProps(fields.note, { type: 'text' })}
+          autoComplete='off'
+          aria-invalid={noteError !== undefined}
+          aria-describedby={noteError !== undefined ? fields.note.errorId : undefined}
+          onChange={() => {
+            handleFieldChange('note')
+          }}
+        />
+        {noteError !== undefined ? (
+          <p
+            id={fields.note.errorId}
+            className={fieldError}>
+            {noteError}
+          </p>
+        ) : null}
+      </div>
     </>
   )
 }

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/index.stories.tsx
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/index.stories.tsx
@@ -300,7 +300,7 @@ export const EditingOtherFieldKeepsUnrelatedServerError = meta.story({
   }
 })
 
-export const FormischValidationClearsOnEdit = Default.extend({
+export const ValidationClearsOnEdit = Default.extend({
   args: {
     initialValues: {
       url: 'not-a-url',
@@ -311,11 +311,11 @@ export const FormischValidationClearsOnEdit = Default.extend({
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
-    // 送信で Formisch validation error を出す
+    // 送信で Conform validation error を出す
     await userEvent.click(canvas.getByRole('button', { name: '更新' }))
     await expect(canvas.getByText('Invalid URL: Received "not-a-url"')).toBeInTheDocument()
 
-    // URL を編集すると Formisch 側の error は onChange で clear される (従来通り)
+    // URL を編集すると Conform 側の error は onInput 再検証で消える
     const url = canvas.getByLabelText('URL')
     await userEvent.clear(url)
     await userEvent.type(url, 'https://example.com/edited')

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/index.tsx
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/index.tsx
@@ -1,12 +1,13 @@
-import { Form, getErrors, useForm } from '@formisch/react'
-import { useId } from 'react'
+import { getFormProps, useForm } from '@conform-to/react'
+import { parseWithValibot } from '@conform-to/valibot'
+import { useTransition } from 'react'
 
 import { StyledButton } from '../../../../../shared/components/styled-button'
 import { srOnly } from '../../../../../styles/sr-only'
 import { workbenchFields, workbenchForm } from '../../../../../styles/workbench'
 import { BookmarkFormFields } from './fields'
-import type { BookmarkFormFieldIds } from './fields'
 import { bookmarkFormSchema } from './schema'
+import type { BookmarkFormOutput } from './schema'
 import { BookmarkFormSummary } from './summary'
 import type { BookmarkFormFieldKey, BookmarkFormProps } from './types'
 import { useBookmarkTitleFetch } from './use-bookmark-title-fetch'
@@ -23,6 +24,15 @@ export type {
 } from './types'
 export type { BookmarkFormInput, BookmarkFormOutput } from './schema'
 
+function readFormValue(formId: string, name: string): string {
+  const formElement = document.getElementById(formId)
+  if (!(formElement instanceof HTMLFormElement)) {
+    return ''
+  }
+  const value = new FormData(formElement).get(name)
+  return typeof value === 'string' ? value : ''
+}
+
 export function BookmarkForm({
   initialValues,
   serverError = null,
@@ -33,39 +43,49 @@ export function BookmarkForm({
   onSubmit,
   fetchTitleAction
 }: BookmarkFormProps) {
-  const baseId = useId()
-  const ids: BookmarkFormFieldIds & { readonly summary: string } = {
-    url: `${baseId}-url`,
-    title: `${baseId}-title`,
-    note: `${baseId}-note`,
-    summary: `${baseId}-summary`
-  }
-
-  const form = useForm({
-    initialInput: {
+  const [pending, startSubmit] = useTransition()
+  const [form, fields] = useForm<BookmarkFormOutput>({
+    defaultValue: {
       url: initialValues.url,
       title: initialValues.title,
-      note: initialValues.note
+      note: initialValues.note ?? ''
     },
-    schema: bookmarkFormSchema
+    onSubmit(event, { submission }) {
+      if (submission?.status !== 'success') {
+        return
+      }
+      event.preventDefault()
+      startSubmit(async () => {
+        await onSubmit(submission.value)
+      })
+    },
+    onValidate({ formData }) {
+      return parseWithValibot(formData, {
+        disableAutoCoercion: true,
+        schema: bookmarkFormSchema
+      })
+    },
+    shouldRevalidate: 'onInput',
+    shouldValidate: 'onSubmit'
   })
 
   const { titleFetchError, isFetchingTitle, handleFetchTitle } = useBookmarkTitleFetch({
-    form,
     fetchTitleAction,
-    onClearFieldError
+    getUrl: () => readFormValue(form.id, fields.url.name),
+    onClearFieldError,
+    setTitle: (title) => {
+      form.update({ name: fields.title.name, value: title })
+    }
   })
 
-  // Server error を Formisch store へコピーしない。
-  // Formisch は現在の入力値に対する validation を、serverError は直前の送信結果を
+  // Server error を Conform へコピーしない。
+  // Conform は現在の入力値に対する validation を、serverError は直前の送信結果を
   // それぞれ独立に持つ責務にする。両者を同期させると、外部 prop の serverError と
-  // Formisch 内部 store の clear タイミングがずれて、古い server error が field に
+  // Conform 内部 state の clear タイミングがずれて、古い server error が field に
   // 残り続ける不具合を作る (以前の実装で顕在化していた)。
-  // よって Formisch は Formisch の error だけを所有し、serverError は表示だけ扱う。
+  // よって Conform は Conform の error だけを所有し、serverError は表示だけ扱う。
 
-  const pending = form.isSubmitting
   const busy = pending || isFetchingTitle
-  const formErrors = getErrors(form) ?? []
 
   // Summary 候補は「重複除去せずに」集めるだけにする。完全一致の除去は
   // BookmarkFormSummary に任せる。責務境界を、
@@ -73,8 +93,8 @@ export function BookmarkForm({
   //   BookmarkFormSummary = 表示上の重複除去
   // で分ける。
   const summaryCandidates = [
-    ...(form.isSubmitted && !form.isValid ? ['入力内容を確認してください'] : []),
-    ...formErrors,
+    ...(form.status === 'error' ? ['入力内容を確認してください'] : []),
+    ...(form.errors ?? []),
     serverError?.summary,
     serverError?.fields?.url,
     serverError?.fields?.title,
@@ -85,21 +105,20 @@ export function BookmarkForm({
   )
 
   function handleClearFieldError(key: BookmarkFormFieldKey) {
-    // Formisch の field error は Formisch store が所有し、
+    // Conform の field error は Conform が所有し、
     // Server error は BookmarkEditor が所有する。所有者が別なので clear も別経路で行う。
-    // Formisch 側の clear は fields.tsx の Field 内で fieldProps.onChange 経由で処理されるため、
+    // Conform 側の clear は shouldRevalidate: onInput で処理されるため、
     // ここでは server 側の clear だけを親へ通知する。
     onClearFieldError?.(key)
   }
 
   return (
-    <Form
+    <form
       className={workbenchForm}
-      of={form}
-      onSubmit={onSubmit}
-      aria-describedby={summaryCandidates.length > 0 ? ids.summary : undefined}>
+      {...getFormProps(form)}
+      aria-describedby={summaryCandidates.length > 0 ? form.errorId : undefined}>
       <BookmarkFormSummary
-        id={ids.summary}
+        id={form.errorId}
         messages={summaryCandidates}
       />
 
@@ -108,8 +127,7 @@ export function BookmarkForm({
         disabled={busy}>
         <legend className={srOnly}>{legend}</legend>
         <BookmarkFormFields
-          form={form}
-          ids={ids}
+          fields={fields}
           serverFieldErrors={serverError?.fields}
           busy={busy}
           isFetchingTitle={isFetchingTitle}
@@ -124,6 +142,6 @@ export function BookmarkForm({
         isDisabled={busy}>
         {pending ? pendingLabel : submitLabel}
       </StyledButton>
-    </Form>
+    </form>
   )
 }

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/summary.tsx
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/summary.tsx
@@ -8,7 +8,7 @@ type BookmarkFormSummaryProps = {
 }
 
 // Summary の重複除去はここでだけ行う。BookmarkForm 側では複数の発生源
-// (Formisch / server / title fetch) からのメッセージ候補を素朴に集めるだけにして、
+// (Conform / server / title fetch) からのメッセージ候補を素朴に集めるだけにして、
 // 「どのエラーの重複を許すか」という判断を一箇所に集める。
 // 完全一致に限定するのは、意味や field が異なるエラーを文字列比較でまとめないため。
 function dedupeExactMatchMessages(messages: readonly string[]): readonly string[] {

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/types.ts
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/types.ts
@@ -1,13 +1,10 @@
-import type { FormStore } from '@formisch/react'
-
-import { bookmarkFormSchema } from './schema'
 import type { BookmarkFormOutput } from './schema'
 
 export type BookmarkFormFieldKey = 'url' | 'title' | 'note'
 
 /**
  * BookmarkForm が受け取る画面表示用サーバーエラー。
- * Formisch の validation error はここに載せず、Formisch store が所有する。
+ * Conform の validation error はここに載せず、Conform が所有する。
  * tags は BookmarkForm の責務外なので含めない。
  */
 export type BookmarkFormServerError = {
@@ -17,7 +14,7 @@ export type BookmarkFormServerError = {
 
 /**
  * BookmarkEditor が唯一の所有者となる更新結果エラー。
- * Formisch validation error はここへ持ち込まない。
+ * Conform validation error はここへ持ち込まない。
  */
 export type BookmarkEditorError = {
   readonly form?: BookmarkFormServerError
@@ -56,13 +53,13 @@ export type BookmarkFormProps = {
   readonly initialValues: BookmarkFormInitialValues
   /**
    * BookmarkEditor が保持するサーバーエラーを表示だけのために受け取る。
-   * Formisch store へコピーしない。入力変更時は onClearFieldError 経由で
+   * Conform へコピーしない。入力変更時は onClearFieldError 経由で
    * 所有者 (BookmarkEditor) に削除を依頼する。
    */
   readonly serverError?: BookmarkFormServerError | null
   /**
    * Field 入力変更時に、対応する server error を BookmarkEditor 側で clear するための通知。
-   * Formisch の field error は BookmarkForm が自前で clear するので、
+   * Conform の field error は BookmarkForm が自前で clear するので、
    * ここでは server error 側の clear だけを扱う。
    */
   readonly onClearFieldError?: (field: BookmarkFormFieldKey) => void
@@ -73,5 +70,3 @@ export type BookmarkFormProps = {
   /** タイトル取得 action。hook 側のラッパーを経て useActionState に渡る。Server Function は注入側が持つ */
   readonly fetchTitleAction: BookmarkTitleFetchAction
 }
-
-export type BookmarkFormStore = FormStore<typeof bookmarkFormSchema>

--- a/src/features/bookmarks/components/bookmark-editor/bookmark-form/use-bookmark-title-fetch.ts
+++ b/src/features/bookmarks/components/bookmark-editor/bookmark-form/use-bookmark-title-fetch.ts
@@ -1,9 +1,7 @@
-import { getInput, setErrors, setInput } from '@formisch/react'
 import { startTransition, useActionState, useRef, useState } from 'react'
 
 import type {
   BookmarkFormFieldKey,
-  BookmarkFormStore,
   BookmarkTitleFetchAction,
   BookmarkTitleFetchPayload,
   BookmarkTitleFetchState
@@ -15,13 +13,15 @@ const initialTitleFetchState: BookmarkTitleFetchState = { status: 'idle' }
 const urlRequiredMessage = '先にURLを入力してください'
 
 type UseBookmarkTitleFetchOptions = {
-  readonly form: BookmarkFormStore
+  readonly getUrl: () => string
+  readonly setTitle: (title: string) => void
   readonly fetchTitleAction: BookmarkTitleFetchAction
   readonly onClearFieldError: ((field: BookmarkFormFieldKey) => void) | undefined
 }
 
 export function useBookmarkTitleFetch({
-  form,
+  getUrl,
+  setTitle,
   fetchTitleAction,
   onClearFieldError
 }: UseBookmarkTitleFetchOptions) {
@@ -29,7 +29,7 @@ export function useBookmarkTitleFetch({
   // 同期チェックできる ref で race window を塞ぐ (閉包の isFetchingTitle では塞げない)。
   const inFlightRef = useRef(false)
 
-  // 成功時の form 反映 (setInput / error clear) はこのラッパーが行う (fetchTitleAction は form store に触れないため)。
+  // 成功時の form 反映はこのラッパーが行う (fetchTitleAction は form に触れないため)。
   // ラッパーは毎レンダー再生成されるが、useActionState は最新レンダーの action を実行する。
   const applyFetchedTitleAction = async (
     previous: BookmarkTitleFetchState,
@@ -38,8 +38,7 @@ export function useBookmarkTitleFetch({
     try {
       const next = await fetchTitleAction(previous, payload)
       if (next.status === 'success') {
-        setInput(form, { path: ['title'], input: next.title })
-        clearFieldError(form, 'title')
+        setTitle(next.title)
         onClearFieldError?.('title')
         // 反映後に success を state に残す必要はないため idle へ正規化する。
         return { status: 'idle' }
@@ -60,10 +59,7 @@ export function useBookmarkTitleFetch({
   // 文言は表示時に導出する (フラグ && 現在入力が空)。
   const [urlEmptyErrorShown, setUrlEmptyErrorShown] = useState(false)
 
-  const urlEmptyError =
-    urlEmptyErrorShown && (getInput(form, { path: ['url'] }) ?? '').trim() === ''
-      ? urlRequiredMessage
-      : null
+  const urlEmptyError = urlEmptyErrorShown && getUrl().trim() === '' ? urlRequiredMessage : null
 
   const titleFetchError =
     urlEmptyError ??
@@ -74,7 +70,7 @@ export function useBookmarkTitleFetch({
     if (inFlightRef.current) {
       return
     }
-    const currentInputUrl = getInput(form, { path: ['url'] }) ?? ''
+    const currentInputUrl = getUrl()
     if (currentInputUrl.trim() === '') {
       setUrlEmptyErrorShown(true)
       return
@@ -87,8 +83,4 @@ export function useBookmarkTitleFetch({
   }
 
   return { titleFetchError, isFetchingTitle, handleFetchTitle }
-}
-
-function clearFieldError(form: BookmarkFormStore, key: BookmarkFormFieldKey) {
-  setErrors(form, { path: [key], errors: null })
 }

--- a/src/features/bookmarks/components/bookmark-editor/index.tsx
+++ b/src/features/bookmarks/components/bookmark-editor/index.tsx
@@ -57,16 +57,16 @@ export function BookmarkEditor({
   fetchTitleAction
 }: BookmarkEditorProps) {
   // 更新結果の server error は BookmarkEditor が唯一の所有者になる。
-  // BookmarkForm へは表示用に serverError を渡し、Formisch store へはコピーしない。
-  // これによって、Formisch の validation error と server error のライフサイクルを
-  // 分離でき、field の onChange から Formisch と server それぞれの clear 経路が
+  // BookmarkForm へは表示用に serverError を渡し、Conform へはコピーしない。
+  // これによって、Conform の validation error と server error のライフサイクルを
+  // 分離でき、field の onChange から Conform と server それぞれの clear 経路が
   // 明確に分かれる。
   const [editorError, setEditorError] = useState<BookmarkEditorError | null>(null)
 
   function clearFormFieldError(field: BookmarkFormFieldKey) {
     // BookmarkForm の field 入力変更に応じて、対応する server field error だけを取り除く。
     // Summary と他 field は残す。所有者が Editor 側なので、
-    // BookmarkForm から Formisch を触らずに済む。
+    // BookmarkForm から Conform を触らずに済む。
     setEditorError((current) => {
       if (current === null || current.form === undefined) {
         return current
@@ -92,7 +92,7 @@ export function BookmarkEditor({
     // OnUpdateBookmark と onCompleted のエラー境界を分離する。
     // Update が成功したあとに Navigation (onCompleted) が失敗しても、
     // それは「保存失敗」ではない (実データは保存済み)。
-    // 保存済みであることを伝える安全なメッセージへ変換し、Formisch の submit
+    // 保存済みであることを伝える安全なメッセージへ変換し、Conform の submit
     // Handler へ rejection を返して raw error を validation error にしない。
     const updateResult = await onUpdateBookmark(buildUpdateBookmarkCommand(initialData, values))
 

--- a/src/features/bookmarks/components/bookmark-workbench-form.tsx
+++ b/src/features/bookmarks/components/bookmark-workbench-form.tsx
@@ -1,6 +1,7 @@
-import { Field, getErrors, getInput, useForm, validate } from '@formisch/react'
+import { getFormProps, getInputProps, useForm } from '@conform-to/react'
+import { parseWithValibot } from '@conform-to/valibot'
 import { CircleAlert, Download } from 'lucide-react'
-import { useActionState, useState } from 'react'
+import { startTransition, useActionState, useState } from 'react'
 import * as v from 'valibot'
 
 import { StyledButton } from '../../../shared/components/styled-button'
@@ -36,6 +37,15 @@ interface BookmarkWorkbenchFormProps {
   readonly mapError: (error: unknown) => string | null
 }
 
+function readFormValue(formId: string, name: string): string {
+  const formElement = document.getElementById(formId)
+  if (!(formElement instanceof HTMLFormElement)) {
+    return ''
+  }
+  const value = new FormData(formElement).get(name)
+  return typeof value === 'string' ? value : ''
+}
+
 export function BookmarkWorkbenchForm({
   mode,
   initialValues,
@@ -44,57 +54,76 @@ export function BookmarkWorkbenchForm({
   onSubmit,
   mapError
 }: BookmarkWorkbenchFormProps) {
-  const form = useForm({
-    initialInput: {
+  const [formError, setFormError] = useState<string | null>(null)
+  const [, submitAction, isPending] = useActionState(
+    async (_previous: unknown, formData: FormData) => {
+      setFormError(null)
+      const submission = parseWithValibot(formData, {
+        disableAutoCoercion: true,
+        schema: workbenchSchema
+      })
+      if (submission.status !== 'success') {
+        return
+      }
+
+      const note = submission.value.note === '' ? null : submission.value.note
+
+      try {
+        await onSubmit({ url: submission.value.url, title: submission.value.title, note })
+      } catch (error) {
+        const message = mapError(error)
+        if (message !== null) {
+          setFormError(message)
+        }
+      }
+    },
+    null
+  )
+  const [form, fields] = useForm<BookmarkWorkbenchValues>({
+    defaultValue: {
       url: initialValues.url,
       title: initialValues.title,
       note: initialValues.note ?? ''
     },
-    schema: workbenchSchema
+    onSubmit(event, { formData, submission }) {
+      event.preventDefault()
+      if (submission?.status !== 'success') {
+        return
+      }
+      startTransition(() => {
+        submitAction(formData)
+      })
+    },
+    onValidate({ formData }) {
+      return parseWithValibot(formData, { disableAutoCoercion: true, schema: workbenchSchema })
+    },
+    shouldRevalidate: 'onInput',
+    shouldValidate: 'onSubmit'
   })
 
-  const { titleFetchError, isFetchingTitle, handleFetchTitle } = useBookmarkTitleFetch(form)
-
-  const [formError, setFormError] = useState<string | null>(null)
-
-  const [, submitAction, isPending] = useActionState(async () => {
-    setFormError(null)
-    const result = await validate(form)
-    if (!result.success) {
-      setFormError('入力内容を確認してください')
-      return
+  const { titleFetchError, isFetchingTitle, handleFetchTitle } = useBookmarkTitleFetch({
+    getUrl: () => readFormValue(form.id, fields.url.name),
+    setTitle: (title) => {
+      form.update({ name: fields.title.name, value: title })
     }
-
-    const url = getInput(form, { path: ['url'] }) ?? ''
-    const title = getInput(form, { path: ['title'] }) ?? ''
-    const rawNote = getInput(form, { path: ['note'] }) ?? ''
-    const note = rawNote === '' ? null : rawNote
-
-    try {
-      await onSubmit({ url, title, note })
-    } catch (error) {
-      const message = mapError(error)
-      if (message !== null) {
-        setFormError(message)
-      }
-    }
-  }, null)
+  })
 
   const busy = isPending || isFetchingTitle
   const summaryErrors = [formError, titleFetchError].filter(
     (message): message is string => message != null
   )
-  const schemaErrors = getErrors(form)
+  const schemaErrors = form.status === 'error' ? ['入力内容を確認してください'] : []
   const allSummary = [
     ...summaryErrors,
-    ...(schemaErrors ?? []).filter((message) => !summaryErrors.includes(message))
+    ...schemaErrors.filter((message) => !summaryErrors.includes(message)),
+    ...(form.errors ?? []).filter((message) => !summaryErrors.includes(message))
   ]
 
   return (
     <form
       className={workbenchForm}
-      action={submitAction}
-      noValidate>
+      {...getFormProps(form)}
+      action={submitAction}>
       {allSummary.length > 0 ? (
         <div
           className={formSummary}
@@ -120,80 +149,47 @@ export function BookmarkWorkbenchForm({
           {mode === 'new' ? 'ブックマーク新規登録' : 'ブックマーク編集'}
         </legend>
 
-        <Field
-          of={form}
-          path={['url']}>
-          {(f) => (
-            <div className={field}>
-              <StyledLabel htmlFor={f.props.name}>URL</StyledLabel>
-              <div className={fieldUrlRow}>
-                <StyledInput
-                  id={f.props.name}
-                  value={f.input}
-                  type='url'
-                  onChange={(event) => {
-                    f.onChange(event.target.value)
-                  }}
-                  required
-                  disabled={busy}
-                />
-                <StyledButton
-                  onPress={() => {
-                    void handleFetchTitle()
-                  }}
-                  isDisabled={busy}>
-                  <Download
-                    size={16}
-                    aria-hidden
-                  />{' '}
-                  {isFetchingTitle ? '取得中…' : 'タイトルを取得'}
-                </StyledButton>
-              </div>
-              {f.errors ? <p className={fieldError}>{f.errors[0]}</p> : null}
-            </div>
-          )}
-        </Field>
+        <div className={field}>
+          <StyledLabel htmlFor={fields.url.id}>URL</StyledLabel>
+          <div className={fieldUrlRow}>
+            <StyledInput
+              {...getInputProps(fields.url, { type: 'url' })}
+              required
+              disabled={busy}
+            />
+            <StyledButton
+              onPress={() => {
+                void handleFetchTitle()
+              }}
+              isDisabled={busy}>
+              <Download
+                size={16}
+                aria-hidden
+              />{' '}
+              {isFetchingTitle ? '取得中…' : 'タイトルを取得'}
+            </StyledButton>
+          </div>
+          {fields.url.errors ? <p className={fieldError}>{fields.url.errors[0]}</p> : null}
+        </div>
 
-        <Field
-          of={form}
-          path={['title']}>
-          {(f) => (
-            <div className={field}>
-              <StyledLabel htmlFor={f.props.name}>タイトル</StyledLabel>
-              <StyledInput
-                id={f.props.name}
-                value={f.input}
-                type='text'
-                onChange={(event) => {
-                  f.onChange(event.target.value)
-                }}
-                required
-                disabled={busy}
-              />
-              {f.errors ? <p className={fieldError}>{f.errors[0]}</p> : null}
-            </div>
-          )}
-        </Field>
+        <div className={field}>
+          <StyledLabel htmlFor={fields.title.id}>タイトル</StyledLabel>
+          <StyledInput
+            {...getInputProps(fields.title, { type: 'text' })}
+            required
+            disabled={busy}
+          />
+          {fields.title.errors ? <p className={fieldError}>{fields.title.errors[0]}</p> : null}
+        </div>
 
-        <Field
-          of={form}
-          path={['note']}>
-          {(f) => (
-            <div className={field}>
-              <StyledLabel htmlFor={f.props.name}>メモ</StyledLabel>
-              <StyledInput
-                id={f.props.name}
-                value={f.input ?? ''}
-                type='text'
-                onChange={(event) => {
-                  f.onChange(event.target.value)
-                }}
-                disabled={busy}
-              />
-              {f.errors ? <p className={fieldError}>{f.errors[0]}</p> : null}
-            </div>
-          )}
-        </Field>
+        <div className={field}>
+          <StyledLabel htmlFor={fields.note.id}>メモ</StyledLabel>
+          <StyledInput
+            {...getInputProps(fields.note, { type: 'text' })}
+            disabled={busy}
+          />
+          {fields.note.errors ? <p className={fieldError}>{fields.note.errors[0]}</p> : null}
+        </div>
       </fieldset>
 
       <StyledButton

--- a/src/features/bookmarks/hooks/use-bookmark-title-fetch.ts
+++ b/src/features/bookmarks/hooks/use-bookmark-title-fetch.ts
@@ -1,20 +1,22 @@
-import { getInput, setInput } from '@formisch/react'
-import type { FormStore } from '@formisch/react'
 import { useState } from 'react'
 
 import { rpcClient } from '../../../rpc/client'
-import type { workbenchSchema } from '../components/bookmark-workbench-form'
 import { getTitleFetchErrorMessage } from '../lib/get-title-fetch-error-message'
 
 const titleFetchFailedMessage = 'タイトルを取得できませんでした。手入力で続けられます'
 
-export function useBookmarkTitleFetch(form: FormStore<typeof workbenchSchema>) {
+type UseBookmarkTitleFetchOptions = {
+  readonly getUrl: () => string
+  readonly setTitle: (title: string) => void
+}
+
+export function useBookmarkTitleFetch({ getUrl, setTitle }: UseBookmarkTitleFetchOptions) {
   const [titleFetchError, setTitleFetchError] = useState<string | null>(null)
   const [isFetchingTitle, setIsFetchingTitle] = useState(false)
 
   async function handleFetchTitle() {
     setTitleFetchError(null)
-    const url = getInput(form, { path: ['url'] }) ?? ''
+    const url = getUrl()
     if (url.trim() === '') {
       setTitleFetchError('先にURLを入力してください')
       return
@@ -27,7 +29,7 @@ export function useBookmarkTitleFetch(form: FormStore<typeof workbenchSchema>) {
         setTitleFetchError(titleFetchFailedMessage)
         return
       }
-      setInput(form, { path: ['title'], input: fetchedTitle })
+      setTitle(fetchedTitle)
     } catch (error) {
       setTitleFetchError(getTitleFetchErrorMessage(error))
     } finally {

--- a/src/features/tags/components/tag-form.tsx
+++ b/src/features/tags/components/tag-form.tsx
@@ -1,15 +1,20 @@
-import { Field, getInput, useForm } from '@formisch/react'
+import { getFormProps, getInputProps, useForm } from '@conform-to/react'
+import { parseWithValibot } from '@conform-to/valibot'
 import { CircleAlert } from 'lucide-react'
-import { useActionState, useState } from 'react'
+import { startTransition, useActionState, useState } from 'react'
 import * as v from 'valibot'
 
 import { StyledButton } from '../../../shared/components/styled-button'
 import { StyledInput } from '../../../shared/components/styled-input'
 import { StyledLabel } from '../../../shared/components/styled-label'
-import { field, formSummary } from '../../../styles/form'
+import { field, fieldError, formSummary } from '../../../styles/form'
 import { srOnly } from '../../../styles/sr-only'
 import { workbenchFields, workbenchForm } from '../../../styles/workbench'
 import { TagEditFields } from './tag-edit-fields'
+
+const tagNameSchema = v.object({
+  name: v.pipe(v.string(), v.nonEmpty('タグ名を入力してください'))
+})
 
 type TagFormValues = {
   readonly name: string
@@ -43,20 +48,18 @@ export function TagForm({
   const [color, setColor] = useState<string | null>(initialValues.color)
   const [sortOrder, setSortOrder] = useState(initialValues.sortOrder)
   const [formError, setFormError] = useState<string | null>(null)
-  const form = useForm({
-    initialInput: {
-      name: initialValues.name
-    },
-    schema: v.object({
-      name: v.string()
-    })
-  })
-  const [, submit, isPending] = useActionState(async () => {
+  const [, submit, isPending] = useActionState(async (_previous: unknown, formData: FormData) => {
     setFormError(null)
-    const name = getInput(form, { path: ['name'] }) ?? ''
+    const submission = parseWithValibot(formData, {
+      disableAutoCoercion: true,
+      schema: tagNameSchema
+    })
+    if (submission.status !== 'success') {
+      return
+    }
 
     try {
-      await onSubmit({ name, pinned, color, sortOrder })
+      await onSubmit({ name: submission.value.name, pinned, color, sortOrder })
     } catch (error) {
       const message = mapError(error)
       if (message !== null) {
@@ -64,10 +67,30 @@ export function TagForm({
       }
     }
   }, null)
+  const [form, fields] = useForm({
+    defaultValue: {
+      name: initialValues.name
+    },
+    onSubmit(event, { formData, submission }) {
+      event.preventDefault()
+      if (submission?.status !== 'success') {
+        return
+      }
+      startTransition(() => {
+        submit(formData)
+      })
+    },
+    onValidate({ formData }) {
+      return parseWithValibot(formData, { disableAutoCoercion: true, schema: tagNameSchema })
+    },
+    shouldRevalidate: 'onInput',
+    shouldValidate: 'onSubmit'
+  })
 
   return (
     <form
       className={workbenchForm}
+      {...getFormProps(form)}
       action={submit}>
       {formError != null ? (
         <div
@@ -89,24 +112,14 @@ export function TagForm({
         disabled={isPending}>
         <legend className={srOnly}>{legend}</legend>
 
-        <Field
-          of={form}
-          path={['name']}>
-          {(fieldProps) => (
-            <div className={field}>
-              <StyledLabel htmlFor={fieldProps.props.name}>タグ名</StyledLabel>
-              <StyledInput
-                id={fieldProps.props.name}
-                value={fieldProps.input}
-                type='text'
-                onChange={(event) => {
-                  fieldProps.onChange(event.target.value)
-                }}
-                required
-              />
-            </div>
-          )}
-        </Field>
+        <div className={field}>
+          <StyledLabel htmlFor={fields.name.id}>タグ名</StyledLabel>
+          <StyledInput
+            {...getInputProps(fields.name, { type: 'text' })}
+            required
+          />
+          {fields.name.errors ? <p className={fieldError}>{fields.name.errors[0]}</p> : null}
+        </div>
 
         <TagEditFields
           pinned={pinned}


### PR DESCRIPTION
## Summary
- Replace `@formisch/react` with `@conform-to/react` + `@conform-to/valibot` so sign-in, bookmark, and tag forms submit native `FormData` while keeping the existing Valibot schemas.
- Uncontrolled Conform inputs stay filled after a failed `useActionState` submit by `preventDefault` + `startTransition` on the client action.
- Title fetch no longer talks to a Formisch store; it reads URL from the form DOM and updates the title field through Conform's `form.update`.

## Test plan
- [ ] Sign-in: empty submit shows schema errors; values remain after a failed submit
- [ ] New bookmark: empty submit shows URL/title errors; title fetch from `https://example.com` fills the title
- [ ] New tag: empty submit shows the tag name error
- [ ] Edit bookmark: invalid URL stays on the editor with a validation error and does not save


Made with [Cursor](https://cursor.com)