### PR TITLE
perf(react): trim production DEV tools and split list Suspense

### DIFF
--- a/src/features/app-shell/components/app-header.test.ts
+++ b/src/features/app-shell/components/app-header.test.ts
@@ -8,8 +8,9 @@ const dir = import.meta.dirname;
 describe("AppHeader", () => {
   const source = readFileSync(join(dir, "app-header.tsx"), "utf-8");
 
-  test("search draft resets by key, not an effect", () => {
-    expect(source).toContain('key={listSearch?.q ?? ""}');
+  test("search draft follows committed q during render, without an effect or remount key", () => {
+    expect(source).toContain("committedQ !== prevCommittedQ");
     expect(source).not.toContain("useEffect");
+    expect(source).not.toContain("key={listSearch?.q");
   });
 });

--- a/src/features/app-shell/components/app-header.test.ts
+++ b/src/features/app-shell/components/app-header.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, test } from "vitest";
+
+const dir = import.meta.dirname;
+
+describe("AppHeader", () => {
+  const source = readFileSync(join(dir, "app-header.tsx"), "utf-8");
+
+  test("search draft resets by key, not an effect", () => {
+    expect(source).toContain('key={listSearch?.q ?? ""}');
+    expect(source).not.toContain("useEffect");
+  });
+});

--- a/src/features/app-shell/components/app-header.tsx
+++ b/src/features/app-shell/components/app-header.tsx
@@ -96,7 +96,14 @@ const HeaderSearch = ({
   readonly listSearch: BookmarkSearchSchema | undefined;
 }) => {
   const navigate = useNavigate();
-  const [draftQ, setDraftQ] = useState(listSearch?.q ?? "");
+  const committedQ = listSearch?.q ?? "";
+  const [draftQ, setDraftQ] = useState(committedQ);
+  const [prevCommittedQ, setPrevCommittedQ] = useState(committedQ);
+
+  if (committedQ !== prevCommittedQ) {
+    setPrevCommittedQ(committedQ);
+    setDraftQ(committedQ);
+  }
 
   const commitSearch = (raw: string) => {
     const nextQ = raw.trim();
@@ -166,7 +173,7 @@ export const AppHeader = ({
         {shelfTrigger}
       </div>
 
-      <HeaderSearch key={listSearch?.q ?? ""} listSearch={listSearch} />
+      <HeaderSearch listSearch={listSearch} />
 
       <div className={headerActions}>
         <StyledLink

--- a/src/features/app-shell/components/app-header.tsx
+++ b/src/features/app-shell/components/app-header.tsx
@@ -1,7 +1,7 @@
 import type { LinkProps, RegisteredRouter } from "@tanstack/react-router";
 import { useNavigate } from "@tanstack/react-router";
 import { LogOut, Plus, Search, Settings, Tags } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type { ReactNode } from "react";
 import { Label, SearchField } from "react-aria-components";
 import { css } from "styled-system/css";
@@ -90,24 +90,13 @@ const searchSubmit = css({
   paddingInline: "3",
 });
 
-export const AppHeader = ({
-  newBookmarkSearch,
+const HeaderSearch = ({
   listSearch,
-  shelfTrigger,
 }: {
-  readonly newBookmarkSearch: NonNullable<
-    LinkProps<"a", RegisteredRouter, string, "/bookmarks/new">["search"]
-  >;
   readonly listSearch: BookmarkSearchSchema | undefined;
-  readonly shelfTrigger: ReactNode;
 }) => {
-  const { handleSignOut, isPending } = useSignOut();
   const navigate = useNavigate();
   const [draftQ, setDraftQ] = useState(listSearch?.q ?? "");
-
-  useEffect(() => {
-    setDraftQ(listSearch?.q ?? "");
-  }, [listSearch?.q]);
 
   const commitSearch = (raw: string) => {
     const nextQ = raw.trim();
@@ -120,6 +109,47 @@ export const AppHeader = ({
       to: "/",
     });
   };
+
+  return (
+    <div className={searchForm}>
+      <SearchField
+        className={searchField}
+        value={draftQ}
+        onChange={setDraftQ}
+        onSubmit={commitSearch}
+      >
+        <Label className={srOnly}>検索</Label>
+        <StyledInput
+          type="search"
+          placeholder="タイトル・URL・メモ"
+          enterKeyHint="search"
+        />
+      </SearchField>
+      <StyledButton
+        className={searchSubmit}
+        aria-label="検索"
+        onPress={() => {
+          commitSearch(draftQ);
+        }}
+      >
+        <Search size={16} aria-hidden />
+      </StyledButton>
+    </div>
+  );
+};
+
+export const AppHeader = ({
+  newBookmarkSearch,
+  listSearch,
+  shelfTrigger,
+}: {
+  readonly newBookmarkSearch: NonNullable<
+    LinkProps<"a", RegisteredRouter, string, "/bookmarks/new">["search"]
+  >;
+  readonly listSearch: BookmarkSearchSchema | undefined;
+  readonly shelfTrigger: ReactNode;
+}) => {
+  const { handleSignOut, isPending } = useSignOut();
 
   return (
     <header className={shellHeader}>
@@ -136,30 +166,7 @@ export const AppHeader = ({
         {shelfTrigger}
       </div>
 
-      <div className={searchForm}>
-        <SearchField
-          className={searchField}
-          value={draftQ}
-          onChange={setDraftQ}
-          onSubmit={commitSearch}
-        >
-          <Label className={srOnly}>検索</Label>
-          <StyledInput
-            type="search"
-            placeholder="タイトル・URL・メモ"
-            enterKeyHint="search"
-          />
-        </SearchField>
-        <StyledButton
-          className={searchSubmit}
-          aria-label="検索"
-          onPress={() => {
-            commitSearch(draftQ);
-          }}
-        >
-          <Search size={16} aria-hidden />
-        </StyledButton>
-      </div>
+      <HeaderSearch key={listSearch?.q ?? ""} listSearch={listSearch} />
 
       <div className={headerActions}>
         <StyledLink

--- a/src/features/app-shell/components/query-devtools.tsx
+++ b/src/features/app-shell/components/query-devtools.tsx
@@ -1,0 +1,3 @@
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+
+export const QueryDevtools = () => <ReactQueryDevtools initialIsOpen={false} />;

--- a/src/features/app-shell/components/root-devtools.tsx
+++ b/src/features/app-shell/components/root-devtools.tsx
@@ -1,0 +1,21 @@
+import type { TanStackDevtoolsReactInit } from "@tanstack/react-devtools";
+import { TanStackDevtools } from "@tanstack/react-devtools";
+import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
+
+const tanstackDevtoolsConfig = {
+  position: "bottom-right",
+} satisfies TanStackDevtoolsReactInit["config"];
+
+const tanstackDevtoolsPlugins = [
+  {
+    name: "Tanstack Router",
+    render: <TanStackRouterDevtoolsPanel />,
+  },
+] satisfies TanStackDevtoolsReactInit["plugins"];
+
+export const RootDevtools = () => (
+  <TanStackDevtools
+    config={tanstackDevtoolsConfig}
+    plugins={tanstackDevtoolsPlugins}
+  />
+);

--- a/src/features/app-shell/components/root-document.tsx
+++ b/src/features/app-shell/components/root-document.tsx
@@ -1,23 +1,18 @@
-import type { TanStackDevtoolsReactInit } from "@tanstack/react-devtools";
-import { TanStackDevtools } from "@tanstack/react-devtools";
 import { HeadContent, Scripts } from "@tanstack/react-router";
-import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
+import { lazy, Suspense } from "react";
+import type { ReactNode } from "react";
 
-const tanstackDevtoolsConfig = {
-  position: "bottom-right",
-} satisfies TanStackDevtoolsReactInit["config"];
-
-const tanstackDevtoolsPlugins = [
-  {
-    name: "Tanstack Router",
-    render: <TanStackRouterDevtoolsPanel />,
-  },
-] satisfies TanStackDevtoolsReactInit["plugins"];
+const RootDevtools = import.meta.env.DEV
+  ? lazy(async () => {
+      const { RootDevtools: Devtools } = await import("./root-devtools");
+      return { default: Devtools };
+    })
+  : () => null;
 
 export const RootDocument = ({
   children,
 }: {
-  readonly children: React.ReactNode;
+  readonly children: ReactNode;
 }) => (
   <html lang="ja">
     <head>
@@ -35,10 +30,9 @@ export const RootDocument = ({
     <body>
       {children}
       {import.meta.env.DEV ? (
-        <TanStackDevtools
-          config={tanstackDevtoolsConfig}
-          plugins={tanstackDevtoolsPlugins}
-        />
+        <Suspense fallback={null}>
+          <RootDevtools />
+        </Suspense>
       ) : null}
       <Scripts />
     </body>

--- a/src/features/bookmarks/components/bookmark-list-frame.tsx
+++ b/src/features/bookmarks/components/bookmark-list-frame.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "@tanstack/react-router";
-import { Suspense, use } from "react";
+import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 
 import { createErrorFallback } from "../../../shared/components/error-fallback";
@@ -11,6 +11,7 @@ import type { ListLayout } from "../lib/list-layout-preference";
 import { ListLoading } from "./bookmark-list-loading";
 import { BookmarkListResults } from "./bookmark-list-results";
 import { ListToolbar } from "./bookmark-list-toolbar";
+import { ListToolbarAsync } from "./list-toolbar-async";
 
 const ListError = createErrorFallback("一覧の読み込みに失敗しました");
 
@@ -25,18 +26,28 @@ export const BookmarkListFrame = ({
   readonly changeLayout: (layout: ListLayout) => void;
   readonly shelfTagsPromise: Promise<ShelfTag[]>;
 }) => {
-  const shelfTags = use(shelfTagsPromise);
   const router = useRouter();
   const listKey = bookmarkListSearchIdentity(search);
 
   return (
     <>
-      <ListToolbar
-        search={search}
-        layout={layout}
-        onLayoutChange={changeLayout}
-        shelfTags={shelfTags}
-      />
+      <Suspense
+        fallback={
+          <ListToolbar
+            search={search}
+            layout={layout}
+            onLayoutChange={changeLayout}
+            shelfTags={[]}
+          />
+        }
+      >
+        <ListToolbarAsync
+          search={search}
+          layout={layout}
+          onLayoutChange={changeLayout}
+          shelfTagsPromise={shelfTagsPromise}
+        />
+      </Suspense>
 
       <ErrorBoundary
         FallbackComponent={ListError}

--- a/src/features/bookmarks/components/bookmark-list.tsx
+++ b/src/features/bookmarks/components/bookmark-list.tsx
@@ -1,5 +1,3 @@
-import { Suspense } from "react";
-
 import type { BookmarkSearchSchema } from "../../navigation/lib/bookmark-search";
 import { useTouchTagLastUsedOnce } from "../../tags/hooks/use-touch-tag-last-used";
 import type { ShelfTag } from "../../tags/lib/tag-shelf";
@@ -9,8 +7,6 @@ import {
   rememberBookmarkListScroll,
 } from "../lib/bookmark-list-scroll-session";
 import { BookmarkListFrame } from "./bookmark-list-frame";
-import { ListLoading } from "./bookmark-list-loading";
-import { ListToolbar } from "./bookmark-list-toolbar";
 
 interface BookmarkListProps {
   readonly search: BookmarkSearchSchema;
@@ -33,26 +29,12 @@ export const BookmarkList = ({
 
   return (
     <section>
-      <Suspense
-        fallback={
-          <>
-            <ListToolbar
-              search={search}
-              layout={layout}
-              onLayoutChange={changeLayout}
-              shelfTags={[]}
-            />
-            <ListLoading layout={layout} />
-          </>
-        }
-      >
-        <BookmarkListFrame
-          search={search}
-          layout={layout}
-          changeLayout={changeLayout}
-          shelfTagsPromise={shelfTagsPromise}
-        />
-      </Suspense>
+      <BookmarkListFrame
+        search={search}
+        layout={layout}
+        changeLayout={changeLayout}
+        shelfTagsPromise={shelfTagsPromise}
+      />
     </section>
   );
 };

--- a/src/features/bookmarks/components/list-toolbar-async.tsx
+++ b/src/features/bookmarks/components/list-toolbar-async.tsx
@@ -1,0 +1,30 @@
+import { use } from "react";
+
+import type { BookmarkSearchSchema } from "../../navigation/lib/bookmark-search";
+import type { ShelfTag } from "../../tags/lib/tag-shelf";
+import type { ListLayout } from "../lib/list-layout-preference";
+import { ListToolbar } from "./bookmark-list-toolbar";
+
+interface ListToolbarAsyncProps {
+  readonly search: BookmarkSearchSchema;
+  readonly layout: ListLayout;
+  readonly onLayoutChange: (layout: ListLayout) => void;
+  readonly shelfTagsPromise: Promise<ShelfTag[]>;
+}
+
+export const ListToolbarAsync = ({
+  search,
+  layout,
+  onLayoutChange,
+  shelfTagsPromise,
+}: ListToolbarAsyncProps) => {
+  const shelfTags = use(shelfTagsPromise);
+  return (
+    <ListToolbar
+      search={search}
+      layout={layout}
+      onLayoutChange={onLayoutChange}
+      shelfTags={shelfTags}
+    />
+  );
+};

--- a/src/features/bookmarks/lib/query-ownership.test.ts
+++ b/src/features/bookmarks/lib/query-ownership.test.ts
@@ -143,4 +143,27 @@ describe("bookmark list query ownership", () => {
     expect(source).not.toContain("resetBookmarkListCache");
     expect(source).not.toContain("removeQueries");
   });
+
+  test("BookmarkList は Frame 全体を一つの Suspense で包まない", () => {
+    const source = readSource(
+      "features/bookmarks/components/bookmark-list.tsx"
+    );
+    expect(source).not.toContain("Suspense");
+    expect(source).not.toContain("ListLoading");
+  });
+
+  test("棚タグの use() は toolbar に閉じ、一覧結果を待たせない", () => {
+    const frame = readSource(
+      "features/bookmarks/components/bookmark-list-frame.tsx"
+    );
+    const toolbar = readSource(
+      "features/bookmarks/components/list-toolbar-async.tsx"
+    );
+
+    expect(frame).not.toContain("use(shelfTagsPromise)");
+    expect(frame).toContain("ListToolbarAsync");
+    expect(frame).toContain("BookmarkListResults");
+    expect(frame).toContain("ListLoading");
+    expect(toolbar).toContain("use(shelfTagsPromise)");
+  });
 });

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,10 +1,18 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { createRouter as createTanStackRouter } from "@tanstack/react-router";
 import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
+import { lazy, Suspense } from "react";
 
 import { shouldRestoreRouterScroll } from "./features/bookmarks/lib/bookmark-list-scroll-session";
 import { routeTree } from "./routeTree.gen";
+
+const QueryDevtools = import.meta.env.DEV
+  ? lazy(async () => {
+      const { QueryDevtools: Devtools } =
+        await import("./features/app-shell/components/query-devtools");
+      return { default: Devtools };
+    })
+  : () => null;
 
 export const getRouter = function getRouter() {
   const queryClient = new QueryClient();
@@ -13,7 +21,11 @@ export const getRouter = function getRouter() {
     Wrap: ({ children }) => (
       <QueryClientProvider client={queryClient}>
         {children}
-        <ReactQueryDevtools initialIsOpen={false} />
+        {import.meta.env.DEV ? (
+          <Suspense fallback={null}>
+            <QueryDevtools />
+          </Suspense>
+        ) : null}
       </QueryClientProvider>
     ),
     context: {

--- a/src/rpc/source-boundary.test.ts
+++ b/src/rpc/source-boundary.test.ts
@@ -98,3 +98,20 @@ describe("shelf query ownership", () => {
     }
   });
 });
+
+describe("production client graph", () => {
+  test("router は react-query-devtools を静的 import しない", async () => {
+    const source = await readSource("router.tsx");
+
+    expect(source).not.toMatch(/from ["']@tanstack\/react-query-devtools["']/);
+  });
+
+  test("RootDocument は tanstack DEV tools を静的 import しない", async () => {
+    const source = await readSource(
+      "features/app-shell/components/root-document.tsx"
+    );
+
+    expect(source).not.toMatch(/from ["']@tanstack\/react-devtools["']/);
+    expect(source).not.toMatch(/from ["']@tanstack\/react-router-devtools["']/);
+  });
+});

--- a/src/shared/components/ui-loading.test.ts
+++ b/src/shared/components/ui-loading.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, test } from "vitest";
+
+const dir = import.meta.dirname;
+
+describe("UiLoading", () => {
+  const source = readFileSync(join(dir, "ui-loading.tsx"), "utf-8");
+
+  test("spin animation lives on a wrapper, not the SVG", () => {
+    expect(source).toContain("className={spinner}");
+    expect(source).not.toContain("<LoaderCircle size={16} className={spinner}");
+  });
+});

--- a/src/shared/components/ui-loading.tsx
+++ b/src/shared/components/ui-loading.tsx
@@ -4,6 +4,9 @@ import { skeleton, spinner } from "../../styles/feedback";
 
 export const UiLoading = ({ label = "読み込み中" }: { label?: string }) => (
   <output className={skeleton} aria-live="polite">
-    <LoaderCircle size={16} className={spinner} aria-hidden /> {label}
+    <span className={spinner} aria-hidden>
+      <LoaderCircle size={16} />
+    </span>{" "}
+    {label}
   </output>
 );

--- a/src/styles/feedback.ts
+++ b/src/styles/feedback.ts
@@ -19,6 +19,7 @@ export const spinner = css({
   animationIterationCount: "infinite",
   animationName: "spin",
   animationTimingFunction: "linear",
+  display: "inline-flex",
 });
 
 export const stateBox = css({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,6 +31,8 @@ const nodeTests = [
   "src/features/bookmarks/orpc-update.source.test.ts",
   "src/features/bookmarks/components/bookmark-delete-dialog.test.ts",
   "src/features/bookmarks/lib/query-ownership.test.ts",
+  "src/shared/components/ui-loading.test.ts",
+  "src/features/app-shell/components/app-header.test.ts",
   "src/features/auth/passkey-plugin-wiring.test.ts",
   "src/features/auth/passkey-ui.source.test.ts",
 ];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 関連Issue

なし。Vercel React Best Practices に沿った既存画面の最適化。

## 実装概要

本番クライアントグラフから TanStack DEV tools を外し、一覧の棚タグ `use()` を toolbar に閉じ、スピナーは SVG ではなくラッパを回し、ヘッダー検索下書きは committed `q` の変化を render 中に反映する。

## Why

本番バンドルが DEV 専用モジュールを静的 import していた。一覧結果は棚タグ解決を待っていた。検索下書きは props を effect で state にコピーしていた。

## Scope

- `src/router.tsx` と `RootDocument` は `import.meta.env.DEV` の `lazy()` でのみ `QueryDevtools` / `RootDevtools` を載せる
- `ListToolbarAsync` が `use(shelfTagsPromise)` を持ち、`BookmarkListResults` は独自の `Suspense` で進む
- `UiLoading` の `spinner` は `span` ラッパへ移動
- `HeaderSearch` は `committedQ !== prevCommittedQ` のときだけ draft を合わせる。`useEffect` も remount `key` も使わない

## Tradeoffs

棚タグが未解決の間、toolbar は空の `shelfTags` で描画する。以前の外枠 `Suspense` と同じフォールバック。

検索 submit 後に `key` でフィールドを作り直すとフォーカスが落ちるので、render 中の state 調整に切り替えた。

## Blast Radius

保護レイアウトのヘッダー、ブックマーク一覧、`UiLoading` を使うタグ画面。サーバー RPC と query key は触っていない。

## 主な実装上の判断

- View Transitions と React Compiler は既存の `PantryMotion` と未計測のため入れない
- boolean loading props の composition 書き換えは今回の対象外
- lucide の deep import は TypeScript 型が落ちるので触らない

## 受け入れ条件の検証

| 受け入れ条件 | 結果 | 検証方法・証跡 |
| --- | :---: | --- |
| 本番クライアントが TanStack DEV tools を静的 import しない | ✅ | `src/rpc/source-boundary.test.ts`。`pnpm build` 後の `dist/client` と `dist/server` に Devtools 文字列なし |
| 一覧結果が棚タグ `use()` を待たない | ✅ | `src/features/bookmarks/lib/query-ownership.test.ts` |
| スピナーアニメは SVG ではなくラッパ | ✅ | `src/shared/components/ui-loading.test.ts`。本番 chunk が `span` ラッパ |
| 検索下書きは effect 同期しない | ✅ | `src/features/app-shell/components/app-header.test.ts`。Storybook で committed `q` がフィールドに入る |

## 自動検証

- [x] `pnpm run check`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [ ] `pnpm run test:persistence`
- [x] `pnpm run build`

## 仕様との差異

なし

## 補足

`test:persistence` は DB 契約を変えていないのでこの PR では走らせない。Storybook の Playwright iframe では list の queryFn スタブが効かず `/api/rpc/bookmarks/list` が 404 になる。toolbar とヘッダーは描画される。一覧本体のスタブは Storybook の play 関数側の話で、この差分の対象外。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07794-98fe-7b85-a295-3618cfb1c4cb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07794-98fe-7b85-a295-3618cfb1c4cb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

