### PR TITLE
chore(e2e): Playwright E2Eを導入し主要フローをPR CIで検証する

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,3 +128,31 @@ jobs:
         shell: bash
         run: |
           pnpm run test:persistence
+
+  e2e:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup
+        uses: ./.github/composite-actions/cache-and-install
+
+      - name: Install Playwright Chromium
+        shell: bash
+        run: |
+          pnpm exec playwright install --with-deps chromium
+
+      - name: Playwright E2E
+        shell: bash
+        run: |
+          pnpm run test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/e2e-smoke.yaml
+++ b/.github/workflows/e2e-smoke.yaml
@@ -1,0 +1,24 @@
+name: E2E external HTTP smoke
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-smoke:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup
+        uses: ./.github/composite-actions/cache-and-install
+      - name: Install Playwright Chromium
+        shell: bash
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Playwright external HTTP smoke
+        shell: bash
+        run: pnpm run test:e2e:smoke

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,10 @@ screenshots/
 *storybook.log
 debug-storybook.log
 storybook-static
+
+# Playwright E2E
+/playwright-report/
+/test-results/
+/blob-report/
+/e2e/.auth/
+/e2e/.runtime/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,18 +23,20 @@
 
 ## 開発コマンド
 
-| コマンド                    | 説明                                                        |
-| --------------------------- | ----------------------------------------------------------- |
-| `pnpm run dev`              | 開発サーバー起動（Vite + workerd）                          |
-| `pnpm run build`            | プロダクションビルド                                        |
-| `pnpm run preview`          | ビルド成果物を preview                                      |
-| `pnpm run deploy`           | Cloudflare Workers にデプロイ                               |
-| `pnpm run test`             | テスト実行（Vitest。Docker 不要）                           |
-| `pnpm run test:persistence` | Persistence Integration test（Testcontainers + 実 libSQL）  |
-| `pnpm run cf-typegen`       | Worker バインディングの型生成                               |
-| `pnpm run migrate:dev`      | Turso開発DBへDrizzleマイグレーション適用                    |
-| `pnpm run db:seed`          | Turso開発DBへテスト／開発データを投入                       |
-| `pnpm run lint:markup`      | HTML/JSX のアクセシビリティ・マークアップ検査（markuplint） |
+| コマンド                    | 説明                                                                 |
+| --------------------------- | -------------------------------------------------------------------- |
+| `pnpm run dev`              | 開発サーバー起動（Vite + workerd）                                   |
+| `pnpm run build`            | プロダクションビルド                                                 |
+| `pnpm run preview`          | ビルド成果物を preview                                               |
+| `pnpm run deploy`           | Cloudflare Workers にデプロイ                                        |
+| `pnpm run test`             | テスト実行（Vitest。Docker 不要）                                    |
+| `pnpm run test:persistence` | Persistence Integration test（Testcontainers + 実 libSQL）           |
+| `pnpm run test:e2e`         | Playwright E2E（Chromium + ローカル Worker + Testcontainers libSQL） |
+| `pnpm run test:e2e:smoke`   | 外部 HTTP タイトル取得 smoke（`https://example.com`）                |
+| `pnpm run cf-typegen`       | Worker バインディングの型生成                                        |
+| `pnpm run migrate:dev`      | Turso開発DBへDrizzleマイグレーション適用                             |
+| `pnpm run db:seed`          | Turso開発DBへテスト／開発データを投入                                |
+| `pnpm run lint:markup`      | HTML/JSX のアクセシビリティ・マークアップ検査（markuplint）          |
 
 ## 設計方針
 

--- a/docs/superpowers/plans/2026-08-31-playwright-e2e.md
+++ b/docs/superpowers/plans/2026-08-31-playwright-e2e.md
@@ -206,7 +206,7 @@ Create `e2e/sign-in.spec.ts`:
 ```ts
 import { expect, test } from '@playwright/test'
 
-test('sign-in page renders the login heading', async ({ page }) => {
+test('サインインページにログイン見出しが表示される', async ({ page }) => {
   await page.goto('/sign-in')
   await expect(page.getByRole('heading', { name: 'ログイン' })).toBeVisible()
 })
@@ -417,7 +417,9 @@ import { expect, test } from '@playwright/test'
 
 import { E2E_USER } from './constants'
 
-test('email and password sign-in shows the bookmark list', async ({ page }) => {
+test('メールアドレスとパスワードでサインインするとブックマーク一覧が表示される', async ({
+  page
+}) => {
   await page.goto('/sign-in')
   await page.getByRole('textbox', { name: 'メール' }).fill(E2E_USER.email)
   await page.getByRole('textbox', { name: 'パスワード' }).fill(E2E_USER.password)
@@ -491,7 +493,7 @@ import { readRuntime } from './runtime'
 
 const authFile = path.join(import.meta.dirname, '.auth/user.json')
 
-setup('authenticate', async ({ page }) => {
+setup('認証済み状態を保存する', async ({ page }) => {
   const { libsqlUrl } = await readRuntime()
   const { client, close } = createE2eClient(libsqlUrl)
   try {
@@ -565,8 +567,8 @@ projects: [
 ```ts
 import { expect, test } from './fixtures'
 
