### PR TITLE
Restrict Cloud Agent subagents to Grok 4.6 and Composer 2.5

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,6 +1,12 @@
 {
   "hooks": {
-    "afterFileEdit": [{ "command": "pnpm run fix" }]
+    "afterFileEdit": [{ "command": "pnpm run fix" }],
+    "subagentStart": [
+      {
+        "command": "node .cursor/hooks/allow-subagent-model.mjs",
+        "failClosed": true
+      }
+    ]
   },
   "version": 1
 }

--- a/.cursor/hooks/allow-subagent-model.mjs
+++ b/.cursor/hooks/allow-subagent-model.mjs
@@ -1,0 +1,98 @@
+import { readFileSync } from "node:fs";
+
+const DENY_MESSAGE_SUFFIX = "Only Grok 4.6 and Composer 2.5 are allowed.";
+const GROK_4_6_PATTERN = /(?:^|[^a-z0-9])grok-4(?:\.|-)6(?:[^0-9]|$)/u;
+const COMPOSER_2_5_PATTERN = /(?:^|[^a-z0-9])composer-2(?:\.|-)5(?:[^0-9]|$)/u;
+
+const writeDecision = (permission, modelLabel = "unknown") => {
+  if (permission === "allow") {
+    process.stdout.write(JSON.stringify({ permission: "allow" }));
+    return;
+  }
+
+  process.stdout.write(
+    JSON.stringify({
+      permission: "deny",
+      user_message: `Blocked subagent model: ${modelLabel}. ${DENY_MESSAGE_SUFFIX}`,
+    })
+  );
+};
+
+const extractModelId = (value) => {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    "id" in value &&
+    typeof value.id === "string"
+  ) {
+    return value.id;
+  }
+
+  return "";
+};
+
+const normalizeModelId = (value) => {
+  const raw = extractModelId(value);
+  if (raw === "") {
+    return "";
+  }
+
+  return raw
+    .trim()
+    .toLowerCase()
+    .replaceAll("_", "-")
+    .replaceAll(/\s+/g, "-")
+    .replace(/\[.*$/u, "")
+    .replaceAll(/-{2,}/g, "-")
+    .replaceAll(/^-+|-+$/g, "");
+};
+
+const isAllowedFamily = (normalized) =>
+  GROK_4_6_PATTERN.test(normalized) || COMPOSER_2_5_PATTERN.test(normalized);
+
+const isAllowedSubagentEvent = (event) => {
+  const subagentModel = normalizeModelId(event.subagent_model);
+
+  if (subagentModel === "inherit") {
+    const parentFromId = normalizeModelId(event.model_id);
+    const parentModel =
+      parentFromId === "" ? normalizeModelId(event.model) : parentFromId;
+    return isAllowedFamily(parentModel);
+  }
+
+  return isAllowedFamily(subagentModel);
+};
+
+const labelFor = (event) => {
+  const subagentModel = normalizeModelId(event.subagent_model);
+  return subagentModel === "" ? "unknown" : subagentModel;
+};
+
+const parseEvent = (input) => {
+  const parsed = JSON.parse(input);
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new TypeError("Hook input must be a JSON object");
+  }
+
+  return parsed;
+};
+
+const main = () => {
+  try {
+    const event = parseEvent(readFileSync(0, "utf-8"));
+    if (isAllowedSubagentEvent(event)) {
+      writeDecision("allow");
+      return;
+    }
+
+    writeDecision("deny", labelFor(event));
+  } catch {
+    writeDecision("deny", "unknown");
+  }
+};
+
+main();

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -6,7 +6,13 @@ const config: KnipConfig = {
   // Nested `dotenvx` / `pnpm` wrappers are not fully resolved by the script parser.
   // The tanstack-entry stub is an alias target loaded by the Vitest bundler
   // (see vitest.config.ts resolve.alias); Knip cannot trace that reference.
-  entry: ["auth.ts", "scripts/**/*.ts", "vitest/tanstack-entry-stub.ts"],
+  // Cursor Project Hooks invoke `.cursor/hooks/*.mjs` by command path, not imports.
+  entry: [
+    "auth.ts",
+    "scripts/**/*.ts",
+    "vitest/tanstack-entry-stub.ts",
+    ".cursor/hooks/**/*.mjs",
+  ],
   vitest: {
     config: ["vitest.config.ts", "vitest.persistence.config.ts"],
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 関連Issue

Closes #271

## 実装概要

既存の `.cursor/hooks.json` に `subagentStart` hook を追加し、Cursor が Task で起動する subagent の `subagent_model` を検査する。

- 許可: Grok 4.6 系（例: `cursor-grok-4.6-medium`）、Composer 2.5 系（例: `composer-2.5` / `composer-2.5-fast`）
- 拒否: Claude / Gemini / GPT などそれ以外、空文字、未知モデル、壊れた JSON
- 既存の `afterFileEdit`（`pnpm run fix`）は維持

`failClosed: true` を該hookだけに付け、スクリプト自身も parse 失敗時に deny JSON を返す。

`inherit` は親の `model_id` / `model` を同じ規則で評価する。親が許可ファミリなら通す。

Knip は Cursor が command path で呼ぶ `.cursor/hooks/*.mjs` を辿れないため、entry に追加した。

## 主な実装上の判断

- 公式 `subagentStart` の例値 `claude-sonnet-4-20250514`、このリポの Custom subagent `cursor-grok-4.6-medium`、Cloud Agent の Task slug（`cursor-grok-4.6-*` / `composer-2.5`）をマッチ根拠にした
- 表記揺れ対策として小文字化・空白/アンダースコアのハイフン化・`[fast=false]` の除去を行い、`grok-4.6` / `grok-4-6` と `composer-2.5` をトークンとして判定する（`grok-4.5` や `composer-2` は許可しない）
- デフォルト fail-open を避けるため `failClosed: true` を使う
- `inherit` を無条件許可しない。親が Claude 等なら deny する

## 受け入れ条件の検証

| 受け入れ条件 | 結果 | 検証方法・証跡 |
| ------------ | :---: | -------------- |
| writable environment で起動される subagent について、Grok 4.6 / Composer 2.5 以外を Project Hook で拒否できる | ✅ | hook スクリプトへ stdin で payload を渡し、Claude / Gemini / GPT / grok-4.5 / composer-2 / 空 / 不正 JSON が `permission: "deny"` になることを確認した。Cloud Agent 上の実起動確認は今回の指示により未実施 |
| 許可モデルの判定は実際の Cursor の `subagent_model` 値に合わせている | ✅ | `cursor-grok-4.6-medium` / `cursor-grok-4.6-high-fast` / `composer-2.5` / `composer-2.5-fast` / `composer-2.5[fast=false]` が allow |
| 未知モデルは fail-closed で拒否される | ✅ | 空・未知 slug・不正 JSON が deny |
| hook 自身の異常系で意図せず第三者モデルを許可しない | ✅ | 不正 JSON / 非object は deny。hooks.json に `failClosed: true` |
| ローカル Agent の通常利用を壊さない | ✅ | `afterFileEdit` を維持。`inherit` + 許可ファミリの親は allow |

## 自動検証

- [x] `pnpm run check`
- [ ] `pnpm run typecheck`
- [ ] `pnpm run test`
- [ ] `pnpm run test:persistence`
- [ ] `pnpm run build`

アプリケーションコードは変更していない。`pnpm run check` と `pnpm run knip`（pre-push）を実行した。

## 仕様との差異

なし。Cloud Agent 実環境での hook 発火確認は、今回の作業指示により実施していない。Issue 注意事項どおり、read-only exploratory phase では hook が走らない。

## 補足

Issue には `spec:ready` が付いていなかった。本文に未解決事項はなく、実装指示に従って進めた。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a085d3-8b83-71ee-a882-128dfb5ebe62?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a085d3-8b83-71ee-a882-128dfb5ebe62&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

