### PR TITLE
chore(test): minimize successful Vitest output

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,6 +37,8 @@ export default defineConfig({
   },
   // Required so Knip's Vitest plugin registers default test entry globs.
   test: {
+    reporters:
+      process.env['GITHUB_ACTIONS'] === 'true' ? ['minimal', 'github-actions'] : ['minimal'],
     projects: [
       {
         plugins: [


### PR DESCRIPTION
Closes #253

## Summary

- Configure Vitest to use the standard `minimal` reporter locally.
- Add the standard `github-actions` reporter in GitHub Actions to preserve annotations.
- Keep the standard Vitest success summary; suppress successful test/file listings and successful-test console output.

## Verification

- [x] `env -u GITHUB_ACTIONS pnpm test` (80 test files, 403 tests)
- [x] `pnpm run format:check`
- [x] `pnpm run typecheck`
- [x] `pnpm exec oxlint .` (existing warnings only)
- [x] `pnpm run build`
- [x] Pre-push hooks (`betterleaks`, `knip`)

The repeated `Using secrets defined in .env` messages come from Wrangler while initializing the Cloudflare Workers test pool and are unchanged by this reporter configuration.