### PR TITLE
Cursor Cloud Agent で LibSQL を自動起動する

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -19,7 +19,7 @@ RUN install -m 0755 -d /etc/apt/keyrings \
   && curl --retry 3 --retry-delay 5 -fsSL https://download.docker.com/linux/ubuntu/gpg \
     | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
   && chmod a+r /etc/apt/keyrings/docker.gpg \
-  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo \"$VERSION_CODENAME\") stable" \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
     > /etc/apt/sources.list.d/docker.list \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,56 @@
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    gnupg \
+    iptables \
+    openssh-client \
+    sudo \
+    fuse-overlayfs \
+  && rm -rf /var/lib/apt/lists/*
+
+# Cursor Cloud Agent 上で nested Docker を実行するため Docker Engine を導入する。
+RUN install -m 0755 -d /etc/apt/keyrings \
+  && curl --retry 3 --retry-delay 5 -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+  && chmod a+r /etc/apt/keyrings/docker.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo \"$VERSION_CODENAME\") stable" \
+    > /etc/apt/sources.list.d/docker.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+    containerd.io \
+    docker-buildx-plugin \
+    docker-ce \
+    docker-ce-cli \
+    docker-compose-plugin \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /etc/docker \
+  && printf '%s\n' \
+    '{' \
+    '  "storage-driver": "fuse-overlayfs"' \
+    '}' \
+    > /etc/docker/daemon.json \
+  && update-alternatives --set iptables /usr/sbin/iptables-legacy \
+  && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+# Pantry が要求する Node.js 24 系と pnpm をシステム全体で利用可能にする。
+RUN curl --retry 3 --retry-delay 5 -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+  && apt-get install -y --no-install-recommends nodejs \
+  && npm install --global pnpm@11.17.0 \
+  && node --version \
+  && pnpm --version \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN id -u ubuntu >/dev/null 2>&1 || useradd -m -s /bin/bash ubuntu \
+  && groupadd -f docker \
+  && usermod -aG docker,sudo ubuntu \
+  && echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu \
+  && chmod 0440 /etc/sudoers.d/ubuntu
+
+USER ubuntu

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,8 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "install": "pnpm install --frozen-lockfile",
+  "start": "bash .cursor/start-libsql.sh"
+}

--- a/.cursor/start-libsql.sh
+++ b/.cursor/start-libsql.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly container_name="pantry-turso"
+readonly image_tag="pantry-turso:cursor-cloud"
+readonly health_url="http://127.0.0.1:8080/v2"
+
+sudo service docker start
+
+docker rm -f "${container_name}" >/dev/null 2>&1 || true
+
+docker build \
+  --file Dockerfile \
+  --tag "${image_tag}" \
+  .
+
+docker run \
+  --detach \
+  --name "${container_name}" \
+  --publish 127.0.0.1:8080:8080 \
+  --tmpfs /var/lib/sqld \
+  "${image_tag}" \
+  >/dev/null
+
+for _ in $(seq 1 30); do
+  if curl --fail --silent "${health_url}" >/dev/null; then
+    exit 0
+  fi
+
+  sleep 0.5
+done
+
+echo "LibSQL が ${health_url} で起動可能になる前にタイムアウトしました。" >&2
+docker logs "${container_name}" >&2 || true
+exit 1

--- a/.cursor/start-libsql.sh
+++ b/.cursor/start-libsql.sh
@@ -5,7 +5,27 @@ readonly container_name="pantry-turso"
 readonly image_tag="pantry-turso:cursor-cloud"
 readonly health_url="http://127.0.0.1:8080/v2"
 
-sudo service docker start
+ensure_docker_daemon() {
+  if docker info >/dev/null 2>&1; then
+    return 0
+  fi
+
+  # `service docker start` は既に起動中だと非 0 を返すため、成否は docker info で判定する。
+  sudo service docker start || true
+
+  for _ in $(seq 1 30); do
+    if docker info >/dev/null 2>&1; then
+      return 0
+    fi
+
+    sleep 0.5
+  done
+
+  echo "Docker デーモンを起動できませんでした。" >&2
+  return 1
+}
+
+ensure_docker_daemon
 
 docker rm -f "${container_name}" >/dev/null 2>&1 || true
 


### PR DESCRIPTION
## 関連Issue

Closes #242

## 実装概要

- `.cursor/environment.json` を追加し、Cursor Cloud Agent の環境設定をリポジトリ管理にした。
- `.cursor/Dockerfile` を追加し、Cloud Agent 内で Node.js 24 / pnpm 11.17.0 と nested Docker を利用できる環境を用意した。
- `.cursor/start-libsql.sh` を追加し、agent 起動時に Docker デーモンを起動したうえで、リポジトリのルート `Dockerfile` から LibSQL イメージをビルドして `pantry-turso` コンテナを起動するようにした。
- LibSQL は既存ローカル開発と同じ `127.0.0.1:8080` で公開し、`/v2` が応答するまで readiness check を行う。
- 再起動時は既存の `pantry-turso` コンテナを削除してから作り直し、名前衝突を避ける。

## 主な実装上の判断

- ルート `Dockerfile` は LibSQL サーバー用イメージなので、Cloud Agent 自体の build Dockerfile として直接は使用していない。Cloud Agent 用の `.cursor/Dockerfile` で開発環境を作り、その中の Docker Engine からルート `Dockerfile` を build/run する二層構成にした。
- Cursor 公式ドキュメントの nested Docker 向け推奨に合わせ、`fuse-overlayfs` と `iptables-legacy` を使用する。
- `compose.yaml` は `platform: linux/arm64` を固定しているため Cloud Agent の実行アーキテクチャと不要に結合する。Cloud Agent ではルート `Dockerfile` を直接 build/run する。
- LibSQL イメージの build は agent 起動時に実施する。feature branch 上でルート `Dockerfile` が変わった場合も、その branch の定義を使用するため。通常は Docker のレイヤーキャッシュが再利用される。
- DB migration / seed と Vite dev server は自動起動していない。Issue の対象外どおり、今回は LibSQL サービスの起動だけに限定した。

## 受け入れ条件の検証

| 受け入れ条件 | 結果 | 検証方法・証跡 |
| ------------ | :--: | -------------- |
| Cursor Cloud Agent の環境 Build が、リポジトリにコミットされた設定から作成できる | ⚠️ | `.cursor/environment.json` は Cursor 公式仕様に沿って `build` / `install` / `start` を定義。新規 repo-level 設定の実 Build は Cursor Cloud Agent 実環境で要確認 |
| Cloud Agent 起動後、`docker ps` で LibSQL コンテナが起動中である | ⚠️ | `start-libsql.sh` が `docker run --detach --name pantry-turso` を実行。実 Cloud Agent VM 上で要確認 |
| Cloud Agent 起動後、`curl http://127.0.0.1:8080/v2` が成功する | ⚠️ | 起動処理自身が同 URL を最大 15 秒 readiness check し、失敗時は非 0 終了する。実 Cloud Agent VM 上で要確認 |
| `pnpm install --frozen-lockfile` が成功する前提の Node.js / pnpm 環境が用意される | ⚠️ | `.cursor/Dockerfile` で Node.js 24 系と `pnpm@11.17.0` を導入し、`install` に `pnpm install --frozen-lockfile` を設定。Docker image build は実 Cloud Agent 上で要確認 |
| 起動処理を再実行しても LibSQL コンテナの重複・名前衝突で失敗しない | ✅ | `docker rm -f pantry-turso || true` の後に新規コンテナを作成する構成を確認 |
| LibSQL コンテナはリポジトリのルート `Dockerfile` を入力として生成される | ✅ | `docker build --file Dockerfile --tag pantry-turso:cursor-cloud .` を使用 |

## 自動検証

アプリケーションコードは変更していないため、通常の `pnpm` 系チェックは未実行。

- ✅ `environment.json`: `python -m json.tool` による JSON 構文検証
- ✅ `start-libsql.sh`: `bash -n` による shell 構文検証
- ⚠️ `.cursor/Dockerfile` の image build: 現在の実行環境に Docker daemon がないため未実行
- ⚠️ GitHub Actions: branch head に workflow run なし

## 仕様との差異

なし

## 補足

Cursor の現行ドキュメントでは、Docker やデータベースのような実行中サービスは `install` ではなく agent 起動時の `start` で起動することが推奨されている。また nested Docker の複雑な構成では `fuse-overlayfs` / `iptables-legacy` が推奨されている。

参考: https://prod.cursor.com/ja/docs/cloud-agent/setup

repo-level `.cursor/environment.json` の新規環境 Build については、Cursor が default branch の設定を基準に Build を作成する仕様があるため、マージ後の環境 Build で最終確認が必要になる可能性がある。