### PR TITLE
fix: exclude Storybook files from TanStack Router file routes

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,13 @@ const config = defineConfig({
   plugins: [
     devtools(),
     cloudflare({ viteEnvironment: { name: 'ssr' } }),
-    tanstackStart(),
+    tanstackStart({
+      router: {
+        // File-based routing treats dots as path segments, so
+        // `index.stories.tsx` would otherwise be crawled as `/stories`.
+        routeFileIgnorePattern: '\\.stories\\.(tsx|ts|jsx|js)$'
+      }
+    }),
     viteReact()
   ],
   resolve: {


### PR DESCRIPTION
## Summary
- `src/routes/` 配下の `*.stories.tsx` はファイル名のドット区切りで `/stories` などのルート候補としてクロールされていた
- `tanstackStart` に `routeFileIgnorePattern` を設定し、Storybook ファイルを file-based routing から除外する

## Test plan
- [ ] `src/routes/` 配下の Story（サインイン、ブックマーク一覧、編集）が Storybook でこれまで通り開ける
- [ ] アプリのルート一覧に `*.stories.tsx` 由来の画面（例: `/stories`）が出ない
- [ ] `pnpm run dev` 起動時に stories ファイルを Route として扱う警告が出ない


Made with [Cursor](https://cursor.com)