-test.describe.serial('fixture isolation', () => {
-  test('first test inserts a bookmark that must not leak', async ({ page }) => {
+test.describe.serial('fixture の独立性', () => {
+  test('先のテストが入れたブックマークは後続へ漏れない', async ({ page }) => {
     const { libsqlUrl } = await readRuntime()
     const { db, close } = createE2eDb(libsqlUrl)
     try {
@@ -584,7 +586,7 @@ test.describe.serial('fixture isolation', () => {
     await expect(page.getByRole('link', { name: 'LeakProbe' })).toBeVisible()
   })
 
-  test('second test starts from empty bookmark tables', async ({ page }) => {
+  test('後続テストは空のブックマーク表から始まる', async ({ page }) => {
     await page.goto('/')
     await expect(page.getByText('まだブックマークがありません')).toBeVisible()
     await expect(page.getByRole('link', { name: 'LeakProbe' })).toHaveCount(0)
@@ -639,7 +641,7 @@ Do not click `タイトルを取得`. Fill タイトル manually. Use URLs on `h
 ```ts
 import { expect, test } from './fixtures'
 
-test('creating a bookmark shows it on the list', async ({ page }) => {
+test('ブックマークを作成すると一覧から確認できる', async ({ page }) => {
   await page.goto('/')
   await page.getByRole('link', { name: '新規' }).click()
   await page.getByLabel('URL').fill('https://example.test/created')
@@ -811,7 +813,7 @@ EOF
 ```ts
 import { expect, test } from './fixtures'
 
-test('fetching https://example.com fills the title field', async ({ page }) => {
+test('https://example.com のタイトル取得結果がフォームに反映される', async ({ page }) => {
   await page.goto('/bookmarks/new')
   await page.getByLabel('URL').fill('https://example.com')
   await page.getByRole('button', { name: 'タイトルを取得' }).click()

--- a/docs/superpowers/plans/2026-08-31-playwright-e2e.md
+++ b/docs/superpowers/plans/2026-08-31-playwright-e2e.md
@@ -1,0 +1,984 @@
+# Playwright E2E Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Chromium から `@cloudflare/vite-plugin` のローカル Worker runtime と Testcontainers libSQL を通して、Pantry の主要ユーザーフローを Playwright Test で自動検証し、Pull Request の blocking check にする。
+
+**Architecture:** Playwright の `webServer` は `e2e/start-pantry.ts` を起動する。このスクリプトが Testcontainers の libSQL を先に立ち上げ、本番と同じ Drizzle migration を適用し、Worker 用 `.dev.vars` を E2E 専用値へ差し替えてから `pnpm vite dev --host 127.0.0.1 --port 3100` を子プロセスとして起動する。主要 E2E は外部 HTTP に依存せずタイトルは手入力する。`https://example.com` の実アクセス smoke は別 script / 別 workflow に分離する。
+
+**Tech Stack:** Playwright Test 1.62.1、Chromium、`@cloudflare/vite-plugin` + Vite 8 + workerd、Testcontainers 12.1.0、libSQL、Drizzle migrator、Better Auth `auth.api.createUser`
+
+**Spec:** GitHub Issue #258（Issue 本文が仕様の正本。この plan は How のみ）
+
+## Global Constraints
+
+- 主要 E2E は任意の外部 Web サイトや第三者サービスの可用性へ依存しない。
+- 外部 Turso の認証情報・既存データを使用しない。
+- E2E 用の認証情報・fixture を本番環境と共有しない。
+- Cloudflare Workers と異なる Node 固有 runtime だけで主要 E2E を成立させない。`pnpm vite dev`（既存 `vite.config.ts` の `cloudflare({ viteEnvironment: { name: 'ssr' } })`）以外のサーバーで主要 E2E を起動しない。
+- flaky なテストを retry の常用で隠蔽しない（`retries: 0`）。
+- 通常の `pnpm test` へ Browser / Docker 依存を持ち込まない。
+- 本番アプリケーションへユーザーから到達可能なテスト専用認証 API を追加しない。
+- development seed（`pnpm run db:seed` / `scripts/seed.ts`）を流用しない。
+- Firefox / WebKit / mobile viewport / Passkey E2E / 並列実行 / Visual Regression は対象外。
+- Issue 本文の受け入れ条件を狭めたり、観測可能な振る舞いを独断で変えない。
+
+## File map
+
+- Create: `playwright.config.ts` — 主要 E2E の Playwright 設定
+- Create: `playwright.smoke.config.ts` — smoke 専用設定（main config を spread）
+- Create: `e2e/constants.ts` — origin / 認証情報 / secret の定数
+- Create: `e2e/runtime.ts` — Testcontainers URL をテスト側へ渡す gitignored ファイル
+- Create: `e2e/dev-vars.ts` — `.dev.vars` の backup / 上書き / restore
+- Create: `e2e/libsql.ts` — Testcontainers 起動と本番 migration
+- Create: `e2e/start-pantry.ts` — webServer オーケストレーション
+- Create: `e2e/db.ts` — libSQL client、table reset、bookmark/tag seed
+- Create: `e2e/auth-user.ts` — Better Auth で E2E ユーザー作成
+- Create: `e2e/fixtures.ts` — authenticated fixture（DB reset）
+- Create: `e2e/auth.setup.ts` — storageState 作成
+- Create: `e2e/sign-in.spec.ts`
+- Create: `e2e/create-bookmark.spec.ts`
+- Create: `e2e/edit-bookmark.spec.ts`
+- Create: `e2e/search-and-filter.spec.ts`
+- Create: `e2e/pagination.spec.ts`
+- Create: `e2e/delete-bookmark.spec.ts`
+- Create: `e2e/isolation.spec.ts`
+- Create: `e2e/fetch-title.smoke.spec.ts`
+- Create: `.github/workflows/e2e-smoke.yaml`
+- Modify: `pnpm-workspace.yaml` — `catalogs.test['@playwright/test'] = 1.62.1`
+- Modify: `package.json` — devDependency と scripts
+- Modify: `pnpm-lock.yaml` — `pnpm install` が更新
+- Modify: `knip.config.ts` — Playwright / e2e entry
+- Modify: `.gitignore` — Playwright 成果物と runtime
+- Modify: `.github/workflows/ci.yaml` — blocking `e2e` job
+- Modify: `docs/testing.md` — Playwright Test を自動 E2E の正本として追記
+- Modify: `AGENTS.md` — `pnpm run test:e2e` / `test:e2e:smoke` をコマンド表へ追加
+
+## Locked values
+
+Copy these exact values. Do not invent alternatives.
+
+```ts
+export const E2E_HOST = '127.0.0.1'
+export const E2E_PORT = 3100
+export const E2E_ORIGIN = 'http://127.0.0.1:3100'
+export const E2E_TURSO_AUTH_TOKEN = 'e2e-local-unused'
+export const E2E_BETTER_AUTH_SECRET = 'e2e-local-better-auth-secret-001'
+export const E2E_USER = {
+  email: 'e2e@pantry.test',
+  name: 'e2e',
+  password: 'e2e-password-not-for-production'
+} as const
+```
+
+`E2E_BETTER_AUTH_SECRET` is 32 characters. Do not reuse `scripts/create-user.ts` (`koralle@example.com` / `password`).
+
+libSQL image: import `LIBSQL_SERVER_IMAGE` from `src/test/persistence/libsql-server-image.ts`.
+
+Playwright: `@playwright/test` `1.62.1` via `catalog:test`.
+
+Scripts:
+
+- `test` remains `vitest run` (no Playwright, no Docker).
+- `test:e2e` = `playwright test`
+- `test:e2e:smoke` = `playwright test --config playwright.smoke.config.ts`
+
+CI job name: `e2e` (this is the blocking check name).
+Smoke workflow name: `E2E external HTTP smoke`. Job name: `e2e-smoke`.
+Smoke schedule: `0 6 * * 1` (Monday 06:00 UTC) plus `workflow_dispatch`.
+
+Auth strategy:
+
+- One spec (`e2e/sign-in.spec.ts`) performs UI email/password sign-in.
+- Other specs start from Playwright `storageState` produced by `e2e/auth.setup.ts` (UI sign-in once per run). That setup is test harness, not a user-reachable auth API.
+- `beforeEach` in authenticated fixtures truncates `bookmarks`, `bookmark_tags`, and `tags` only. Keep `users` / `sessions` / `accounts` so storageState stays valid.
+
+Title fetch:
+
+- Main suite never clicks `タイトルを取得`. Type the title.
+- Smoke suite clicks `タイトルを取得` against `https://example.com`.
+
+Worker env isolation:
+
+- `reuseExistingServer` is always `false`. Never attach to a developer's `pnpm dev`.
+- `e2e/start-pantry.ts` backs up existing `.dev.vars` (if any), writes E2E-only values, starts Vite, restores `.dev.vars` on shutdown. This prevents a local Turso `.dev.vars` from being used.
+- Guard: `TURSO_CONNECTION_URL` written to `.dev.vars` must be `http://127.0.0.1:<port>` (or `http://localhost:<port>`). Reject any host containing `turso.io`.
+
+Playwright:
+
+- `fullyParallel: false`
+- `workers: 1`
+- `retries: 0`
+- Chromium only
+- desktop viewport (Playwright default is fine; do not add mobile projects)
+- `timeout: 30_000` for tests; `webServer.timeout: 180_000`
+
+PATH: this environment's default `node` may be v22 via `/exec-daemon`. Use `/usr/bin/node` (v24) for pnpm commands: `export PATH="/usr/bin:$PATH"`.
+
+---
+
+### Task 1: E2E harness and sign-in page boot
+
+**Files:**
+
+- Modify: `pnpm-workspace.yaml`
+- Modify: `package.json`
+- Modify: `.gitignore`
+- Modify: `knip.config.ts`
+- Create: `e2e/constants.ts`
+- Create: `e2e/runtime.ts`
+- Create: `e2e/dev-vars.ts`
+- Create: `e2e/libsql.ts`
+- Create: `e2e/start-pantry.ts`
+- Create: `playwright.config.ts`
+- Create: `e2e/sign-in.spec.ts` (first assertion only: `/sign-in` heading; full login comes in Task 2)
+- Test: `e2e/sign-in.spec.ts`
+
+**Interfaces:**
+
+- Consumes: existing `vite.config.ts` Cloudflare plugin, `LIBSQL_SERVER_IMAGE`, Drizzle `migrate` from persistence global setup
+- Produces: `E2E_ORIGIN` serving Pantry on workerd; `e2e/.runtime/runtime.json` with `{ "libsqlUrl": string }`; `pnpm run test:e2e`
+
+- [ ] **Step 1: Add Playwright dependency**
+
+In `pnpm-workspace.yaml` catalogs.test, add after `vitest`:
+
+```yaml
+'@playwright/test': 1.62.1
+```
+
+In `package.json` `devDependencies` add:
+
+```json
+    "@playwright/test": "catalog:test",
+```
+
+Add scripts next to `test:persistence`:
+
+```json
+    "test:e2e": "playwright test",
+    "test:e2e:smoke": "playwright test --config playwright.smoke.config.ts",
+```
+
+`.gitignore` append:
+
+```
+# Playwright E2E
+/playwright-report/
+/test-results/
+/blob-report/
+/e2e/.auth/
+/e2e/.runtime/
+```
+
+Keep `!.dev.vars.example`. Do not gitignore `.dev.vars` handling beyond the existing `.dev.vars*` rule.
+
+`knip.config.ts`:
+
+- Add `'playwright.config.ts'` and `'playwright.smoke.config.ts'` and `'e2e/start-pantry.ts'` to `entry`.
+- Add knip playwright plugin config:
+
+```ts
+  playwright: {
+    config: ['playwright.config.ts', 'playwright.smoke.config.ts'],
+    entry: ['e2e/**/*.ts']
+  },
+```
+
+Do not add `@playwright/test` to `ignoreDependencies`.
+
+Run:
+
+```bash
+export PATH="/usr/bin:$PATH"
+pnpm install
+pnpm exec playwright install chromium
+```
+
+Expected: lockfile updates; Chromium installs.
+
+- [ ] **Step 2: Write the failing boot test**
+
+Create `e2e/constants.ts` with the locked values above.
+
+Create `e2e/sign-in.spec.ts`:
+
+```ts
+import { expect, test } from '@playwright/test'
+
+test('sign-in page renders the login heading', async ({ page }) => {
+  await page.goto('/sign-in')
+  await expect(page.getByRole('heading', { name: 'ログイン' })).toBeVisible()
+})
+```
+
+Create a minimal `playwright.config.ts` that points `webServer.command` at `pnpm exec tsx e2e/start-pantry.ts` even if that file is still a stub. Do not implement start-pantry yet.
+
+```ts
+import { defineConfig, devices } from '@playwright/test'
+
+import { E2E_ORIGIN } from './e2e/constants'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  reporter:
+    process.env['GITHUB_ACTIONS'] === 'true' ? [['github'], ['html']] : [['list'], ['html']],
+  use: {
+    ...devices['Desktop Chrome'],
+    baseURL: E2E_ORIGIN,
+    viewport: { width: 1280, height: 720 },
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure'
+  },
+  webServer: {
+    command: 'pnpm exec tsx e2e/start-pantry.ts',
+    url: E2E_ORIGIN,
+    reuseExistingServer: false,
+    timeout: 180_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    gracefulShutdown: { signal: 'SIGTERM', timeout: 20_000 }
+  },
+  projects: [
+    { name: 'setup', testMatch: /auth\.setup\.ts/ },
+    {
+      name: 'sign-in',
+      testMatch: /sign-in\.spec\.ts/,
+      dependencies: [],
+      use: { storageState: { cookies: [], origins: [] } }
+    },
+    {
+      name: 'main',
+      testMatch: /.*\.spec\.ts/,
+      testIgnore: [/sign-in\.spec\.ts/, /fetch-title\.smoke\.spec\.ts/],
+      dependencies: ['setup'],
+      use: { storageState: 'e2e/.auth/user.json' }
+    }
+  ]
+})
+```
+
+For this task only, temporarily comment out the `setup` project and `main` project (or give `sign-in` no dependencies and leave setup file absent). If Playwright errors because `auth.setup.ts` is missing, keep only the `sign-in` project until Task 2. Task 2 restores the three-project layout.
+
+- [ ] **Step 3: Run the boot test and confirm it fails for the missing server**
+
+```bash
+export PATH="/usr/bin:$PATH"
+pnpm run test:e2e
+```
+
+Expected: FAIL because `e2e/start-pantry.ts` does not exist or does not serve `E2E_ORIGIN`. Do not implement the harness until you have seen this failure.
+
+- [ ] **Step 4: Implement the harness**
+
+`e2e/runtime.ts`:
+
+```ts
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url))
+export const runtimeDir = path.join(repoRoot, 'e2e/.runtime')
+const runtimeFile = path.join(runtimeDir, 'runtime.json')
+
+export type E2eRuntime = {
+  readonly libsqlUrl: string
+}
+
+export async function writeRuntime(runtime: E2eRuntime): Promise<void> {
+  await mkdir(runtimeDir, { recursive: true })
+  await writeFile(runtimeFile, `${JSON.stringify(runtime, null, 2)}\n`, 'utf8')
+}
+
+export async function readRuntime(): Promise<E2eRuntime> {
+  const parsed: unknown = JSON.parse(await readFile(runtimeFile, 'utf8'))
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    !('libsqlUrl' in parsed) ||
+    typeof parsed.libsqlUrl !== 'string'
+  ) {
+    throw new Error('e2e/.runtime/runtime.json is missing libsqlUrl')
+  }
+  return { libsqlUrl: parsed.libsqlUrl }
+}
+```
+
+`e2e/dev-vars.ts` must:
+
+1. Resolve repo-root `.dev.vars`.
+2. If `.dev.vars` exists and `e2e/.runtime/dev.vars.backup` does not, copy it to the backup.
+3. Write:
+
+```
+TURSO_CONNECTION_URL=<libsqlUrl>
+TURSO_AUTH_TOKEN=e2e-local-unused
+BETTER_AUTH_SECRET=e2e-local-better-auth-secret-001
+BETTER_AUTH_URL=http://127.0.0.1:3100
+```
+
+4. `restoreDevVars()`: if backup exists, move it back to `.dev.vars`; else unlink `.dev.vars` if we created it. Always run from SIGINT/SIGTERM/exit.
+
+Reject `libsqlUrl` unless the host is `127.0.0.1` or `localhost`, protocol is `http:`, and hostname does not include `turso.io`.
+
+`e2e/libsql.ts`:
+
+Copy the container options from `src/test/persistence/global-setup.ts` (same image, port 8080, tmpfs `/var/lib/sqld`, wait `/v2`, 120s startup). Apply production migrations with `drizzle-orm/libsql/migrator` and `migrationsFolder = <repoRoot>/drizzle`. Return `{ container, libsqlUrl }` where `libsqlUrl = http://127.0.0.1:${mappedPort}`.
+
+`e2e/start-pantry.ts`:
+
+```ts
+import { spawn } from 'node:child_process'
+import { setTimeout as delay } from 'node:timers/promises'
+
+import {
+  E2E_BETTER_AUTH_SECRET,
+  E2E_HOST,
+  E2E_ORIGIN,
+  E2E_PORT,
+  E2E_TURSO_AUTH_TOKEN
+} from './constants'
+import { restoreDevVars, writeE2eDevVars } from './dev-vars'
+import { startMigratedLibsql } from './libsql'
+import { writeRuntime } from './runtime'
+
+const childEnv = {
+  ...process.env,
+  TURSO_CONNECTION_URL: libsqlUrl,
+  TURSO_AUTH_TOKEN: E2E_TURSO_AUTH_TOKEN,
+  BETTER_AUTH_SECRET: E2E_BETTER_AUTH_SECRET,
+  BETTER_AUTH_URL: E2E_ORIGIN
+}
+
+const vite = spawn('pnpm', ['vite', 'dev', '--host', E2E_HOST, '--port', String(E2E_PORT)], {
+  env: childEnv,
+  stdio: 'inherit'
+})
+```
+
+Order: start libSQL → migrate → writeRuntime → writeE2eDevVars → spawn vite. Do not spawn a Node HTTP server. On signal: kill vite, stop container, restoreDevVars.
+
+Keep the process alive until vite exits. If vite exits non-zero before SIGTERM, exit with that code after cleanup.
+
+- [ ] **Step 5: Re-run the boot test**
+
+```bash
+export PATH="/usr/bin:$PATH"
+pnpm run test:e2e
+```
+
+Expected: PASS. The heading `ログイン` is visible. Confirm start-pantry logs `Using secrets defined in .dev.vars` or equivalent wrangler/vite secret load, and that `libsqlUrl` in `e2e/.runtime/runtime.json` is `http://127.0.0.1:<port>`.
+
+If Chromium is missing, run `pnpm exec playwright install chromium` and re-run. If Docker socket is unreachable, the harness should fail with Testcontainers' error — do not fall back to Turso.
+
+- [ ] **Step 6: Commit**
+
+```bash
+export PATH="/usr/bin:$PATH"
+git add pnpm-workspace.yaml package.json pnpm-lock.yaml .gitignore knip.config.ts playwright.config.ts e2e
+git commit -m "$(cat <<'EOF'
+chore(e2e): Playwright を Testcontainers libSQL と workerd に接続する
+
+EOF
+)"
+```
+
+---
+
+### Task 2: UI sign-in spec and authenticated storageState
+
+**Files:**
+
+- Create: `e2e/db.ts`
+- Create: `e2e/auth-user.ts`
+- Create: `e2e/auth.setup.ts`
+- Create: `e2e/fixtures.ts`
+- Modify: `playwright.config.ts` — restore setup / sign-in / main projects
+- Modify: `e2e/sign-in.spec.ts` — full UI sign-in
+- Create: `e2e/isolation.spec.ts`
+
+**Interfaces:**
+
+- Consumes: `readRuntime().libsqlUrl`, `E2E_USER`, Better Auth `auth.api.createUser`
+- Produces: `e2e/.auth/user.json`; `test` from `e2e/fixtures.ts` that resets bookmark/tag tables before each test
+
+- [ ] **Step 1: Write failing UI sign-in assertions**
+
+Replace `e2e/sign-in.spec.ts` with:
+
+```ts
+import { expect, test } from '@playwright/test'
+
+import { E2E_USER } from './constants'
+
+test('email and password sign-in shows the bookmark list', async ({ page }) => {
+  await page.goto('/sign-in')
+  await page.getByRole('textbox', { name: 'メール' }).fill(E2E_USER.email)
+  await page.getByRole('textbox', { name: 'パスワード' }).fill(E2E_USER.password)
+  await page.getByRole('button', { name: 'サインイン' }).click()
+  await expect(page).toHaveURL(/\/(\?.*)?$/)
+  await expect(page.getByRole('link', { name: '新規' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'ログイン' })).toHaveCount(0)
+  await expect(page.getByText('まだブックマークがありません')).toBeVisible()
+})
+```
+
+Do not use `storageState` in this file. The `sign-in` project must set `storageState: { cookies: [], origins: [] }`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+export PATH="/usr/bin:$PATH"
+pnpm run test:e2e -- e2e/sign-in.spec.ts
+```
+
+Expected: FAIL (invalid credentials or redirect to sign-in) because the E2E user is not created yet.
+
+- [ ] **Step 3: Implement user seed, setup project, and fixtures**
+
+`e2e/db.ts`:
+
+- `createE2eClient(url)` using `createClient({ url })` from `@libsql/client` and `drizzle({ client })`.
+- `resetApplicationTables(client)`: same SQL as `resetPersistenceTables` in `src/test/persistence/migrated-db.ts` but **only** delete from `bookmarks`, `bookmark_tags`, and `tags` (quote identifiers). Do not delete `users`, `sessions`, `accounts`, `verifications`, `passkeys`.
+- `resetAllDataTables(client)`: delete every non-sqlite / non-`__drizzle` table (copy `resetPersistenceTables`). Used only by `auth.setup.ts` before creating the user, so each run starts from a clean auth+data state.
+- `seedTag` / `seedBookmark` / `seedBookmarks`: same column mapping as `migrated-db.ts` (`normalizedName: name.toLowerCase()`, default URL `https://example.test/${id}` — not `example.com` in the main suite). Use `https://example.test/...` so main E2E never even looks like it depends on example.com.
+
+`e2e/auth-user.ts`:
+
+```ts
+export function applyE2eProcessEnv(libsqlUrl: string): void {
+  process.env['TURSO_CONNECTION_URL'] = libsqlUrl
+  process.env['TURSO_AUTH_TOKEN'] = E2E_TURSO_AUTH_TOKEN
+  process.env['BETTER_AUTH_SECRET'] = E2E_BETTER_AUTH_SECRET
+  process.env['BETTER_AUTH_URL'] = E2E_ORIGIN
+}
+
+export async function ensureE2eUser(libsqlUrl: string): Promise<void> {
+  applyE2eProcessEnv(libsqlUrl)
+  const { auth } = await import('../auth')
+  await auth.api.createUser({
+    body: {
+      email: E2E_USER.email,
+      name: E2E_USER.name,
+      password: E2E_USER.password
+    }
+  })
+}
+```
+
+Import `auth.ts` only after `applyE2eProcessEnv`. `auth.ts` reads `env` at import time.
+
+If `createUser` throws because the email exists, that is a harness bug (setup should have truncated users). Do not swallow it.
+
+`e2e/auth.setup.ts`:
+
+```ts
+import { mkdir } from 'node:fs/promises'
+import path from 'node:path'
+
+import { test as setup, expect } from '@playwright/test'
+
+import { ensureE2eUser } from './auth-user'
+import { E2E_USER } from './constants'
+import { createE2eClient, resetAllDataTables } from './db'
+import { readRuntime } from './runtime'
+
+const authFile = path.join(import.meta.dirname, '.auth/user.json')
+
+setup('authenticate', async ({ page }) => {
+  const { libsqlUrl } = await readRuntime()
+  const { client, close } = createE2eClient(libsqlUrl)
+  try {
+    await resetAllDataTables(client)
+  } finally {
+    close()
+  }
+  await ensureE2eUser(libsqlUrl)
+  await page.goto('/sign-in')
+  await page.getByRole('textbox', { name: 'メール' }).fill(E2E_USER.email)
+  await page.getByRole('textbox', { name: 'パスワード' }).fill(E2E_USER.password)
+  await page.getByRole('button', { name: 'サインイン' }).click()
+  await expect(page.getByRole('link', { name: '新規' })).toBeVisible()
+  await mkdir(path.dirname(authFile), { recursive: true })
+  await page.context().storageState({ path: authFile })
+})
+```
+
+`e2e/fixtures.ts`:
+
+```ts
+import { test as base } from '@playwright/test'
+
+import { createE2eClient, resetApplicationTables } from './db'
+import { readRuntime } from './runtime'
+
+export const test = base.extend<{ resetData: void }>({
+  resetData: [
+    async ({}, use) => {
+      const { libsqlUrl } = await readRuntime()
+      const { client, close } = createE2eClient(libsqlUrl)
+      try {
+        await resetApplicationTables(client)
+        await use()
+      } finally {
+        close()
+      }
+    },
+    { auto: true }
+  ]
+})
+
+export { expect } from '@playwright/test'
+```
+
+`playwright.config.ts` projects (final):
+
+```ts
+projects: [
+  { name: 'setup', testMatch: /auth\.setup\.ts/ },
+  {
+    name: 'sign-in',
+    testMatch: /sign-in\.spec\.ts/,
+    dependencies: ['setup'],
+    use: { storageState: { cookies: [], origins: [] } }
+  },
+  {
+    name: 'main',
+    testMatch: /.*\.spec\.ts/,
+    testIgnore: [/sign-in\.spec\.ts/, /fetch-title\.smoke\.spec\.ts/],
+    dependencies: ['setup'],
+    use: { storageState: 'e2e/.auth/user.json' }
+  }
+]
+```
+
+`sign-in` depends on `setup` so the user exists, but uses empty storageState so the spec actually types credentials.
+
+`e2e/isolation.spec.ts` uses `test` from `./fixtures` (so it gets `resetData`):
+
+```ts
+import { expect, test } from './fixtures'
+
+test.describe.serial('fixture isolation', () => {
+  test('first test inserts a bookmark that must not leak', async ({ page }) => {
+    const { libsqlUrl } = await readRuntime()
+    const { db, close } = createE2eDb(libsqlUrl)
+    try {
+      const userId = await findE2eUserId(db)
+      await seedBookmark(db, {
+        id: bookmarkId(1),
+        userId,
+        title: 'LeakProbe',
+        url: 'https://example.test/leak-probe'
+      })
+    } finally {
+      close()
+    }
+    await page.goto('/')
+    await expect(page.getByRole('link', { name: 'LeakProbe' })).toBeVisible()
+  })
+
+  test('second test starts from empty bookmark tables', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByText('まだブックマークがありません')).toBeVisible()
+    await expect(page.getByRole('link', { name: 'LeakProbe' })).toHaveCount(0)
+  })
+})
+```
+
+Expose `createE2eDb` / `findE2eUserId` / `bookmarkId` from `e2e/db.ts`. `findE2eUserId` selects `users.id` where email is `E2E_USER.email`. `bookmarkId` can match persistence (`019fae92-3bb0-78cd-b488-${index.toString(16).padStart(12, '0')}`).
+
+- [ ] **Step 4: Run sign-in and isolation**
+
+```bash
+export PATH="/usr/bin:$PATH"
+pnpm run test:e2e -- e2e/sign-in.spec.ts e2e/isolation.spec.ts e2e/auth.setup.ts
+```
+
+Expected: PASS. Sign-in uses the form. Isolation second test does not see `LeakProbe`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e playwright.config.ts
+git commit -m "$(cat <<'EOF'
+chore(e2e): メールサインインと認証済み storageState を追加する
+
+EOF
+)"
+```
+
+---
+
+### Task 3: Create, edit tags, and delete
+
+**Files:**
+
+- Create: `e2e/create-bookmark.spec.ts`
+- Create: `e2e/edit-bookmark.spec.ts`
+- Create: `e2e/delete-bookmark.spec.ts`
+- Test: those three files
+
+**Interfaces:**
+
+- Consumes: `test` from `e2e/fixtures.ts`; `seedTag` / `seedBookmark` / `findE2eUserId`
+- Produces: browser-observable coverage for Issue scenarios 2, 3, 6
+
+Do not click `タイトルを取得`. Fill タイトル manually. Use URLs on `https://example.test/...`.
+
+- [ ] **Step 1: Write failing create spec**
+
+`e2e/create-bookmark.spec.ts`:
+
+```ts
+import { expect, test } from './fixtures'
+
+test('creating a bookmark shows it on the list', async ({ page }) => {
+  await page.goto('/')
+  await page.getByRole('link', { name: '新規' }).click()
+  await page.getByLabel('URL').fill('https://example.test/created')
+  await page.getByLabel('タイトル').fill('Created from E2E')
+  await page.getByRole('button', { name: '登録' }).click()
+  await expect(page.getByRole('heading', { name: 'Created from E2E' })).toBeVisible()
+  await page.getByRole('link', { name: '一覧へ戻る' }).click()
+  await expect(page.getByRole('link', { name: 'Created from E2E' })).toBeVisible()
+})
+```
+
+- [ ] **Step 2: Run create spec to verify it fails**
+
+```bash
+export PATH="/usr/bin:$PATH"
+pnpm run test:e2e -- e2e/create-bookmark.spec.ts
+```
+
+Expected: FAIL until the flow is wired (should fail on missing link/heading if setup is broken; if it already passes because the app works, that is acceptable **only after** you watched it fail once against a missing assertion — if the app already implements create, the red step is the test file not existing. Run before adding the spec if needed, or assert a unique title that is not seeded.)
+
+Because create already exists in the app, the new spec should fail first if storageState/setup is missing; with Task 2 complete it may pass immediately. That is OK for this spec: the production behavior already exists. Do not change application code to make create pass. If it fails, fix the selector (labels are `URL` / `タイトル`, submit is `登録`, detail heading is `h1.workbenchTitle`).
+
+- [ ] **Step 3: Write edit and delete specs**
+
+`e2e/edit-bookmark.spec.ts`:
+
+Seed two tags `keep-tag` and `drop-tag`, and a bookmark titled `Editable` with only `drop-tag`. Then:
+
+1. `page.goto('/')`
+2. Click link `Editable`
+3. Click link `編集`
+4. Click `タグを選ぶ`
+5. Select `keep-tag` (getByRole('option', { name: 'keep-tag' }) or checkbox/button inside the dialog `タグを選ぶ`)
+6. Remove `drop-tag` via `getByRole('button', { name: 'drop-tagを外す' })`
+7. Optionally edit title to `Editable updated`
+8. Click `更新`
+9. Expect heading `Editable updated` (or `Editable` if title unchanged)
+10. Expect visible text `keep-tag`
+11. Expect `drop-tag` count 0
+12. Go 一覧へ戻る and confirm the same tag state on the list (`keep-tag` chip visible, `drop-tag` absent)
+
+Inspect `BookmarkTagPicker` if option roles differ; prefer role/accessible name, not CSS classes.
+
+`e2e/delete-bookmark.spec.ts`:
+
+Seed bookmark titled `Doomed`. Open detail, click `削除`, click `削除を確認`, expect list empty / `Doomed` count 0, and `まだブックマークがありません` visible.
+
+- [ ] **Step 4: Run the three specs**
+
+```bash
+export PATH="/usr/bin:$PATH"
+pnpm run test:e2e -- e2e/create-bookmark.spec.ts e2e/edit-bookmark.spec.ts e2e/delete-bookmark.spec.ts
+```
+
+Expected: PASS. Adjust selectors only; do not add a test auth API or mock oRPC.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/create-bookmark.spec.ts e2e/edit-bookmark.spec.ts e2e/delete-bookmark.spec.ts e2e/db.ts
+git commit -m "$(cat <<'EOF'
+chore(e2e): ブックマーク作成・タグ編集・削除を検証する
+
+EOF
+)"
+```
+
+---
+
+### Task 4: Search, tag filter, and cursor pagination
+
+**Files:**
+
+- Create: `e2e/search-and-filter.spec.ts`
+- Create: `e2e/pagination.spec.ts`
+
+**Interfaces:**
+
+- Consumes: `seedBookmarks`, `seedTag`, `BOOKMARK_LIST_PAGE_SIZE` from `src/features/bookmarks/lib/bookmark-list-page-size.ts`
+- Produces: coverage for Issue scenarios 4 and 5
+
+- [ ] **Step 1: Write failing search/filter spec**
+
+Seed:
+
+- Tag `rust`, tag `python`
+- Bookmark `Alpha rust` with tag rust, url `https://example.test/alpha`
+- Bookmark `Beta python` with tag python, url `https://example.test/beta`
+- Bookmark `Gamma both` with both tags
+
+Cases in one file, separate `test()`s (each gets `resetData`, so seed in each test):
+
+1. Search: fill placeholder `タイトル・URL・メモ` with `Alpha`, click button `検索`. Expect `Alpha rust` visible, `Beta python` count 0, `Gamma both` count 0.
+2. Tag filter: `page.getByRole('navigation', { name: 'タグ' }).getByRole('link', { name: /rust/ }).click()`. Expect `Alpha rust` and `Gamma both` visible, `Beta python` count 0.
+
+- [ ] **Step 2: Run search spec to see it fail or pass**
+
+```bash
+export PATH="/usr/bin:$PATH"
+pnpm run test:e2e -- e2e/search-and-filter.spec.ts
+```
+
+Fix selectors if the search field's accessible name is `検索` (SearchField + sr-only Label). Placeholder is `タイトル・URL・メモ`.
+
+- [ ] **Step 3: Write pagination spec**
+
+```ts
+import { BOOKMARK_LIST_PAGE_SIZE } from '../src/features/bookmarks/lib/bookmark-list-page-size'
+```
+
+Seed `BOOKMARK_LIST_PAGE_SIZE + 2` bookmarks. Titles:
+
+- First page (newest): `Keep ${String(i).padStart(2, '0')}` for `i = 0 .. PAGE_SIZE-1` with `createdAt = base + (PAGE_SIZE + 1 - i) * 1000`
+- Extra older rows: `Next Page Alpha`, `Next Page Beta` with earlier `createdAt`
+
+`page.goto('/')`.
+
+Expect `Keep 00` visible and `Next Page Alpha` count 0.
+Expect button `さらに読み込む` visible.
+Click it.
+Expect `Keep 00` still visible **and** `Next Page Alpha` visible (existing items kept, new items appended).
+Expect `Next Page Beta` visible too.
+
+Do not reload the page between assertions.
+
+- [ ] **Step 4: Run pagination**
+
+```bash
+export PATH="/usr/bin:$PATH"
+pnpm run test:e2e -- e2e/pagination.spec.ts e2e/search-and-filter.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/search-and-filter.spec.ts e2e/pagination.spec.ts
+git commit -m "$(cat <<'EOF'
+chore(e2e): 検索・タグ絞り込みと cursor pagination を検証する
+
+EOF
+)"
+```
+
+---
+
+### Task 5: External HTTP smoke, CI blocking job, and docs
+
+**Files:**
+
+- Create: `e2e/fetch-title.smoke.spec.ts`
+- Create: `playwright.smoke.config.ts`
+- Create: `.github/workflows/e2e-smoke.yaml`
+- Modify: `.github/workflows/ci.yaml`
+- Modify: `docs/testing.md`
+- Modify: `AGENTS.md`
+- Modify: `knip.config.ts` if smoke config is not already listed
+
+**Interfaces:**
+
+- Consumes: authenticated `storageState` via a smoke config that still starts `e2e/start-pantry.ts`
+- Produces: `pnpm run test:e2e:smoke`; PR job `e2e`; scheduled/manual job `e2e-smoke`
+
+- [ ] **Step 1: Write the smoke spec**
+
+`e2e/fetch-title.smoke.spec.ts`:
+
+```ts
+import { expect, test } from './fixtures'
+
+test('fetching https://example.com fills the title field', async ({ page }) => {
+  await page.goto('/bookmarks/new')
+  await page.getByLabel('URL').fill('https://example.com')
+  await page.getByRole('button', { name: 'タイトルを取得' }).click()
+  await expect(page.getByLabel('タイトル')).toHaveValue(/example/i)
+})
+```
+
+`example.com`'s title is typically `Example Domain`. Assert `/example/i` so a trivial wording change does not flake; do not retry.
+
+- [ ] **Step 2: Add smoke config that is not used by `pnpm run test:e2e`**
+
+`playwright.smoke.config.ts`:
+
+```ts
+import config from './playwright.config'
+
+export default {
+  ...config,
+  projects: [
+    { name: 'setup', testMatch: /auth\.setup\.ts/ },
+    {
+      name: 'smoke',
+      testMatch: /fetch-title\.smoke\.spec\.ts/,
+      dependencies: ['setup'],
+      use: { storageState: 'e2e/.auth/user.json' }
+    }
+  ]
+}
+```
+
+Confirm `pnpm run test:e2e` does **not** run the smoke spec (`testIgnore` already lists it in main).
+
+- [ ] **Step 3: Add CI jobs**
+
+In `.github/workflows/ci.yaml`, add job `e2e` after `persistence-integration`, same `ubuntu-24.04` + cache-and-install composite:
+
+```yaml
+e2e:
+  runs-on: ubuntu-24.04
+
+  steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Setup
+      uses: ./.github/composite-actions/cache-and-install
+
+    - name: Install Playwright Chromium
+      shell: bash
+      run: |
+        pnpm exec playwright install --with-deps chromium
+
+    - name: Playwright E2E
+      shell: bash
+      run: |
+        pnpm run test:e2e
+
+    - name: Upload Playwright report
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 7
+```
+
+Pin `actions/upload-artifact` to a commit SHA like other actions in this repo (look up the current v4 SHA used in GitHub if needed; do not use a floating major tag if the rest of the workflow pins SHAs). If looking up SHA is blocked, match the repo's existing pin style by searching other workflows; `osv-scanner.yaml` / `security.yaml` may already pin `upload-artifact`.
+
+`.github/workflows/e2e-smoke.yaml`:
+
+```yaml
+name: E2E external HTTP smoke
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-smoke:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup
+        uses: ./.github/composite-actions/cache-and-install
+      - name: Install Playwright Chromium
+        shell: bash
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Playwright external HTTP smoke
+        shell: bash
+        run: pnpm run test:e2e:smoke
+```
+
+This workflow must **not** use `pull_request`. Do not add the smoke job to `ci.yaml`.
+
+- [ ] **Step 4: Docs**
+
+`docs/testing.md`: add section **2.3 Playwright E2E（実ブラウザ + ローカル Worker）** after 2.2:
+
+- Command `pnpm run test:e2e` (Docker + Chromium)
+- Path: Chromium → UI → TanStack Query → oRPC → UseCase → Drizzle → Testcontainers libSQL
+- Runtime is `@cloudflare/vite-plugin` / `pnpm vite dev`, not a Node-only server
+- PR CI job `e2e` is the blocking check; adding it to GitHub ruleset as required is the same operational note as `persistence-integration`
+- `pnpm test` stays Docker/Browser-free
+- `pnpm run test:e2e:smoke` hits `https://example.com`; workflow `E2E external HTTP smoke` is weekly + manual; not a merge gate
+
+Update section 3 heading to clarify Playwright MCP remains exploratory/manual, while Playwright Test is the automated suite.
+
+`AGENTS.md` command table: add `pnpm run test:e2e` and `pnpm run test:e2e:smoke`.
+
+- [ ] **Step 5: Verify script split**
+
+```bash
+export PATH="/usr/bin:$PATH"
+pnpm run test
+```
+
+Expected: Vitest only; no Playwright, no Docker container start. (Persistence is `test:persistence`, not `test`.)
+
+```bash
+pnpm run test:e2e
+```
+
+Expected: setup + sign-in + main specs; smoke spec not in the list.
+
+Do not fail the task if `test:e2e:smoke` cannot reach example.com in a locked-down network; the spec and workflow must still exist. On GitHub-hosted runners it should run. If this Cloud environment blocks egress to example.com, record that in the PR 仕様との差異 as an environment limitation, not a spec change.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add e2e/fetch-title.smoke.spec.ts playwright.smoke.config.ts .github/workflows/ci.yaml .github/workflows/e2e-smoke.yaml docs/testing.md AGENTS.md knip.config.ts
+git commit -m "$(cat <<'EOF'
+chore(e2e): 主要フローを PR CI の blocking check にし smoke を分離する
+
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+**Spec coverage:**
+
+| Issue requirement                                       | Task                                                    |
+| ------------------------------------------------------- | ------------------------------------------------------- |
+| Local Chromium Playwright                               | 1                                                       |
+| `@cloudflare/vite-plugin` / workerd via `pnpm vite dev` | 1                                                       |
+| Testcontainers libSQL, no Turso                         | 1 (URL guard + `.dev.vars` overlay)                     |
+| Same production migrations                              | 1 (`e2e/libsql.ts`)                                     |
+| UI email/password sign-in → list                        | 2                                                       |
+| Create → list                                           | 3                                                       |
+| Edit tags add/remove                                    | 3                                                       |
+| Search and tag filter                                   | 4                                                       |
+| Cursor pagination keeps old rows and appends            | 4                                                       |
+| Delete → gone                                           | 3                                                       |
+| Non-sign-in tests skip UI login                         | 2 (`storageState`)                                      |
+| Consecutive runs / no leftover DB                       | 2 (`isolation.spec.ts` + `resetAllDataTables` in setup) |
+| PR blocking `e2e` job                                   | 5                                                       |
+| example.com smoke manual                                | 5 (`pnpm run test:e2e:smoke`, `workflow_dispatch`)      |
+| example.com smoke scheduled, not merge gate             | 5 (cron, not in `ci.yaml`)                              |
+| `pnpm test` without Browser/Docker                      | 5                                                       |
+
+**Placeholder scan:** no TBD/TODO. Exact constants, scripts, selectors, and commands are inlined.
+
+**Type consistency:** `E2E_ORIGIN`, `E2E_USER`, `readRuntime()`, `storageState: 'e2e/.auth/user.json'`, job name `e2e` are reused as written.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -35,7 +35,20 @@ DB 固有の semantics（cursor pagination、タグ AND/OR、検索 escape、sof
 - Pull Request CI の `persistence-integration` job で実行する
 - マージ条件にするには、GitHub の branch protection / ruleset へ status check `persistence-integration` を required として追加する
 
-## 3. Playwright MCP検証
+## 2.3 Playwright E2E（実ブラウザ + ローカル Worker）
+
+主要ユーザーフローは、Chromium からローカル Worker と実 libSQL までを Playwright Test で自動検証する。
+
+- 実行: `pnpm run test:e2e`（Docker と Chromium が必要）
+- 経路: Chromium → UI → TanStack Query → oRPC → UseCase → Drizzle → Testcontainers libSQL
+- Pantry は `@cloudflare/vite-plugin` を使う `pnpm vite dev` で起動し、Node.js 専用サーバーへ置き換えない
+- Pull Request CI の `e2e` job を blocking check として実行する
+- マージ条件にするには、`persistence-integration` と同様に GitHub の branch protection / ruleset へ status check `e2e` を required として追加する
+- 通常の `pnpm test` は Playwright E2E から分離し、Docker と Browser を起動しない
+- 外部 HTTP smoke は `pnpm run test:e2e:smoke` で `https://example.com` へ実アクセスする
+- workflow `E2E external HTTP smoke` は週次および手動で実行し、Pull Request の merge gate には含めない
+
+## 3. 手動・探索的なPlaywright MCP検証（自動 E2E は Playwright Test）
 
 ローカルとデプロイ済みWorkerに対し、Playwright MCPで実ブラウザ検証を実施する。
 

--- a/e2e/auth-user.ts
+++ b/e2e/auth-user.ts
@@ -1,0 +1,20 @@
+import { E2E_BETTER_AUTH_SECRET, E2E_ORIGIN, E2E_TURSO_AUTH_TOKEN, E2E_USER } from './constants'
+
+export function applyE2eProcessEnv(libsqlUrl: string): void {
+  process.env['TURSO_CONNECTION_URL'] = libsqlUrl
+  process.env['TURSO_AUTH_TOKEN'] = E2E_TURSO_AUTH_TOKEN
+  process.env['BETTER_AUTH_SECRET'] = E2E_BETTER_AUTH_SECRET
+  process.env['BETTER_AUTH_URL'] = E2E_ORIGIN
+}
+
+export async function ensureE2eUser(libsqlUrl: string): Promise<void> {
+  applyE2eProcessEnv(libsqlUrl)
+  const { auth } = await import('../auth')
+  await auth.api.createUser({
+    body: {
+      email: E2E_USER.email,
+      name: E2E_USER.name,
+      password: E2E_USER.password
+    }
+  })
+}

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,0 +1,29 @@
+import { mkdir } from 'node:fs/promises'
+import path from 'node:path'
+
+import { expect, test as setup } from '@playwright/test'
+
+import { ensureE2eUser } from './auth-user'
+import { E2E_USER } from './constants'
+import { createE2eClient, resetAllDataTables } from './db'
+import { readRuntime } from './runtime'
+
+const authFile = path.join(import.meta.dirname, '.auth/user.json')
+
+setup('authenticate', async ({ page }) => {
+  const { libsqlUrl } = await readRuntime()
+  const { client, close } = createE2eClient(libsqlUrl)
+  try {
+    await resetAllDataTables(client)
+  } finally {
+    close()
+  }
+  await ensureE2eUser(libsqlUrl)
+  await page.goto('/sign-in')
+  await page.getByRole('textbox', { name: 'メール' }).fill(E2E_USER.email)
+  await page.getByRole('textbox', { name: 'パスワード' }).fill(E2E_USER.password)
+  await page.getByRole('button', { name: 'サインイン' }).click()
+  await expect(page.getByRole('link', { name: '新規' }).first()).toBeVisible()
+  await mkdir(path.dirname(authFile), { recursive: true })
+  await page.context().storageState({ path: authFile })
+})

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -10,7 +10,7 @@ import { readRuntime } from './runtime'
 
 const authFile = path.join(import.meta.dirname, '.auth/user.json')
 
-setup('authenticate', async ({ page }) => {
+setup('認証済み状態を保存する', async ({ page }) => {
   const { libsqlUrl } = await readRuntime()
   const { client, close } = createE2eClient(libsqlUrl)
   try {

--- a/e2e/constants.ts
+++ b/e2e/constants.ts
@@ -1,0 +1,10 @@
+export const E2E_HOST = '127.0.0.1'
+export const E2E_PORT = 3100
+export const E2E_ORIGIN = 'http://127.0.0.1:3100'
+export const E2E_TURSO_AUTH_TOKEN = 'e2e-local-unused'
+export const E2E_BETTER_AUTH_SECRET = 'e2e-local-better-auth-secret-001'
+export const E2E_USER = {
+  email: 'e2e@pantry.test',
+  name: 'e2e',
+  password: 'e2e-password-not-for-production'
+} as const

--- a/e2e/create-bookmark.spec.ts
+++ b/e2e/create-bookmark.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from './fixtures'
 
-test('creating a bookmark shows it on the list', async ({ page }) => {
+test('ブックマークを作成すると一覧から確認できる', async ({ page }) => {
   await page.goto('/')
   await page.getByRole('link', { name: '新規' }).first().click()
   await page.getByLabel('URL').fill('https://example.test/created')

--- a/e2e/create-bookmark.spec.ts
+++ b/e2e/create-bookmark.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from './fixtures'
+
+test('creating a bookmark shows it on the list', async ({ page }) => {
+  await page.goto('/')
+  await page.getByRole('link', { name: '新規' }).click()
+  await page.getByLabel('URL').fill('https://example.test/created')
+  await page.getByLabel('タイトル').fill('Created from E2E')
+  await page.getByRole('button', { name: '登録' }).click()
+  await expect(page.getByRole('heading', { name: 'Created from E2E' })).toBeVisible()
+  await page.getByRole('link', { name: '一覧へ戻る' }).click()
+  await expect(page.getByRole('link', { name: 'Created from E2E' })).toBeVisible()
+})

--- a/e2e/create-bookmark.spec.ts
+++ b/e2e/create-bookmark.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from './fixtures'
 
 test('creating a bookmark shows it on the list', async ({ page }) => {
   await page.goto('/')
-  await page.getByRole('link', { name: '新規' }).click()
+  await page.getByRole('link', { name: '新規' }).first().click()
   await page.getByLabel('URL').fill('https://example.test/created')
   await page.getByLabel('タイトル').fill('Created from E2E')
   await page.getByRole('button', { name: '登録' }).click()

--- a/e2e/db.ts
+++ b/e2e/db.ts
@@ -1,0 +1,157 @@
+import { createClient } from '@libsql/client'
+import type { Client } from '@libsql/client'
+import { eq } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/libsql'
+
+import type { AppDb } from '../src/db/app-db'
+import { user } from '../src/db/schema/auth-schema'
+import { bookmarkTable } from '../src/db/schema/bookmark'
+import { bookmarkTagsTable } from '../src/db/schema/bookmark-tag'
+import { tagsTable } from '../src/db/schema/tag'
+import { E2E_USER } from './constants'
+
+type E2eDbConnection = {
+  readonly client: Client
+  readonly db: AppDb
+  readonly close: () => void
+}
+
+export type SeedBookmarkInput = {
+  readonly id: string
+  readonly userId: string
+  readonly title?: string
+  readonly url?: string
+  readonly note?: string | null
+  readonly createdAt?: Date
+  readonly updatedAt?: Date
+  readonly deletedAt?: Date | null
+  readonly tagIds?: readonly number[]
+}
+
+function namesFrom(rows: readonly Record<string, unknown>[]): string[] {
+  return rows.flatMap((row) => {
+    const { name } = row
+    return typeof name === 'string' && name.length > 0 ? [name] : []
+  })
+}
+
+export function createE2eClient(url: string): E2eDbConnection {
+  const client = createClient({ url })
+  const db = drizzle({ client })
+  return { client, db, close: () => client.close() }
+}
+
+export function createE2eDb(url: string): E2eDbConnection {
+  return createE2eClient(url)
+}
+
+export async function resetApplicationTables(client: Client): Promise<void> {
+  await client.executeMultiple(
+    [
+      'PRAGMA foreign_keys = OFF',
+      'DELETE FROM "bookmarks"',
+      'DELETE FROM "bookmark_tags"',
+      'DELETE FROM "tags"',
+      'PRAGMA foreign_keys = ON'
+    ].join(';\n')
+  )
+}
+
+export async function resetAllDataTables(client: Client): Promise<void> {
+  const tables = await client.execute(
+    "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '__drizzle%'"
+  )
+  const tableNames = namesFrom(tables.rows)
+  const statements = [
+    'PRAGMA foreign_keys = OFF',
+    ...tableNames.map((name) => `DELETE FROM "${name.replaceAll('"', '""')}"`),
+    'PRAGMA foreign_keys = ON'
+  ]
+  await client.executeMultiple(statements.join(';\n'))
+}
+
+export async function findE2eUserId(db: AppDb): Promise<string> {
+  const [row] = await db
+    .select({ id: user.id })
+    .from(user)
+    .where(eq(user.email, E2E_USER.email))
+    .limit(1)
+  if (row === undefined) {
+    throw new Error(`E2E user not found: ${E2E_USER.email}`)
+  }
+  return row.id
+}
+
+export async function seedTag(
+  db: AppDb,
+  input: { readonly userId: string; readonly name: string }
+): Promise<number> {
+  const inserted = await db
+    .insert(tagsTable)
+    .values({
+      userId: input.userId,
+      name: input.name,
+      normalizedName: input.name.toLowerCase()
+    })
+    .returning({ id: tagsTable.id })
+  const [row] = inserted
+  if (row === undefined) {
+    throw new Error('seedTag failed to return the inserted row')
+  }
+  return row.id
+}
+
+export async function seedBookmark(db: AppDb, input: SeedBookmarkInput): Promise<void> {
+  await db.insert(bookmarkTable).values({
+    id: input.id,
+    userId: input.userId,
+    url: input.url ?? `https://example.test/${input.id}`,
+    title: input.title ?? input.id,
+    note: input.note ?? null,
+    ...(input.createdAt === undefined ? {} : { createdAt: input.createdAt }),
+    ...(input.updatedAt === undefined ? {} : { updatedAt: input.updatedAt }),
+    ...(input.deletedAt === undefined ? {} : { deletedAt: input.deletedAt })
+  })
+  if (input.tagIds !== undefined && input.tagIds.length > 0) {
+    await db.insert(bookmarkTagsTable).values(
+      input.tagIds.map((tagId) => ({
+        bookmarkId: input.id,
+        tagId
+      }))
+    )
+  }
+}
+
+export async function seedBookmarks(
+  db: AppDb,
+  rows: ReadonlyArray<SeedBookmarkInput>
+): Promise<void> {
+  if (rows.length === 0) {
+    return
+  }
+  await db.insert(bookmarkTable).values(
+    rows.map((input) => ({
+      id: input.id,
+      userId: input.userId,
+      url: input.url ?? `https://example.test/${input.id}`,
+      title: input.title ?? input.id,
+      note: input.note ?? null,
+      ...(input.createdAt === undefined ? {} : { createdAt: input.createdAt }),
+      ...(input.updatedAt === undefined ? {} : { updatedAt: input.updatedAt }),
+      ...(input.deletedAt === undefined ? {} : { deletedAt: input.deletedAt })
+    }))
+  )
+  const tagRows = rows.flatMap((input) =>
+    (input.tagIds ?? []).map((tagId) => ({
+      bookmarkId: input.id,
+      tagId
+    }))
+  )
+  if (tagRows.length > 0) {
+    await db.insert(bookmarkTagsTable).values(tagRows)
+  }
+}
+
+export function bookmarkId(index: number): string {
+  return `019fae92-3bb0-78cd-b488-${index.toString(16).padStart(12, '0')}`
+}

--- a/e2e/delete-bookmark.spec.ts
+++ b/e2e/delete-bookmark.spec.ts
@@ -1,8 +1,10 @@
+import type { Locator, Page } from '@playwright/test'
+
 import { bookmarkId, createE2eDb, findE2eUserId, seedBookmark } from './db'
 import { expect, test } from './fixtures'
 import { readRuntime } from './runtime'
 
-test('deleting a bookmark removes it from the list', async ({ page }) => {
+async function seedDoomedBookmark(): Promise<void> {
   const { libsqlUrl } = await readRuntime()
   const { db, close } = createE2eDb(libsqlUrl)
   try {
@@ -16,12 +18,30 @@ test('deleting a bookmark removes it from the list', async ({ page }) => {
   } finally {
     close()
   }
+}
 
+async function openDialog(trigger: Locator, content: Locator): Promise<void> {
+  await trigger.click()
+  await expect(async () => {
+    if (await content.isVisible()) {
+      return
+    }
+    await trigger.click()
+    await expect(content).toBeVisible()
+  }).toPass()
+}
+
+async function deleteBookmark(page: Page): Promise<void> {
   await page.goto('/')
   await page.getByRole('link', { name: 'Doomed' }).click()
-  await page.getByRole('button', { name: '削除' }).click()
-  await page.getByRole('button', { name: '削除を確認' }).click()
+  const confirmButton = page.getByRole('button', { name: '削除を確認' })
+  await openDialog(page.getByRole('button', { name: '削除' }), confirmButton)
+  await confirmButton.click()
+}
 
+test('deleting a bookmark removes it from the list', async ({ page }) => {
+  await seedDoomedBookmark()
+  await deleteBookmark(page)
   await expect(page.getByRole('link', { name: 'Doomed' })).toHaveCount(0)
   await expect(page.getByText('まだブックマークがありません')).toBeVisible()
 })

--- a/e2e/delete-bookmark.spec.ts
+++ b/e2e/delete-bookmark.spec.ts
@@ -1,0 +1,27 @@
+import { bookmarkId, createE2eDb, findE2eUserId, seedBookmark } from './db'
+import { expect, test } from './fixtures'
+import { readRuntime } from './runtime'
+
+test('deleting a bookmark removes it from the list', async ({ page }) => {
+  const { libsqlUrl } = await readRuntime()
+  const { db, close } = createE2eDb(libsqlUrl)
+  try {
+    const userId = await findE2eUserId(db)
+    await seedBookmark(db, {
+      id: bookmarkId(3),
+      userId,
+      title: 'Doomed',
+      url: 'https://example.test/doomed'
+    })
+  } finally {
+    close()
+  }
+
+  await page.goto('/')
+  await page.getByRole('link', { name: 'Doomed' }).click()
+  await page.getByRole('button', { name: '削除' }).click()
+  await page.getByRole('button', { name: '削除を確認' }).click()
+
+  await expect(page.getByRole('link', { name: 'Doomed' })).toHaveCount(0)
+  await expect(page.getByText('まだブックマークがありません')).toBeVisible()
+})

--- a/e2e/delete-bookmark.spec.ts
+++ b/e2e/delete-bookmark.spec.ts
@@ -2,6 +2,7 @@ import type { Locator, Page } from '@playwright/test'
 
 import { bookmarkId, createE2eDb, findE2eUserId, seedBookmark } from './db'
 import { expect, test } from './fixtures'
+import { PASS_EXPECT_TIMEOUT_MS, passOptions } from './pass'
 import { readRuntime } from './runtime'
 
 async function seedDoomedBookmark(): Promise<void> {
@@ -27,8 +28,8 @@ async function openDialog(trigger: Locator, content: Locator): Promise<void> {
       return
     }
     await trigger.click()
-    await expect(content).toBeVisible()
-  }).toPass()
+    await expect(content).toBeVisible({ timeout: PASS_EXPECT_TIMEOUT_MS })
+  }).toPass(passOptions)
 }
 
 async function deleteBookmark(page: Page): Promise<void> {

--- a/e2e/delete-bookmark.spec.ts
+++ b/e2e/delete-bookmark.spec.ts
@@ -1,8 +1,8 @@
-import type { Locator, Page } from '@playwright/test'
+import type { Page } from '@playwright/test'
 
 import { bookmarkId, createE2eDb, findE2eUserId, seedBookmark } from './db'
 import { expect, test } from './fixtures'
-import { PASS_EXPECT_TIMEOUT_MS, passOptions } from './pass'
+import { openDialog } from './open-dialog'
 import { readRuntime } from './runtime'
 
 async function seedDoomedBookmark(): Promise<void> {
@@ -21,20 +21,10 @@ async function seedDoomedBookmark(): Promise<void> {
   }
 }
 
-async function openDialog(trigger: Locator, content: Locator): Promise<void> {
-  await trigger.click()
-  await expect(async () => {
-    if (await content.isVisible()) {
-      return
-    }
-    await trigger.click()
-    await expect(content).toBeVisible({ timeout: PASS_EXPECT_TIMEOUT_MS })
-  }).toPass(passOptions)
-}
-
 async function deleteBookmark(page: Page): Promise<void> {
   await page.goto('/')
   await page.getByRole('link', { name: 'Doomed' }).click()
+  await expect(page.getByRole('heading', { name: 'Doomed' })).toBeVisible()
   const confirmButton = page.getByRole('button', { name: '削除を確認' })
   await openDialog(page.getByRole('button', { name: '削除' }), confirmButton)
   await confirmButton.click()

--- a/e2e/delete-bookmark.spec.ts
+++ b/e2e/delete-bookmark.spec.ts
@@ -40,7 +40,7 @@ async function deleteBookmark(page: Page): Promise<void> {
   await confirmButton.click()
 }
 
-test('deleting a bookmark removes it from the list', async ({ page }) => {
+test('ブックマークを削除すると一覧から消える', async ({ page }) => {
   await seedDoomedBookmark()
   await deleteBookmark(page)
   await expect(page.getByRole('link', { name: 'Doomed' })).toHaveCount(0)

--- a/e2e/dev-vars.ts
+++ b/e2e/dev-vars.ts
@@ -1,0 +1,62 @@
+import { copyFileSync, existsSync, mkdirSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { E2E_BETTER_AUTH_SECRET, E2E_ORIGIN, E2E_TURSO_AUTH_TOKEN } from './constants'
+import { runtimeDir } from './runtime'
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url))
+const devVarsFile = path.join(repoRoot, '.dev.vars')
+const backupFile = path.join(runtimeDir, 'dev.vars.backup')
+
+let overlayActive = false
+
+function assertLocalLibsqlUrl(libsqlUrl: string): void {
+  const url = new URL(libsqlUrl)
+  const isLocalHostname = url.hostname === '127.0.0.1' || url.hostname === 'localhost'
+
+  if (url.protocol !== 'http:' || !isLocalHostname || url.hostname.includes('turso.io')) {
+    throw new Error(`Refusing non-local E2E libSQL URL: ${libsqlUrl}`)
+  }
+}
+
+export function restoreDevVars(): void {
+  if (!overlayActive) {
+    return
+  }
+
+  if (existsSync(backupFile)) {
+    renameSync(backupFile, devVarsFile)
+  } else if (existsSync(devVarsFile)) {
+    unlinkSync(devVarsFile)
+  }
+
+  overlayActive = false
+}
+
+export function writeE2eDevVars(libsqlUrl: string): void {
+  assertLocalLibsqlUrl(libsqlUrl)
+  mkdirSync(runtimeDir, { recursive: true })
+
+  if (existsSync(devVarsFile) && !existsSync(backupFile)) {
+    copyFileSync(devVarsFile, backupFile)
+  }
+
+  overlayActive = true
+  try {
+    writeFileSync(
+      devVarsFile,
+      [
+        `TURSO_CONNECTION_URL=${libsqlUrl}`,
+        `TURSO_AUTH_TOKEN=${E2E_TURSO_AUTH_TOKEN}`,
+        `BETTER_AUTH_SECRET=${E2E_BETTER_AUTH_SECRET}`,
+        `BETTER_AUTH_URL=${E2E_ORIGIN}`,
+        ''
+      ].join('\n'),
+      'utf8'
+    )
+  } catch (error) {
+    restoreDevVars()
+    throw error
+  }
+}

--- a/e2e/edit-bookmark.spec.ts
+++ b/e2e/edit-bookmark.spec.ts
@@ -1,0 +1,41 @@
+import { bookmarkId, createE2eDb, findE2eUserId, seedBookmark, seedTag } from './db'
+import { expect, test } from './fixtures'
+import { readRuntime } from './runtime'
+
+test('editing a bookmark updates its tags', async ({ page }) => {
+  const { libsqlUrl } = await readRuntime()
+  const { db, close } = createE2eDb(libsqlUrl)
+  try {
+    const userId = await findE2eUserId(db)
+    await seedTag(db, { userId, name: 'keep-tag' })
+    const dropTagId = await seedTag(db, { userId, name: 'drop-tag' })
+    await seedBookmark(db, {
+      id: bookmarkId(2),
+      userId,
+      title: 'Editable',
+      url: 'https://example.test/editable',
+      tagIds: [dropTagId]
+    })
+  } finally {
+    close()
+  }
+
+  await page.goto('/')
+  await page.getByRole('link', { name: 'Editable' }).click()
+  await page.getByRole('link', { name: '編集' }).click()
+  await page.getByRole('button', { name: 'タグを選ぶ' }).click()
+  await page.getByRole('option', { name: 'keep-tag' }).click()
+  await page.keyboard.press('Escape')
+  await page.getByRole('button', { name: 'drop-tagを外す' }).click()
+  await page.getByLabel('タイトル').fill('Editable updated')
+  await page.getByRole('button', { name: '更新' }).click()
+
+  await expect(page.getByRole('heading', { name: 'Editable updated' })).toBeVisible()
+  await expect(page.getByText('keep-tag', { exact: true })).toBeVisible()
+  await expect(page.getByText('drop-tag', { exact: true })).toHaveCount(0)
+
+  await page.getByRole('link', { name: '一覧へ戻る' }).click()
+  const bookmarkLink = page.getByRole('link', { name: 'Editable updated' })
+  await expect(bookmarkLink.getByText('keep-tag', { exact: true })).toBeVisible()
+  await expect(page.getByText('drop-tag', { exact: true })).toHaveCount(0)
+})

--- a/e2e/edit-bookmark.spec.ts
+++ b/e2e/edit-bookmark.spec.ts
@@ -50,16 +50,17 @@ async function updateBookmarkTags(page: Page): Promise<void> {
 }
 
 async function expectUpdatedDetail(page: Page): Promise<void> {
-  await expect(page.getByRole('heading', { name: 'Editable updated' })).toBeVisible()
-  await expect(page.getByText('keep-tag', { exact: true })).toBeVisible()
-  await expect(page.getByText('drop-tag', { exact: true })).toHaveCount(0)
+  const detail = page.getByRole('region', { name: 'ブックマーク詳細' })
+  await expect(detail.getByRole('heading', { name: 'Editable updated' })).toBeVisible()
+  await expect(detail.getByText('keep-tag', { exact: true })).toBeVisible()
+  await expect(detail.getByText('drop-tag', { exact: true })).toHaveCount(0)
 }
 
 async function expectUpdatedList(page: Page): Promise<void> {
   await page.getByRole('link', { name: '一覧へ戻る' }).click()
   const bookmarkLink = page.getByRole('link', { name: 'Editable updated' })
   await expect(bookmarkLink.getByText('keep-tag', { exact: true })).toBeVisible()
-  await expect(page.getByText('drop-tag', { exact: true })).toHaveCount(0)
+  await expect(bookmarkLink.getByText('drop-tag', { exact: true })).toHaveCount(0)
 }
 
 test('editing a bookmark updates its tags', async ({ page }) => {

--- a/e2e/edit-bookmark.spec.ts
+++ b/e2e/edit-bookmark.spec.ts
@@ -58,9 +58,9 @@ async function expectUpdatedDetail(page: Page): Promise<void> {
 
 async function expectUpdatedList(page: Page): Promise<void> {
   await page.getByRole('link', { name: '一覧へ戻る' }).click()
-  const bookmarkLink = page.getByRole('link', { name: 'Editable updated' })
-  await expect(bookmarkLink.getByText('keep-tag', { exact: true })).toBeVisible()
-  await expect(bookmarkLink.getByText('drop-tag', { exact: true })).toHaveCount(0)
+  const bookmarkRow = page.getByRole('row', { name: 'Editable updated' })
+  await expect(bookmarkRow.getByText('keep-tag', { exact: true })).toBeVisible()
+  await expect(bookmarkRow.getByText('drop-tag', { exact: true })).toHaveCount(0)
 }
 
 test('editing a bookmark updates its tags', async ({ page }) => {

--- a/e2e/edit-bookmark.spec.ts
+++ b/e2e/edit-bookmark.spec.ts
@@ -1,8 +1,10 @@
+import type { Locator, Page } from '@playwright/test'
+
 import { bookmarkId, createE2eDb, findE2eUserId, seedBookmark, seedTag } from './db'
 import { expect, test } from './fixtures'
 import { readRuntime } from './runtime'
 
-test('editing a bookmark updates its tags', async ({ page }) => {
+async function seedEditableBookmark(): Promise<void> {
   const { libsqlUrl } = await readRuntime()
   const { db, close } = createE2eDb(libsqlUrl)
   try {
@@ -19,23 +21,50 @@ test('editing a bookmark updates its tags', async ({ page }) => {
   } finally {
     close()
   }
+}
 
+async function openDialog(trigger: Locator, content: Locator): Promise<void> {
+  await trigger.click()
+  await expect(async () => {
+    if (await content.isVisible()) {
+      return
+    }
+    await trigger.click()
+    await expect(content).toBeVisible()
+  }).toPass()
+}
+
+async function updateBookmarkTags(page: Page): Promise<void> {
   await page.goto('/')
   await page.getByRole('link', { name: 'Editable' }).click()
   await page.getByRole('link', { name: '編集' }).click()
-  await page.getByRole('button', { name: 'タグを選ぶ' }).click()
+  await openDialog(
+    page.getByRole('button', { name: 'タグを選ぶ' }),
+    page.getByRole('option', { name: 'keep-tag' })
+  )
   await page.getByRole('option', { name: 'keep-tag' }).click()
   await page.keyboard.press('Escape')
   await page.getByRole('button', { name: 'drop-tagを外す' }).click()
   await page.getByLabel('タイトル').fill('Editable updated')
   await page.getByRole('button', { name: '更新' }).click()
+}
 
+async function expectUpdatedDetail(page: Page): Promise<void> {
   await expect(page.getByRole('heading', { name: 'Editable updated' })).toBeVisible()
   await expect(page.getByText('keep-tag', { exact: true })).toBeVisible()
   await expect(page.getByText('drop-tag', { exact: true })).toHaveCount(0)
+}
 
+async function expectUpdatedList(page: Page): Promise<void> {
   await page.getByRole('link', { name: '一覧へ戻る' }).click()
   const bookmarkLink = page.getByRole('link', { name: 'Editable updated' })
   await expect(bookmarkLink.getByText('keep-tag', { exact: true })).toBeVisible()
   await expect(page.getByText('drop-tag', { exact: true })).toHaveCount(0)
+}
+
+test('editing a bookmark updates its tags', async ({ page }) => {
+  await seedEditableBookmark()
+  await updateBookmarkTags(page)
+  await expectUpdatedDetail(page)
+  await expectUpdatedList(page)
 })

--- a/e2e/edit-bookmark.spec.ts
+++ b/e2e/edit-bookmark.spec.ts
@@ -2,6 +2,7 @@ import type { Locator, Page } from '@playwright/test'
 
 import { bookmarkId, createE2eDb, findE2eUserId, seedBookmark, seedTag } from './db'
 import { expect, test } from './fixtures'
+import { PASS_EXPECT_TIMEOUT_MS, passOptions } from './pass'
 import { readRuntime } from './runtime'
 
 async function seedEditableBookmark(): Promise<void> {
@@ -30,8 +31,8 @@ async function openDialog(trigger: Locator, content: Locator): Promise<void> {
       return
     }
     await trigger.click()
-    await expect(content).toBeVisible()
-  }).toPass()
+    await expect(content).toBeVisible({ timeout: PASS_EXPECT_TIMEOUT_MS })
+  }).toPass(passOptions)
 }
 
 async function updateBookmarkTags(page: Page): Promise<void> {

--- a/e2e/edit-bookmark.spec.ts
+++ b/e2e/edit-bookmark.spec.ts
@@ -64,7 +64,7 @@ async function expectUpdatedList(page: Page): Promise<void> {
   await expect(bookmarkRow.getByText('drop-tag', { exact: true })).toHaveCount(0)
 }
 
-test('editing a bookmark updates its tags', async ({ page }) => {
+test('ブックマークを編集するとタグの付与と解除が反映される', async ({ page }) => {
   await seedEditableBookmark()
   await updateBookmarkTags(page)
   await expectUpdatedDetail(page)

--- a/e2e/edit-bookmark.spec.ts
+++ b/e2e/edit-bookmark.spec.ts
@@ -1,8 +1,8 @@
-import type { Locator, Page } from '@playwright/test'
+import type { Page } from '@playwright/test'
 
 import { bookmarkId, createE2eDb, findE2eUserId, seedBookmark, seedTag } from './db'
 import { expect, test } from './fixtures'
-import { PASS_EXPECT_TIMEOUT_MS, passOptions } from './pass'
+import { openDialog } from './open-dialog'
 import { readRuntime } from './runtime'
 
 async function seedEditableBookmark(): Promise<void> {
@@ -24,21 +24,11 @@ async function seedEditableBookmark(): Promise<void> {
   }
 }
 
-async function openDialog(trigger: Locator, content: Locator): Promise<void> {
-  await trigger.click()
-  await expect(async () => {
-    if (await content.isVisible()) {
-      return
-    }
-    await trigger.click()
-    await expect(content).toBeVisible({ timeout: PASS_EXPECT_TIMEOUT_MS })
-  }).toPass(passOptions)
-}
-
 async function updateBookmarkTags(page: Page): Promise<void> {
   await page.goto('/')
   await page.getByRole('link', { name: 'Editable' }).click()
   await page.getByRole('link', { name: '編集' }).click()
+  await expect(page.getByLabel('タイトル')).toHaveValue('Editable')
   await openDialog(
     page.getByRole('button', { name: 'タグを選ぶ' }),
     page.getByRole('option', { name: 'keep-tag' })

--- a/e2e/fetch-title.smoke.spec.ts
+++ b/e2e/fetch-title.smoke.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from './fixtures'
+
+test('fetching https://example.com fills the title field', async ({ page }) => {
+  await page.goto('/bookmarks/new')
+  await page.getByLabel('URL').fill('https://example.com')
+  await page.getByRole('button', { name: 'タイトルを取得' }).click()
+  await expect(page.getByLabel('タイトル')).toHaveValue(/example/i)
+})

--- a/e2e/fetch-title.smoke.spec.ts
+++ b/e2e/fetch-title.smoke.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from './fixtures'
 
-test('fetching https://example.com fills the title field', async ({ page }) => {
+test('https://example.com のタイトル取得結果がフォームに反映される', async ({ page }) => {
   await page.goto('/bookmarks/new')
   await page.getByLabel('URL').fill('https://example.com')
   await page.getByRole('button', { name: 'タイトルを取得' }).click()

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,23 @@
+import { test as base } from '@playwright/test'
+
+import { createE2eClient, resetApplicationTables } from './db'
+import { readRuntime } from './runtime'
+
+export const test = base.extend<{ resetData: void }>({
+  resetData: [
+    // oxlint-disable-next-line no-empty-pattern -- Playwright requires object destructuring here.
+    async ({}, use) => {
+      const { libsqlUrl } = await readRuntime()
+      const { client, close } = createE2eClient(libsqlUrl)
+      try {
+        await resetApplicationTables(client)
+        await use()
+      } finally {
+        close()
+      }
+    },
+    { auto: true }
+  ]
+})
+
+export { expect } from '@playwright/test'

--- a/e2e/isolation.spec.ts
+++ b/e2e/isolation.spec.ts
@@ -2,8 +2,8 @@ import { bookmarkId, createE2eDb, findE2eUserId, seedBookmark } from './db'
 import { expect, test } from './fixtures'
 import { readRuntime } from './runtime'
 
-test.describe.serial('fixture isolation', () => {
-  test('first test inserts a bookmark that must not leak', async ({ page }) => {
+test.describe.serial('fixture の独立性', () => {
+  test('先のテストが入れたブックマークは後続へ漏れない', async ({ page }) => {
     const { libsqlUrl } = await readRuntime()
     const { db, close } = createE2eDb(libsqlUrl)
     try {
@@ -21,7 +21,7 @@ test.describe.serial('fixture isolation', () => {
     await expect(page.getByRole('link', { name: 'LeakProbe' })).toBeVisible()
   })
 
-  test('second test starts from empty bookmark tables', async ({ page }) => {
+  test('後続テストは空のブックマーク表から始まる', async ({ page }) => {
     await page.goto('/')
     await expect(page.getByText('まだブックマークがありません')).toBeVisible()
     await expect(page.getByRole('link', { name: 'LeakProbe' })).toHaveCount(0)

--- a/e2e/isolation.spec.ts
+++ b/e2e/isolation.spec.ts
@@ -1,0 +1,29 @@
+import { bookmarkId, createE2eDb, findE2eUserId, seedBookmark } from './db'
+import { expect, test } from './fixtures'
+import { readRuntime } from './runtime'
+
+test.describe.serial('fixture isolation', () => {
+  test('first test inserts a bookmark that must not leak', async ({ page }) => {
+    const { libsqlUrl } = await readRuntime()
+    const { db, close } = createE2eDb(libsqlUrl)
+    try {
+      const userId = await findE2eUserId(db)
+      await seedBookmark(db, {
+        id: bookmarkId(1),
+        userId,
+        title: 'LeakProbe',
+        url: 'https://example.test/leak-probe'
+      })
+    } finally {
+      close()
+    }
+    await page.goto('/')
+    await expect(page.getByRole('link', { name: 'LeakProbe' })).toBeVisible()
+  })
+
+  test('second test starts from empty bookmark tables', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByText('まだブックマークがありません')).toBeVisible()
+    await expect(page.getByRole('link', { name: 'LeakProbe' })).toHaveCount(0)
+  })
+})

--- a/e2e/libsql.ts
+++ b/e2e/libsql.ts
@@ -1,0 +1,44 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { createClient } from '@libsql/client'
+import { drizzle } from 'drizzle-orm/libsql'
+import { migrate } from 'drizzle-orm/libsql/migrator'
+import { GenericContainer, Wait } from 'testcontainers'
+import type { StartedTestContainer } from 'testcontainers'
+
+import { LIBSQL_SERVER_IMAGE } from '../src/test/persistence/libsql-server-image'
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url))
+const migrationsFolder = path.join(repoRoot, 'drizzle')
+
+async function applyProductionMigrations(url: string): Promise<void> {
+  const client = createClient({ url })
+  try {
+    const db = drizzle({ client })
+    await migrate(db, { migrationsFolder })
+  } finally {
+    client.close()
+  }
+}
+
+export async function startMigratedLibsql(): Promise<{
+  readonly container: StartedTestContainer
+  readonly libsqlUrl: string
+}> {
+  const container = await new GenericContainer(LIBSQL_SERVER_IMAGE)
+    .withExposedPorts(8080)
+    .withTmpFs({ '/var/lib/sqld': 'rw,noexec,nosuid,size=64m' })
+    .withWaitStrategy(Wait.forHttp('/v2', 8080))
+    .withStartupTimeout(120_000)
+    .start()
+
+  try {
+    const libsqlUrl = `http://127.0.0.1:${container.getMappedPort(8080)}`
+    await applyProductionMigrations(libsqlUrl)
+    return { container, libsqlUrl }
+  } catch (error) {
+    await container.stop()
+    throw error
+  }
+}

--- a/e2e/open-dialog.ts
+++ b/e2e/open-dialog.ts
@@ -1,0 +1,14 @@
+import type { Locator } from '@playwright/test'
+
+import { expect } from './fixtures'
+
+/**
+ * ダイアログを一度の click で開く。
+ * トリガーの click を toPass で再実行しない。初回 click が hydration に飲まれたら失敗する。
+ */
+export async function openDialog(trigger: Locator, content: Locator): Promise<void> {
+  await expect(trigger).toBeVisible()
+  await expect(trigger).toBeEnabled()
+  await trigger.click()
+  await expect(content).toBeVisible()
+}

--- a/e2e/open-dialog.ts
+++ b/e2e/open-dialog.ts
@@ -1,12 +1,14 @@
 import type { Locator } from '@playwright/test'
 
 import { expect } from './fixtures'
+import { waitForReactReady } from './react-ready'
 
 /**
  * ダイアログを一度の click で開く。
  * トリガーの click を toPass で再実行しない。初回 click が hydration に飲まれたら失敗する。
  */
 export async function openDialog(trigger: Locator, content: Locator): Promise<void> {
+  await waitForReactReady(trigger)
   await expect(trigger).toBeVisible()
   await expect(trigger).toBeEnabled()
   await trigger.click()

--- a/e2e/pagination.spec.ts
+++ b/e2e/pagination.spec.ts
@@ -3,7 +3,6 @@ import type { Page } from '@playwright/test'
 import { BOOKMARK_LIST_PAGE_SIZE } from '../src/features/bookmarks/lib/bookmark-list-page-size'
 import { bookmarkId, createE2eDb, findE2eUserId, seedBookmarks } from './db'
 import { expect, test } from './fixtures'
-import { PASS_EXPECT_TIMEOUT_MS, passOptions } from './pass'
 import { readRuntime } from './runtime'
 
 async function seedPaginatedBookmarks(): Promise<void> {
@@ -43,12 +42,10 @@ async function seedPaginatedBookmarks(): Promise<void> {
 
 async function loadNextPage(page: Page): Promise<void> {
   const loadMoreButton = page.getByRole('button', { name: 'さらに読み込む' })
-  const nextPageAlpha = page.getByRole('link', { name: 'Next Page Alpha' })
   await expect(loadMoreButton).toBeVisible()
-  await expect(async () => {
-    await loadMoreButton.click()
-    await expect(nextPageAlpha).toBeVisible({ timeout: PASS_EXPECT_TIMEOUT_MS })
-  }).toPass(passOptions)
+  await expect(loadMoreButton).toBeEnabled()
+  await loadMoreButton.click()
+  await expect(page.getByRole('link', { name: 'Next Page Alpha' })).toBeVisible()
 }
 
 test('cursor pagination で次ページを読むと既存項目を残したまま追加される', async ({ page }) => {

--- a/e2e/pagination.spec.ts
+++ b/e2e/pagination.spec.ts
@@ -1,0 +1,57 @@
+import { BOOKMARK_LIST_PAGE_SIZE } from '../src/features/bookmarks/lib/bookmark-list-page-size'
+import { bookmarkId, createE2eDb, findE2eUserId, seedBookmarks } from './db'
+import { expect, test } from './fixtures'
+import { readRuntime } from './runtime'
+
+async function seedPaginatedBookmarks(): Promise<void> {
+  const { libsqlUrl } = await readRuntime()
+  const { db, close } = createE2eDb(libsqlUrl)
+  try {
+    const userId = await findE2eUserId(db)
+    const base = new Date('2026-01-01T00:00:00.000Z').getTime()
+    const firstPage = Array.from({ length: BOOKMARK_LIST_PAGE_SIZE }, (_, index) => ({
+      id: bookmarkId(100 + index),
+      userId,
+      title: `Keep ${String(index).padStart(2, '0')}`,
+      url: `https://example.test/keep-${index}`,
+      createdAt: new Date(base + (BOOKMARK_LIST_PAGE_SIZE + 1 - index) * 1000)
+    }))
+    await seedBookmarks(db, [
+      ...firstPage,
+      {
+        id: bookmarkId(100 + BOOKMARK_LIST_PAGE_SIZE),
+        userId,
+        title: 'Next Page Alpha',
+        url: 'https://example.test/next-alpha',
+        createdAt: new Date(base + 1000)
+      },
+      {
+        id: bookmarkId(101 + BOOKMARK_LIST_PAGE_SIZE),
+        userId,
+        title: 'Next Page Beta',
+        url: 'https://example.test/next-beta',
+        createdAt: new Date(base)
+      }
+    ])
+  } finally {
+    close()
+  }
+}
+
+test('cursor pagination appends older bookmarks without removing the first page', async ({
+  page
+}) => {
+  await seedPaginatedBookmarks()
+  await page.goto('/')
+
+  await expect(page.getByRole('link', { name: 'Keep 00' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Next Page Alpha' })).toHaveCount(0)
+  const loadMoreButton = page.getByRole('button', { name: 'さらに読み込む' })
+  await expect(loadMoreButton).toBeVisible()
+
+  await loadMoreButton.click()
+
+  await expect(page.getByRole('link', { name: 'Keep 00' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Next Page Alpha' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Next Page Beta' })).toBeVisible()
+})

--- a/e2e/pagination.spec.ts
+++ b/e2e/pagination.spec.ts
@@ -1,3 +1,5 @@
+import type { Page } from '@playwright/test'
+
 import { BOOKMARK_LIST_PAGE_SIZE } from '../src/features/bookmarks/lib/bookmark-list-page-size'
 import { bookmarkId, createE2eDb, findE2eUserId, seedBookmarks } from './db'
 import { expect, test } from './fixtures'
@@ -38,6 +40,16 @@ async function seedPaginatedBookmarks(): Promise<void> {
   }
 }
 
+async function loadNextPage(page: Page): Promise<void> {
+  const loadMoreButton = page.getByRole('button', { name: 'さらに読み込む' })
+  const nextPageAlpha = page.getByRole('link', { name: 'Next Page Alpha' })
+  await expect(loadMoreButton).toBeVisible()
+  await expect(async () => {
+    await loadMoreButton.click()
+    await expect(nextPageAlpha).toBeVisible()
+  }).toPass()
+}
+
 test('cursor pagination appends older bookmarks without removing the first page', async ({
   page
 }) => {
@@ -47,13 +59,8 @@ test('cursor pagination appends older bookmarks without removing the first page'
   await expect(page.getByRole('link', { name: 'Keep 00' })).toBeVisible()
   const nextPageAlpha = page.getByRole('link', { name: 'Next Page Alpha' })
   await expect(nextPageAlpha).toHaveCount(0)
-  const loadMoreButton = page.getByRole('button', { name: 'さらに読み込む' })
-  await expect(loadMoreButton).toBeVisible()
 
-  await expect(async () => {
-    await loadMoreButton.click()
-    await expect(nextPageAlpha).toBeVisible()
-  }).toPass()
+  await loadNextPage(page)
 
   await expect(page.getByRole('link', { name: 'Keep 00' })).toBeVisible()
   await expect(nextPageAlpha).toBeVisible()

--- a/e2e/pagination.spec.ts
+++ b/e2e/pagination.spec.ts
@@ -51,9 +51,7 @@ async function loadNextPage(page: Page): Promise<void> {
   }).toPass(passOptions)
 }
 
-test('cursor pagination appends older bookmarks without removing the first page', async ({
-  page
-}) => {
+test('cursor pagination で次ページを読むと既存項目を残したまま追加される', async ({ page }) => {
   await seedPaginatedBookmarks()
   await page.goto('/')
 

--- a/e2e/pagination.spec.ts
+++ b/e2e/pagination.spec.ts
@@ -3,6 +3,7 @@ import type { Page } from '@playwright/test'
 import { BOOKMARK_LIST_PAGE_SIZE } from '../src/features/bookmarks/lib/bookmark-list-page-size'
 import { bookmarkId, createE2eDb, findE2eUserId, seedBookmarks } from './db'
 import { expect, test } from './fixtures'
+import { waitForReactReady } from './react-ready'
 import { readRuntime } from './runtime'
 
 async function seedPaginatedBookmarks(): Promise<void> {
@@ -42,6 +43,7 @@ async function seedPaginatedBookmarks(): Promise<void> {
 
 async function loadNextPage(page: Page): Promise<void> {
   const loadMoreButton = page.getByRole('button', { name: 'さらに読み込む' })
+  await waitForReactReady(loadMoreButton)
   await expect(loadMoreButton).toBeVisible()
   await expect(loadMoreButton).toBeEnabled()
   await loadMoreButton.click()

--- a/e2e/pagination.spec.ts
+++ b/e2e/pagination.spec.ts
@@ -3,6 +3,7 @@ import type { Page } from '@playwright/test'
 import { BOOKMARK_LIST_PAGE_SIZE } from '../src/features/bookmarks/lib/bookmark-list-page-size'
 import { bookmarkId, createE2eDb, findE2eUserId, seedBookmarks } from './db'
 import { expect, test } from './fixtures'
+import { PASS_EXPECT_TIMEOUT_MS, passOptions } from './pass'
 import { readRuntime } from './runtime'
 
 async function seedPaginatedBookmarks(): Promise<void> {
@@ -46,8 +47,8 @@ async function loadNextPage(page: Page): Promise<void> {
   await expect(loadMoreButton).toBeVisible()
   await expect(async () => {
     await loadMoreButton.click()
-    await expect(nextPageAlpha).toBeVisible()
-  }).toPass()
+    await expect(nextPageAlpha).toBeVisible({ timeout: PASS_EXPECT_TIMEOUT_MS })
+  }).toPass(passOptions)
 }
 
 test('cursor pagination appends older bookmarks without removing the first page', async ({

--- a/e2e/pagination.spec.ts
+++ b/e2e/pagination.spec.ts
@@ -45,13 +45,17 @@ test('cursor pagination appends older bookmarks without removing the first page'
   await page.goto('/')
 
   await expect(page.getByRole('link', { name: 'Keep 00' })).toBeVisible()
-  await expect(page.getByRole('link', { name: 'Next Page Alpha' })).toHaveCount(0)
+  const nextPageAlpha = page.getByRole('link', { name: 'Next Page Alpha' })
+  await expect(nextPageAlpha).toHaveCount(0)
   const loadMoreButton = page.getByRole('button', { name: 'さらに読み込む' })
   await expect(loadMoreButton).toBeVisible()
 
-  await loadMoreButton.click()
+  await expect(async () => {
+    await loadMoreButton.click()
+    await expect(nextPageAlpha).toBeVisible()
+  }).toPass()
 
   await expect(page.getByRole('link', { name: 'Keep 00' })).toBeVisible()
-  await expect(page.getByRole('link', { name: 'Next Page Alpha' })).toBeVisible()
+  await expect(nextPageAlpha).toBeVisible()
   await expect(page.getByRole('link', { name: 'Next Page Beta' })).toBeVisible()
 })

--- a/e2e/pass.ts
+++ b/e2e/pass.ts
@@ -1,0 +1,8 @@
+const PASS_TIMEOUT_MS = 15_000
+const PASS_INTERVALS_MS = [250, 500, 1000] as const
+export const PASS_EXPECT_TIMEOUT_MS = 2000
+
+export const passOptions: { timeout: number; intervals: number[] } = {
+  timeout: PASS_TIMEOUT_MS,
+  intervals: [...PASS_INTERVALS_MS]
+}

--- a/e2e/pass.ts
+++ b/e2e/pass.ts
@@ -1,8 +1,0 @@
-const PASS_TIMEOUT_MS = 15_000
-const PASS_INTERVALS_MS = [250, 500, 1000] as const
-export const PASS_EXPECT_TIMEOUT_MS = 2000
-
-export const passOptions: { timeout: number; intervals: number[] } = {
-  timeout: PASS_TIMEOUT_MS,
-  intervals: [...PASS_INTERVALS_MS]
-}

--- a/e2e/react-ready.ts
+++ b/e2e/react-ready.ts
@@ -1,0 +1,19 @@
+import type { Locator } from '@playwright/test'
+
+import { expect } from './fixtures'
+
+function hasReactFiber(element: Element): boolean {
+  return Object.keys(element).some((key) => key.startsWith('__reactFiber'))
+}
+
+/**
+ * SSR の可視状態ではなく、対象ノードが React に hydrate されたことを待つ。
+ * fill / click を再実行しない。
+ */
+export async function waitForReactReady(locator: Locator): Promise<void> {
+  await expect
+    .poll(async () => locator.evaluate(hasReactFiber), {
+      message: 'React fiber on locator (hydrated)'
+    })
+    .toBe(true)
+}

--- a/e2e/runtime.ts
+++ b/e2e/runtime.ts
@@ -1,0 +1,29 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url))
+export const runtimeDir = path.join(repoRoot, 'e2e/.runtime')
+const runtimeFile = path.join(runtimeDir, 'runtime.json')
+
+export type E2eRuntime = {
+  readonly libsqlUrl: string
+}
+
+export async function writeRuntime(runtime: E2eRuntime): Promise<void> {
+  await mkdir(runtimeDir, { recursive: true })
+  await writeFile(runtimeFile, `${JSON.stringify(runtime, null, 2)}\n`, 'utf8')
+}
+
+export async function readRuntime(): Promise<E2eRuntime> {
+  const parsed: unknown = JSON.parse(await readFile(runtimeFile, 'utf8'))
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    !('libsqlUrl' in parsed) ||
+    typeof parsed.libsqlUrl !== 'string'
+  ) {
+    throw new Error('e2e/.runtime/runtime.json is missing libsqlUrl')
+  }
+  return { libsqlUrl: parsed.libsqlUrl }
+}

--- a/e2e/search-and-filter.spec.ts
+++ b/e2e/search-and-filter.spec.ts
@@ -1,0 +1,59 @@
+import { bookmarkId, createE2eDb, findE2eUserId, seedBookmarks, seedTag } from './db'
+import { expect, test } from './fixtures'
+import { readRuntime } from './runtime'
+
+async function seedSearchBookmarks(): Promise<void> {
+  const { libsqlUrl } = await readRuntime()
+  const { db, close } = createE2eDb(libsqlUrl)
+  try {
+    const userId = await findE2eUserId(db)
+    const rustTagId = await seedTag(db, { userId, name: 'rust' })
+    const pythonTagId = await seedTag(db, { userId, name: 'python' })
+    await seedBookmarks(db, [
+      {
+        id: bookmarkId(10),
+        userId,
+        title: 'Alpha rust',
+        url: 'https://example.test/alpha',
+        tagIds: [rustTagId]
+      },
+      {
+        id: bookmarkId(11),
+        userId,
+        title: 'Beta python',
+        url: 'https://example.test/beta',
+        tagIds: [pythonTagId]
+      },
+      {
+        id: bookmarkId(12),
+        userId,
+        title: 'Gamma both',
+        url: 'https://example.test/gamma',
+        tagIds: [rustTagId, pythonTagId]
+      }
+    ])
+  } finally {
+    close()
+  }
+}
+
+test('search shows only bookmarks matching the query', async ({ page }) => {
+  await seedSearchBookmarks()
+  await page.goto('/')
+  await page.getByPlaceholder('タイトル・URL・メモ').fill('Alpha')
+  await page.getByRole('button', { name: '検索' }).click()
+
+  await expect(page.getByRole('link', { name: 'Alpha rust' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Beta python' })).toHaveCount(0)
+  await expect(page.getByRole('link', { name: 'Gamma both' })).toHaveCount(0)
+})
+
+test('tag filter shows only bookmarks assigned to the tag', async ({ page }) => {
+  await seedSearchBookmarks()
+  await page.goto('/')
+  await page.getByRole('navigation', { name: 'タグ' }).getByRole('link', { name: /rust/ }).click()
+
+  await expect(page.getByRole('link', { name: 'Alpha rust' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Gamma both' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Beta python' })).toHaveCount(0)
+})

--- a/e2e/search-and-filter.spec.ts
+++ b/e2e/search-and-filter.spec.ts
@@ -1,5 +1,8 @@
+import type { Page } from '@playwright/test'
+
 import { bookmarkId, createE2eDb, findE2eUserId, seedBookmarks, seedTag } from './db'
 import { expect, test } from './fixtures'
+import { waitForReactReady } from './react-ready'
 import { readRuntime } from './runtime'
 
 async function seedSearchBookmarks(): Promise<void> {
@@ -37,15 +40,22 @@ async function seedSearchBookmarks(): Promise<void> {
   }
 }
 
+async function submitKeywordSearch(page: Page, query: string): Promise<void> {
+  const searchField = page.getByPlaceholder('タイトル・URL・メモ')
+  await waitForReactReady(searchField)
+  await searchField.fill(query)
+  await expect(searchField).toHaveValue(query)
+  const searchButton = page.getByRole('button', { name: '検索' })
+  await waitForReactReady(searchButton)
+  await searchButton.click()
+}
+
 test('検索するとクエリに一致するブックマークだけが表示される', async ({ page }) => {
   await seedSearchBookmarks()
   await page.goto('/')
   await expect(page.getByRole('link', { name: 'Alpha rust' })).toBeVisible()
 
-  const searchField = page.getByPlaceholder('タイトル・URL・メモ')
-  await searchField.fill('Alpha')
-  await expect(searchField).toHaveValue('Alpha')
-  await page.getByRole('button', { name: '検索' }).click()
+  await submitKeywordSearch(page, 'Alpha')
   await expect(page).toHaveURL(/(?:\?|&)q=Alpha(?:&|$)/)
 
   await expect(page.getByRole('link', { name: 'Alpha rust' })).toBeVisible()

--- a/e2e/search-and-filter.spec.ts
+++ b/e2e/search-and-filter.spec.ts
@@ -40,9 +40,13 @@ async function seedSearchBookmarks(): Promise<void> {
 test('search shows only bookmarks matching the query', async ({ page }) => {
   await seedSearchBookmarks()
   await page.goto('/')
-  await expect(page.getByRole('link', { name: 'Alpha rust' })).toBeVisible()
-  await page.getByPlaceholder('タイトル・URL・メモ').fill('Alpha')
-  await page.getByRole('button', { name: '検索' }).click()
+  const searchField = page.getByPlaceholder('タイトル・URL・メモ')
+  const searchButton = page.getByRole('button', { name: '検索' })
+  await expect(async () => {
+    await searchField.fill('Alpha')
+    await searchButton.click()
+    await expect(page).toHaveURL(/(?:\?|&)q=Alpha(?:&|$)/)
+  }).toPass()
 
   await expect(page.getByRole('link', { name: 'Alpha rust' })).toBeVisible()
   await expect(page.getByRole('link', { name: 'Beta python' })).toHaveCount(0)

--- a/e2e/search-and-filter.spec.ts
+++ b/e2e/search-and-filter.spec.ts
@@ -1,5 +1,6 @@
 import { bookmarkId, createE2eDb, findE2eUserId, seedBookmarks, seedTag } from './db'
 import { expect, test } from './fixtures'
+import { PASS_EXPECT_TIMEOUT_MS, passOptions } from './pass'
 import { readRuntime } from './runtime'
 
 async function seedSearchBookmarks(): Promise<void> {
@@ -45,8 +46,8 @@ test('search shows only bookmarks matching the query', async ({ page }) => {
   await expect(async () => {
     await searchField.fill('Alpha')
     await searchButton.click()
-    await expect(page).toHaveURL(/(?:\?|&)q=Alpha(?:&|$)/)
-  }).toPass()
+    await expect(page).toHaveURL(/(?:\?|&)q=Alpha(?:&|$)/, { timeout: PASS_EXPECT_TIMEOUT_MS })
+  }).toPass(passOptions)
 
   await expect(page.getByRole('link', { name: 'Alpha rust' })).toBeVisible()
   await expect(page.getByRole('link', { name: 'Beta python' })).toHaveCount(0)

--- a/e2e/search-and-filter.spec.ts
+++ b/e2e/search-and-filter.spec.ts
@@ -40,6 +40,7 @@ async function seedSearchBookmarks(): Promise<void> {
 test('search shows only bookmarks matching the query', async ({ page }) => {
   await seedSearchBookmarks()
   await page.goto('/')
+  await expect(page.getByRole('link', { name: 'Alpha rust' })).toBeVisible()
   await page.getByPlaceholder('タイトル・URL・メモ').fill('Alpha')
   await page.getByRole('button', { name: '検索' }).click()
 

--- a/e2e/search-and-filter.spec.ts
+++ b/e2e/search-and-filter.spec.ts
@@ -1,6 +1,5 @@
 import { bookmarkId, createE2eDb, findE2eUserId, seedBookmarks, seedTag } from './db'
 import { expect, test } from './fixtures'
-import { PASS_EXPECT_TIMEOUT_MS, passOptions } from './pass'
 import { readRuntime } from './runtime'
 
 async function seedSearchBookmarks(): Promise<void> {
@@ -41,13 +40,13 @@ async function seedSearchBookmarks(): Promise<void> {
 test('検索するとクエリに一致するブックマークだけが表示される', async ({ page }) => {
   await seedSearchBookmarks()
   await page.goto('/')
+  await expect(page.getByRole('link', { name: 'Alpha rust' })).toBeVisible()
+
   const searchField = page.getByPlaceholder('タイトル・URL・メモ')
-  const searchButton = page.getByRole('button', { name: '検索' })
-  await expect(async () => {
-    await searchField.fill('Alpha')
-    await searchButton.click()
-    await expect(page).toHaveURL(/(?:\?|&)q=Alpha(?:&|$)/, { timeout: PASS_EXPECT_TIMEOUT_MS })
-  }).toPass(passOptions)
+  await searchField.fill('Alpha')
+  await expect(searchField).toHaveValue('Alpha')
+  await page.getByRole('button', { name: '検索' }).click()
+  await expect(page).toHaveURL(/(?:\?|&)q=Alpha(?:&|$)/)
 
   await expect(page.getByRole('link', { name: 'Alpha rust' })).toBeVisible()
   await expect(page.getByRole('link', { name: 'Beta python' })).toHaveCount(0)

--- a/e2e/search-and-filter.spec.ts
+++ b/e2e/search-and-filter.spec.ts
@@ -38,7 +38,7 @@ async function seedSearchBookmarks(): Promise<void> {
   }
 }
 
-test('search shows only bookmarks matching the query', async ({ page }) => {
+test('検索するとクエリに一致するブックマークだけが表示される', async ({ page }) => {
   await seedSearchBookmarks()
   await page.goto('/')
   const searchField = page.getByPlaceholder('タイトル・URL・メモ')
@@ -54,7 +54,7 @@ test('search shows only bookmarks matching the query', async ({ page }) => {
   await expect(page.getByRole('link', { name: 'Gamma both' })).toHaveCount(0)
 })
 
-test('tag filter shows only bookmarks assigned to the tag', async ({ page }) => {
+test('タグで絞り込むと対象のブックマークだけが表示される', async ({ page }) => {
   await seedSearchBookmarks()
   await page.goto('/')
   await page.getByRole('navigation', { name: 'タグ' }).getByRole('link', { name: /rust/ }).click()

--- a/e2e/sign-in.spec.ts
+++ b/e2e/sign-in.spec.ts
@@ -1,6 +1,14 @@
 import { expect, test } from '@playwright/test'
 
-test('sign-in page renders the login heading', async ({ page }) => {
+import { E2E_USER } from './constants'
+
+test('email and password sign-in shows the bookmark list', async ({ page }) => {
   await page.goto('/sign-in')
-  await expect(page.getByRole('heading', { name: 'ログイン' })).toBeVisible()
+  await page.getByRole('textbox', { name: 'メール' }).fill(E2E_USER.email)
+  await page.getByRole('textbox', { name: 'パスワード' }).fill(E2E_USER.password)
+  await page.getByRole('button', { name: 'サインイン' }).click()
+  await expect(page).toHaveURL(/\/(\?.*)?$/)
+  await expect(page.getByRole('link', { name: '新規' }).first()).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'ログイン' })).toHaveCount(0)
+  await expect(page.getByText('まだブックマークがありません')).toBeVisible()
 })

--- a/e2e/sign-in.spec.ts
+++ b/e2e/sign-in.spec.ts
@@ -1,6 +1,5 @@
-import { expect, test } from '@playwright/test'
-
 import { E2E_USER } from './constants'
+import { expect, test } from './fixtures'
 
 test('email and password sign-in shows the bookmark list', async ({ page }) => {
   await page.goto('/sign-in')

--- a/e2e/sign-in.spec.ts
+++ b/e2e/sign-in.spec.ts
@@ -1,0 +1,6 @@
+import { expect, test } from '@playwright/test'
+
+test('sign-in page renders the login heading', async ({ page }) => {
+  await page.goto('/sign-in')
+  await expect(page.getByRole('heading', { name: 'ログイン' })).toBeVisible()
+})

--- a/e2e/sign-in.spec.ts
+++ b/e2e/sign-in.spec.ts
@@ -1,7 +1,9 @@
 import { E2E_USER } from './constants'
 import { expect, test } from './fixtures'
 
-test('email and password sign-in shows the bookmark list', async ({ page }) => {
+test('メールアドレスとパスワードでサインインするとブックマーク一覧が表示される', async ({
+  page
+}) => {
   await page.goto('/sign-in')
   await page.getByRole('textbox', { name: 'メール' }).fill(E2E_USER.email)
   await page.getByRole('textbox', { name: 'パスワード' }).fill(E2E_USER.password)

--- a/e2e/start-pantry.ts
+++ b/e2e/start-pantry.ts
@@ -1,0 +1,149 @@
+import { spawn } from 'node:child_process'
+import type { ChildProcess } from 'node:child_process'
+import { setTimeout as delay } from 'node:timers/promises'
+
+import type { StartedTestContainer } from 'testcontainers'
+
+import {
+  E2E_BETTER_AUTH_SECRET,
+  E2E_HOST,
+  E2E_ORIGIN,
+  E2E_PORT,
+  E2E_TURSO_AUTH_TOKEN
+} from './constants'
+import { restoreDevVars, writeE2eDevVars } from './dev-vars'
+import { startMigratedLibsql } from './libsql'
+import { writeRuntime } from './runtime'
+
+let container: StartedTestContainer | undefined
+let vite: ChildProcess | undefined
+let cleanupPromise: Promise<void> | undefined
+let shutdownRequested = false
+
+function waitForChildExit(child: ChildProcess): Promise<{
+  readonly code: number | null
+  readonly signal: NodeJS.Signals | null
+}> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve({ code: child.exitCode, signal: child.signalCode })
+  }
+
+  return new Promise((resolve, reject) => {
+    child.once('error', reject)
+    child.once('exit', (code, signal) => resolve({ code, signal }))
+  })
+}
+
+async function stopVite(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return
+  }
+
+  const exited = waitForChildExit(child)
+  child.kill('SIGTERM')
+  const stopped = await Promise.race([exited.then(() => true), delay(5000, false)])
+
+  if (!stopped) {
+    child.kill('SIGKILL')
+    await exited
+  }
+}
+
+async function cleanupResources(): Promise<void> {
+  const runningVite = vite
+  vite = undefined
+
+  try {
+    if (runningVite) {
+      await stopVite(runningVite)
+    }
+  } finally {
+    const runningContainer = container
+    container = undefined
+    let stopContainer: Promise<unknown> | undefined
+
+    try {
+      if (runningContainer) {
+        stopContainer = runningContainer.stop()
+      }
+    } finally {
+      // Playwright can end its command shell before asynchronous container shutdown settles.
+      restoreDevVars()
+    }
+
+    if (stopContainer) {
+      await stopContainer
+    }
+  }
+}
+
+async function cleanup(): Promise<void> {
+  if (cleanupPromise) {
+    return cleanupPromise
+  }
+
+  cleanupPromise = cleanupResources()
+  try {
+    await cleanupPromise
+  } finally {
+    cleanupPromise = undefined
+  }
+}
+
+function requestShutdown(): void {
+  shutdownRequested = true
+  void cleanup().catch((error: unknown) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}
+
+process.once('SIGINT', requestShutdown)
+process.once('SIGTERM', requestShutdown)
+process.once('exit', restoreDevVars)
+
+async function main(): Promise<void> {
+  try {
+    const started = await startMigratedLibsql()
+    container = started.container
+    const { libsqlUrl } = started
+
+    if (shutdownRequested) {
+      return
+    }
+
+    await writeRuntime({ libsqlUrl })
+    writeE2eDevVars(libsqlUrl)
+
+    if (shutdownRequested) {
+      return
+    }
+
+    const childEnv = {
+      ...process.env,
+      TURSO_CONNECTION_URL: libsqlUrl,
+      TURSO_AUTH_TOKEN: E2E_TURSO_AUTH_TOKEN,
+      BETTER_AUTH_SECRET: E2E_BETTER_AUTH_SECRET,
+      BETTER_AUTH_URL: E2E_ORIGIN
+    }
+
+    vite = spawn('pnpm', ['vite', 'dev', '--host', E2E_HOST, '--port', String(E2E_PORT)], {
+      env: childEnv,
+      stdio: 'inherit'
+    })
+
+    const result = await waitForChildExit(vite)
+    if (!shutdownRequested && result.code !== 0) {
+      process.exitCode = result.code ?? 1
+    }
+  } catch (error) {
+    if (!shutdownRequested) {
+      console.error(error)
+      process.exitCode = 1
+    }
+  } finally {
+    await cleanup()
+  }
+}
+
+await main()

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -6,9 +6,20 @@ const config: KnipConfig = {
   // Nested `dotenvx` / `pnpm` wrappers are not fully resolved by the script parser.
   // The tanstack-entry stub is an alias target loaded by the Vitest bundler
   // (see vitest.config.ts resolve.alias); Knip cannot trace that reference.
-  entry: ['auth.ts', 'scripts/**/*.ts', 'vitest/tanstack-entry-stub.ts'],
+  entry: [
+    'auth.ts',
+    'scripts/**/*.ts',
+    'vitest/tanstack-entry-stub.ts',
+    'playwright.config.ts',
+    'playwright.smoke.config.ts',
+    'e2e/start-pantry.ts'
+  ],
   vitest: {
     config: ['vitest.config.ts', 'vitest.persistence.config.ts']
+  },
+  playwright: {
+    config: ['playwright.config.ts', 'playwright.smoke.config.ts'],
+    entry: ['e2e/**/*.ts']
   },
   storybook: {
     config: ['src/storybook/main.ts'],

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "storybook": "storybook dev -p 6006 -c src/storybook",
     "studio:dev": "pnpm dotenvx run -f .env.development -- pnpm drizzle-kit studio",
     "test": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:smoke": "playwright test --config playwright.smoke.config.ts",
     "test:persistence": "vitest run --config vitest.persistence.config.ts",
     "typecheck": "tsc"
   },
@@ -61,6 +63,7 @@
     "@markuplint/jsx-parser": "catalog:lint",
     "@markuplint/react-spec": "catalog:lint",
     "@pandacss/dev": "catalog:ui",
+    "@playwright/test": "catalog:test",
     "@storybook/addon-docs": "catalog:storybook",
     "@storybook/builder-vite": "catalog:storybook",
     "@storybook/tanstack-react": "catalog:storybook",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test'
+
+import { E2E_ORIGIN } from './e2e/constants'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  reporter:
+    process.env['GITHUB_ACTIONS'] === 'true' ? [['github'], ['html']] : [['list'], ['html']],
+  use: {
+    ...devices['Desktop Chrome'],
+    baseURL: E2E_ORIGIN,
+    viewport: { width: 1280, height: 720 },
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure'
+  },
+  webServer: {
+    command: 'pnpm exec tsx e2e/start-pantry.ts',
+    url: E2E_ORIGIN,
+    reuseExistingServer: false,
+    timeout: 180_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    gracefulShutdown: { signal: 'SIGTERM', timeout: 20_000 }
+  },
+  projects: [
+    {
+      name: 'sign-in',
+      testMatch: /sign-in\.spec\.ts/,
+      dependencies: [],
+      use: { storageState: { cookies: [], origins: [] } }
+    }
+  ]
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
     {
       name: 'main',
       testMatch: /.*\.spec\.ts/,
-      testIgnore: [/sign-in\.spec\.ts/, /fetch-title\.smoke\.spec\.ts/],
+      testIgnore: [/sign-in\.spec\.ts/, /.*\.smoke\.spec\.ts/],
       dependencies: ['setup'],
       use: { storageState: 'e2e/.auth/user.json' }
     }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,11 +28,19 @@ export default defineConfig({
     gracefulShutdown: { signal: 'SIGTERM', timeout: 20_000 }
   },
   projects: [
+    { name: 'setup', testMatch: /auth\.setup\.ts/ },
     {
       name: 'sign-in',
       testMatch: /sign-in\.spec\.ts/,
-      dependencies: [],
+      dependencies: ['setup'],
       use: { storageState: { cookies: [], origins: [] } }
+    },
+    {
+      name: 'main',
+      testMatch: /.*\.spec\.ts/,
+      testIgnore: [/sign-in\.spec\.ts/, /fetch-title\.smoke\.spec\.ts/],
+      dependencies: ['setup'],
+      use: { storageState: 'e2e/.auth/user.json' }
     }
   ]
 })

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -6,7 +6,7 @@ export default {
     { name: 'setup', testMatch: /auth\.setup\.ts/ },
     {
       name: 'smoke',
-      testMatch: /fetch-title\.smoke\.spec\.ts/,
+      testMatch: /.*\.smoke\.spec\.ts/,
       dependencies: ['setup'],
       use: { storageState: 'e2e/.auth/user.json' }
     }

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -1,0 +1,14 @@
+import config from './playwright.config'
+
+export default {
+  ...config,
+  projects: [
+    { name: 'setup', testMatch: /auth\.setup\.ts/ },
+    {
+      name: 'smoke',
+      testMatch: /fetch-title\.smoke\.spec\.ts/,
+      dependencies: ['setup'],
+      use: { storageState: 'e2e/.auth/user.json' }
+    }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,9 @@ catalogs:
     '@cloudflare/vitest-pool-workers':
       specifier: 0.21.3
       version: 0.21.3
+    '@playwright/test':
+      specifier: 1.62.1
+      version: 1.62.1
     testcontainers:
       specifier: 12.1.0
       version: 12.1.0
@@ -328,6 +331,9 @@ importers:
       '@pandacss/dev':
         specifier: catalog:ui
         version: 1.12.0(typescript@7.0.2)
+      '@playwright/test':
+        specifier: catalog:test
+        version: 1.62.1
       '@storybook/addon-docs':
         specifier: catalog:storybook
         version: 10.5.8(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(storybook@10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -2480,6 +2486,11 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
 
@@ -4448,6 +4459,11 @@ packages:
     resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -5401,6 +5417,16 @@ packages:
   pkg-up@3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -8290,6 +8316,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@poppinss/colors@4.1.6':
     dependencies:
       kleur: 4.1.5
@@ -10179,6 +10209,9 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -11129,6 +11162,14 @@ snapshots:
   pkg-up@3.1.0:
     dependencies:
       find-up: 3.0.0
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -72,6 +72,7 @@ catalogs:
     '@cloudflare/vitest-pool-workers': 0.21.3
     testcontainers: 12.1.0
     vitest: 4.1.10
+    '@playwright/test': 1.62.1
   typescript:
     '@tsconfig/strictest': 2.0.8
     typescript: 7.0.2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #258

## 実装概要

Playwright Test 1.62.1 を導入し、Chromium から `@cloudflare/vite-plugin` のローカル Worker runtime（`pnpm vite dev` / workerd）と Testcontainers 上の libSQL を通して主要ユーザーフローを自動検証する。

- `e2e/start-pantry.ts` が libSQL → 本番 Drizzle migration → E2E 専用 `.dev.vars` → `pnpm vite dev --host 127.0.0.1 --port 3100` の順で起動する。
- PR CI に job `e2e` を追加。`https://example.com` のタイトル取得 smoke は `pnpm run test:e2e:smoke` と workflow `E2E external HTTP smoke`（週次 cron `0 6 * * 1` + `workflow_dispatch`）に分離し、`pull_request` では動かない。
- `pnpm test` は従来どおり `vitest run`（Browser / Docker なし）。

How の詳細は `docs/superpowers/plans/2026-08-31-playwright-e2e.md`。仕様の正本は Issue #258 本文。

## テストケース

`pnpm run test:e2e`（PR の job `e2e`）

| ファイル | ケース | 確認すること |
| --- | --- | --- |
| `e2e/auth.setup.ts` | 認証済み状態を保存する | UI サインイン後に `storageState` を保存する（ハーネス。ユーザー到達可能な API ではない） |
| `e2e/sign-in.spec.ts` | メールアドレスとパスワードでサインインするとブックマーク一覧が表示される | メール／パスワードを入力してサインインし、一覧（空状態）が出る |
| `e2e/create-bookmark.spec.ts` | ブックマークを作成すると一覧から確認できる | 新規登録したブックマークが一覧に見える |
| `e2e/edit-bookmark.spec.ts` | ブックマークを編集するとタグの付与と解除が反映される | タグを付けて外し、詳細と一覧の両方で結果が見える |
| `e2e/delete-bookmark.spec.ts` | ブックマークを削除すると一覧から消える | 削除確認後、対象が一覧に無い |
| `e2e/search-and-filter.spec.ts` | 検索するとクエリに一致するブックマークだけが表示される | `Alpha` 検索で対象外が消える |
| `e2e/search-and-filter.spec.ts` | タグで絞り込むと対象のブックマークだけが表示される | `rust` タグで対象外が消える |
| `e2e/pagination.spec.ts` | cursor pagination で次ページを読むと既存項目を残したまま追加される | `さらに読み込む` 後も先頭ページが残り、次ページが追加される |
| `e2e/isolation.spec.ts` | 先のテストが入れたブックマークは後続へ漏れない | serial 1 本目がデータを入れる |
| `e2e/isolation.spec.ts` | 後続テストは空のブックマーク表から始まる | serial 2 本目は空一覧から始まる |

`pnpm run test:e2e:smoke`（merge gate 外。週次 + 手動）

| ファイル | ケース | 確認すること |
| --- | --- | --- |
| `e2e/fetch-title.smoke.spec.ts` | https://example.com のタイトル取得結果がフォームに反映される | `タイトルを取得` の結果がタイトル欄に入る |

## 主な実装上の判断

- Playwright `webServer` は Vite を直接起動せず、`e2e/start-pantry.ts` が Testcontainers libSQL → 本番 migration → E2E 専用 `.dev.vars` → `pnpm vite dev --port 3100` の順で起動する（webServer は globalSetup より先に走るため）。
- 開発者の `.dev.vars`（外部 Turso）を使わないよう、E2E 実行中だけ差し替えて終了時に戻す。`reuseExistingServer` は常に false。`TURSO_CONNECTION_URL` は `127.0.0.1` / `localhost` 以外を拒否する。
- サインイン検証は UI フォームを1本。その他は Playwright `storageState`。ユーザー到達可能なテスト専用認証 API は追加しない。`auth.api.createUser` は Playwright プロセス内のハーネス。
- 主要スイートは `タイトルを取得` を押さず、URL は `https://example.test/...` を使う。
- `retries: 0` / `workers: 1` / Chromium desktop のみ。`fill` / `click` は対象ノードに React fiber が付くまで待ってから一度だけ実行し、結果は Playwright の web-first assertion で待つ。副作用のある操作を `toPass` で再実行しない。
- `*.smoke.spec.ts` は拡張子パターンで main から除外し、smoke config だけが拾う。
- E2E 専用 Better Auth secret は本番と共有しない低エントロピーな 32 文字ダミー（`e2e-local-better-auth-secret-001`）。GitGuardian が初期コミットの高エントロピーなダミーを履歴スキャンしていたため、その文字列はブランチ履歴から除去した。

## 受け入れ条件の検証

| 受け入れ条件 | 結果 | 検証方法・証跡 |
| ------------ | :---: | -------------- |
| ローカルで Chromium を使った Playwright E2E を実行できる | ✅ | `pnpm run test:e2e` を連続実行。いずれも 10 passed |
| Pantry は `@cloudflare/vite-plugin` のローカル Worker runtime で実行される | ✅ | `e2e/start-pantry.ts` が `pnpm vite dev --host 127.0.0.1 --port 3100` を起動。ログに `Using secrets defined in .dev.vars` と `VITE v8.2.1 ready` |
| Testcontainers のテスト専用 libSQL へ接続し、外部 Turso へ接続しない | ✅ | `e2e/libsql.ts` が `LIBSQL_SERVER_IMAGE` の GenericContainer を起動。`assertLocalLibsqlUrl` が `turso.io` / 非ローカルを拒否 |
| テスト専用 libSQL に本番と同じ migration が適用される | ✅ | `drizzle-orm/libsql/migrator` で repo の `drizzle/` を適用 |
| メール/パスワード UI サインイン後、ブックマーク一覧を表示できる | ✅ | `e2e/sign-in.spec.ts` |
| ブックマーク作成後、一覧から確認できる | ✅ | `e2e/create-bookmark.spec.ts` |
| 編集でタグを付与・解除し、ブラウザから確認できる | ✅ | `e2e/edit-bookmark.spec.ts` |
| 検索・タグ絞り込みで対象外が除外される | ✅ | `e2e/search-and-filter.spec.ts` |
| cursor pagination で既存項目が維持され、次ページが追加される | ✅ | `e2e/pagination.spec.ts` |
| 削除後、一覧から消える | ✅ | `e2e/delete-bookmark.spec.ts` |
| サインイン検証以外は認証済み状態から開始できる | ✅ | `e2e/auth.setup.ts` の `storageState` |
| 連続実行しても前回の DB 状態へ依存しない | ✅ | 連続実行と `e2e/isolation.spec.ts` |
| PR CI で主要 E2E が自動実行され、失敗時は check が失敗する | ✅ | `.github/workflows/ci.yaml` job `e2e`。GitHub Actions で pass を確認。ruleset の required 化はリポジトリ管理側 |
| `https://example.com` のタイトル取得 smoke を手動実行できる | ✅ | `pnpm run test:e2e:smoke` と `workflow_dispatch`。この Cloud VM の workerd outbound fetch はタイトル空のためローカル smoke は未グリーン |
| smoke は定期実行でき、PR merge gate に含まれない | ✅ | `e2e-smoke.yaml` は `schedule` + `workflow_dispatch` のみ |
| `pnpm test` は Browser / Docker を起動せず実行できる | ✅ | `test` は `vitest run`。80 files / 404 tests pass |

## 自動検証

- [x] `pnpm run format:check`
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] `pnpm run test:persistence`
- [x] `pnpm run test:e2e`
- [x] `pnpm run build`

## 仕様との差異

なし。この Cloud VM の local workerd から `https://example.com` への outbound fetch はタイトルを返さないことがある。本番のタイトル取得実装は変えていない。

## 補足

- job `e2e` を GitHub ruleset の required check に追加する作業はリポジトリ管理側（`persistence-integration` と同様）。
- GitGuardian 対策として、ダミー secret の旧文字列をブランチの全コミットから除去し、最新の `main`（`#192`）の上へ rebase した。
- PR コメント https://github.com/koralle/pantry/pull/262#issuecomment-5474156923 への対応: `fill` / `click` を `toPass` で再実行しない。操作前に対象ノードの React fiber（hydrate 完了）を待ち、操作は一度だけ、結果は web-first assertion で待つ。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbc7a8b9-0a18-4c38-a00c-97c38f8d9d7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbc7a8b9-0a18-4c38-a00c-97c38f8d9d7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

