### PR TITLE
fix: client bundle が ssr-rpc-fetch.server を import しないようにする

### DIFF
--- a/src/rpc/client.ts
+++ b/src/rpc/client.ts
@@ -1,8 +1,16 @@
 import { createORPCClient, ORPCError, onError } from '@orpc/client'
 import { RPCLink } from '@orpc/client/fetch'
 import type { RouterClient } from '@orpc/server'
+import { createIsomorphicFn } from '@tanstack/react-start'
 
 import type { AppRouter } from './create-app-router'
+
+const rpcFetch = createIsomorphicFn()
+  .server(async (request: Request, _init?: RequestInit) => {
+    const { ssrRpcFetch } = await import('./ssr-rpc-fetch.server')
+    return ssrRpcFetch(request)
+  })
+  .client((request: Request, init?: RequestInit) => globalThis.fetch(request, init))
 
 function redirectToSignIn(): void {
   if (typeof window === 'undefined') {
@@ -21,18 +29,12 @@ const link = new RPCLink({
       return `${window.location.origin}/api/rpc`
     }
 
-    // SSR では url を使わない。ssrRpcFetch が process 内の handler へ直接流す。
+    // SSR では url を使わない。rpcFetch の server 実装が process 内の handler へ直接流す。
     return 'http://pantry.internal/api/rpc'
   },
   // 呼び出し毎に解決する。構築時に bind すると、あとから差し替えられた
   // global fetch（テストや Storybook の stub）を拾えない。
-  fetch: (request, init) => {
-    if (import.meta.env.SSR) {
-      return import('./ssr-rpc-fetch.server').then(({ ssrRpcFetch }) => ssrRpcFetch(request))
-    }
-
-    return globalThis.fetch(request, init)
-  },
+  fetch: (request, init) => rpcFetch(request, init),
   interceptors: [
     onError((error) => {
       if (error instanceof ORPCError && error.defined && error.code === 'UNAUTHORIZED') {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 関連Issue

なし（開発時の Vite import-protection 警告対応）

## 実装概要

`src/rpc/client.ts` は client bundle に乗るモジュールなのに、`import.meta.env.SSR` の内側で `ssr-rpc-fetch.server` を動的 import していた。TanStack Start の import-protection は DCE 前の import グラフを見るため、クライアント環境で次の警告が出ていた。

```
[import-protection] Import denied in client environment
  Denied by file pattern: **/*.server.*
  Importer: src/rpc/client.ts
  Import: "./ssr-rpc-fetch.server"
```

プラグインが案内しているとおり、fetch を `createIsomorphicFn().server().client()` に分けた。server コールバックの `*.server.*` import は client bundle から落ちる。SSR の Cookie 転送（`ssrRpcFetch`）と browser の `globalThis.fetch` はどちらも残している。

## 主な実装上の判断

- `import.meta.env.SSR` では import-protection を避けられない。既存の `getRpcClient`（`runtime-client.ts`）と同じ `createIsomorphicFn` に揃えた。
- SSR prefetch（一覧の `orpc` / `rpcClient`）を壊さないため、server 実装は削除せず isomorphic の server 側へ移した。
- 新しいテストファイルは追加していない。

## 受け入れ条件の検証

| 受け入れ条件 | 結果 | 検証方法・証跡 |
| ------------ | :-----: | -------------- |
| クライアント環境で `ssr-rpc-fetch.server` の import-protection が出ない | ✅ | `pnpm run build` 成功（本番は import-protection が error）。client 成果物に `ssr-rpc-fetch` なし。Vite ログにも当該警告なし。 |
| SSR の RPC（Cookie 転送・一覧 prefetch）が動く | ✅ | サインイン後にブックマーク一覧が表示される |

[修正後のブックマーク一覧](https://cursor.com/agents/bc-01a0480a-d586-73bb-9606-85f720f6830f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter-rpc-fix-bookmark-list.png)

## 自動検証

- [x] `pnpm run format:check`
- [x] `pnpm run lint`（既存 warning のみ、error 0）
- [x] `pnpm run typecheck`
- [x] `pnpm run test`（70 files / 350 tests）
- [x] `pnpm run build`

## 仕様との差異

なし

## 補足

- 残っている `[tanstack-router] RouteComponent` 警告は main 上の別件（#247）。この PR の対象外。
- `[React Scan] react-grab is outdated` も DEV のみで対象外。


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0480a-d586-73bb-9606-85f720f6830f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0480a-d586-73bb-9606-85f720f6830f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

