### PR TITLE
一覧の正規URLを /bookmarks に統一する

### DIFF
--- a/src/features/app-shell/components/app-header.tsx
+++ b/src/features/app-shell/components/app-header.tsx
@@ -122,14 +122,18 @@ export const AppHeader = ({
         nextQ === ""
           ? buildListSearch(current, { clearQ: true })
           : buildListSearch(current, { q: nextQ }),
-      to: "/",
+      to: "/bookmarks",
     });
   };
 
   return (
     <header className={shellHeader}>
       <div className={headerLead}>
-        <StyledLink to="/" search={defaultBookmarkSearch} visual="brand">
+        <StyledLink
+          to="/bookmarks"
+          search={defaultBookmarkSearch}
+          visual="brand"
+        >
           Pantry
         </StyledLink>
 

--- a/src/features/auth/components/passkey/sign-in.tsx
+++ b/src/features/auth/components/passkey/sign-in.tsx
@@ -84,7 +84,7 @@ export const PasskeySignIn = ({
       }
 
       if (data !== null && data !== undefined) {
-        await router.navigate({ to: redirect ?? "/" });
+        await router.navigate({ to: redirect ?? "/bookmarks" });
       }
     })();
 
@@ -115,7 +115,7 @@ export const PasskeySignIn = ({
           return;
         }
 
-        await router.navigate({ to: redirect ?? "/" });
+        await router.navigate({ to: redirect ?? "/bookmarks" });
       } catch {
         setErrorMessage(getPasskeySignInErrorMessage({}));
       } finally {

--- a/src/features/auth/passkey-ui.source.test.ts
+++ b/src/features/auth/passkey-ui.source.test.ts
@@ -24,7 +24,7 @@ describe("passkey UI contracts", () => {
     );
     expect(signIn).toContain("パスキーでログイン");
     expect(signIn).toContain("または");
-    expect(signIn).toContain('to: redirect ?? "/"');
+    expect(signIn).toContain('to: redirect ?? "/bookmarks"');
     expect(signIn).toContain("signIn.passkey({");
     expect(signIn).toContain("autoFill: true");
     expect(signIn).toContain("WebAuthnAbortService.cancelCeremony()");

--- a/src/features/bookmarks/components/bookmark-delete-dialog.tsx
+++ b/src/features/bookmarks/components/bookmark-delete-dialog.tsx
@@ -55,7 +55,7 @@ export const BookmarkDeleteDialog = ({
         await navigate({
           search: listSearch,
           state: { bookmarkDeleted: true },
-          to: "/",
+          to: "/bookmarks",
         });
       } catch (error) {
         const message = getDeleteBookmarkErrorMessage(error);

--- a/src/features/bookmarks/components/bookmark-detail-content.tsx
+++ b/src/features/bookmarks/components/bookmark-detail-content.tsx
@@ -57,7 +57,7 @@ export const BookmarkDetailContent = ({
 }) => (
   <>
     <nav className={workbenchNav}>
-      <StyledLink to="/" search={listSearch} visual="accent">
+      <StyledLink to="/bookmarks" search={listSearch} visual="accent">
         <ArrowLeft size={16} aria-hidden /> 一覧へ戻る
       </StyledLink>
     </nav>
@@ -81,7 +81,7 @@ export const BookmarkDetailContent = ({
         {bookmark.tagNames.map((name) => (
           <li key={name}>
             <Link
-              to="/"
+              to="/bookmarks"
               search={buildListBackSearch([name])}
               className={tagChip({ visual: "link" })}
             >

--- a/src/features/bookmarks/components/bookmark-list-results.tsx
+++ b/src/features/bookmarks/components/bookmark-list-results.tsx
@@ -48,7 +48,7 @@ export const BookmarkListResults = ({
           title="条件に合うブックマークがありません"
           action={
             <StyledLink
-              to="/"
+              to="/bookmarks"
               search={buildListSearch(search, {
                 clearQ: hasQ,
                 clearTags: hasTags,

--- a/src/features/bookmarks/components/bookmark-list-toolbar.tsx
+++ b/src/features/bookmarks/components/bookmark-list-toolbar.tsx
@@ -63,7 +63,7 @@ export const ListToolbar = ({
   readonly search: BookmarkSearchSchema;
   readonly shelfTags: ShelfTag[];
 }) => {
-  const navigate = useNavigate({ from: "/" });
+  const navigate = useNavigate({ from: "/bookmarks/" });
 
   const selectedTags = search.tags ?? [];
   const addableTags = shelfTags.filter(
@@ -73,7 +73,7 @@ export const ListToolbar = ({
   const patchSearch = (patch: BookmarkSearchPatch) => {
     void navigate({
       search: buildListSearch(search, patch),
-      to: "/",
+      to: "/bookmarks",
     });
   };
 

--- a/src/features/bookmarks/lib/bookmark-list-scroll-session.test.ts
+++ b/src/features/bookmarks/lib/bookmark-list-scroll-session.test.ts
@@ -117,7 +117,7 @@ describe("bookmark list scroll session", () => {
   });
 
   test("ルーターの scroll restoration は一覧 pathname では動かさない", () => {
-    expect(shouldRestoreRouterScroll({ pathname: "/" })).toBeFalsy();
+    expect(shouldRestoreRouterScroll({ pathname: "/bookmarks" })).toBeFalsy();
     expect(
       shouldRestoreRouterScroll({ pathname: "/bookmarks/new" })
     ).toBeTruthy();

--- a/src/features/bookmarks/lib/bookmark-list-scroll-session.ts
+++ b/src/features/bookmarks/lib/bookmark-list-scroll-session.ts
@@ -46,4 +46,4 @@ export const clearBookmarkListScroll = (): void => {
  */
 export const shouldRestoreRouterScroll = (location: {
   readonly pathname: string;
-}): boolean => location.pathname !== "/";
+}): boolean => location.pathname !== "/bookmarks";

--- a/src/features/bookmarks/lib/query-ownership.test.ts
+++ b/src/features/bookmarks/lib/query-ownership.test.ts
@@ -11,7 +11,7 @@ function readSource(relativePath: string): string {
 
 describe("bookmark list query ownership", () => {
   const factoryConsumers = [
-    "routes/_protected/index.tsx",
+    "routes/_protected/bookmarks/index.tsx",
     "features/bookmarks/hooks/use-bookmark-list-pagination.ts",
   ];
   const uiConsumers = [
@@ -82,7 +82,7 @@ describe("bookmark list query ownership", () => {
     expect(hook).not.toContain("searchToQueryInput");
     expect(hook).not.toContain("tagNames");
 
-    const index = readSource("routes/_protected/index.tsx");
+    const index = readSource("routes/_protected/bookmarks/index.tsx");
     expect(index).toContain("loaderDeps: ({ search }) => search");
     expect(index).not.toContain("bookmarkListLoaderDeps");
   });

--- a/src/features/navigation/lib/bookmark-search.ts
+++ b/src/features/navigation/lib/bookmark-search.ts
@@ -9,6 +9,10 @@ export const bookmarkSearchSchema = v.object({
 
 export type BookmarkSearchSchema = v.InferOutput<typeof bookmarkSearchSchema>;
 
+/** 一覧 search の検証正本。`/bookmarks` 一覧と `/` 正規化リダイレクトの両ルートで共用する。 */
+export const validateBookmarkSearch = (search: unknown): BookmarkSearchSchema =>
+  v.parse(bookmarkSearchSchema, search);
+
 /** 詳細・編集・新規に載せる一覧条件。既定値は省略し、一覧 URL へ戻すときに復元する。 */
 export const bookmarkDetailSearchSchema = v.object({
   q: v.optional(v.string()),

--- a/src/features/tags/components/shelf-nav.tsx
+++ b/src/features/tags/components/shelf-nav.tsx
@@ -94,7 +94,7 @@ export const ShelfNav = ({
   return (
     <nav className={shelfNav} aria-label="タグ">
       <Link
-        to="/"
+        to="/bookmarks"
         search={allShelfSearch(listSearch)}
         className={shelfItem}
         data-selected={allSelected ? "true" : "false"}
@@ -113,7 +113,7 @@ export const ShelfNav = ({
         return (
           <Link
             key={tag.id}
-            to="/"
+            to="/bookmarks"
             search={tagShelfSearch(tag.name, listSearch)}
             className={shelfItem}
             data-selected={selected ? "true" : "false"}

--- a/src/features/tags/components/tag-detail.tsx
+++ b/src/features/tags/components/tag-detail.tsx
@@ -96,7 +96,7 @@ export const TagDetail = ({
 
       <div className={detailActions}>
         <Link
-          to="/"
+          to="/bookmarks"
           search={tagShelfSearch(tag.name)}
           className={button({ visual: "accent" })}
         >

--- a/src/features/tags/components/tag-table.tsx
+++ b/src/features/tags/components/tag-table.tsx
@@ -165,7 +165,7 @@ export const TagTable = ({
                     aria-hidden="true"
                   />
                   <Link
-                    to="/"
+                    to="/bookmarks"
                     search={tagShelfSearch(tag.name)}
                     aria-label={tag.name}
                     className={dataTableRowLink}

--- a/src/routes/_protected.tsx
+++ b/src/routes/_protected.tsx
@@ -20,6 +20,16 @@ import { getRpcClient } from "../rpc/runtime-client";
 
 export const Route = createFileRoute("/_protected")({
   beforeLoad: async ({ location }) => {
+    // 一覧の正規化は認証状態より優先する。`/` は未認証でも `/bookmarks` へ恒久リダイレクトし、
+    // ログイン後の戻り先が `/` を再経由しないようにする。
+    // search は raw のまま引き継ぎ、未知・不正パラメータの扱いは一覧ルートの validateSearch に委譲する。
+    if (location.pathname === "/") {
+      throw redirect({
+        href: `/bookmarks${location.searchStr}`,
+        statusCode: 301,
+      });
+    }
+
     const client = await getRpcClient();
     const session = await client.auth.session();
 
@@ -27,7 +37,9 @@ export const Route = createFileRoute("/_protected")({
       throw redirect({
         to: "/sign-in",
         search: {
-          redirect: isInternalPath(location.href) ? location.href : "/",
+          redirect: isInternalPath(location.href)
+            ? location.href
+            : "/bookmarks",
         },
       });
     }
@@ -48,7 +60,10 @@ export const Route = createFileRoute("/_protected")({
 
 function Layout() {
   const { shelfTagsPromise } = Route.useLoaderData();
-  const indexSearch = useSearch({ from: "/_protected/", shouldThrow: false });
+  const indexSearch = useSearch({
+    from: "/_protected/bookmarks/",
+    shouldThrow: false,
+  });
   const detailSearch = useSearch({
     from: "/_protected/bookmarks/$id/",
     shouldThrow: false,

--- a/src/routes/_protected/bookmarks/$id/edit.tsx
+++ b/src/routes/_protected/bookmarks/$id/edit.tsx
@@ -138,7 +138,7 @@ function RouteComponent() {
 
         <h1>このブックマークは見つかりません</h1>
 
-        <StyledLink to="/" search={listSearch} visual="accent">
+        <StyledLink to="/bookmarks" search={listSearch} visual="accent">
           一覧へ戻る
         </StyledLink>
       </section>
@@ -174,7 +174,7 @@ function RouteComponent() {
         >
           <ArrowLeft size={16} aria-hidden /> 詳細へ戻る
         </StyledLink>
-        <StyledLink to="/" search={listSearch} visual="accent">
+        <StyledLink to="/bookmarks" search={listSearch} visual="accent">
           <ArrowLeft size={16} aria-hidden /> 一覧へ戻る
         </StyledLink>
       </nav>

--- a/src/routes/_protected/bookmarks/$id/index.tsx
+++ b/src/routes/_protected/bookmarks/$id/index.tsx
@@ -47,7 +47,7 @@ function DetailFallback({ error, resetErrorBoundary }: FallbackProps) {
         title="このブックマークは見つかりません"
         action={
           <StyledLink
-            to="/"
+            to="/bookmarks"
             search={listSearchFromDetail({ tags })}
             visual="accent"
           >

--- a/src/routes/_protected/bookmarks/index.tsx
+++ b/src/routes/_protected/bookmarks/index.tsx
@@ -1,15 +1,43 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
-import * as v from "valibot";
+import type { ErrorComponentProps } from "@tanstack/react-router";
+import {
+  createFileRoute,
+  ErrorComponent,
+  getRouteApi,
+} from "@tanstack/react-router";
 
-import { bookmarkSearchSchema } from "../../../features/navigation/lib/bookmark-search";
+import { BookmarkList } from "../../../features/bookmarks/components/bookmark-list";
+import { bookmarkListQueryOptions } from "../../../features/bookmarks/lib/bookmark-list-query-options";
+import { validateBookmarkSearch } from "../../../features/navigation/lib/bookmark-search";
+import { PantryMotion } from "../../../shared/components/pantry-motion";
+
+const protectedRouteApi = getRouteApi("/_protected");
 
 export const Route = createFileRoute("/_protected/bookmarks/")({
-  validateSearch: (search) => v.parse(bookmarkSearchSchema, search),
-  beforeLoad: ({ search }) => {
-    throw redirect({
-      to: "/",
-      search,
-      statusCode: 301,
-    });
+  validateSearch: validateBookmarkSearch,
+  loaderDeps: ({ search }) => search,
+  loader: async ({ deps, context }) => {
+    // Component が同じ infinite query options を読む。待たずに流すことで streaming を維持する。
+    void context.queryClient.prefetchInfiniteQuery(
+      bookmarkListQueryOptions(deps)
+    );
+
+    return {};
   },
+  component: RouteComponent,
+  errorComponent: BookmarkPageFallbackComponent,
 });
+
+function BookmarkPageFallbackComponent({ error }: ErrorComponentProps) {
+  return <ErrorComponent error={error} />;
+}
+
+function RouteComponent() {
+  const search = Route.useSearch();
+  const { shelfTagsPromise } = protectedRouteApi.useLoaderData();
+
+  return (
+    <PantryMotion kind="fade-up">
+      <BookmarkList search={search} shelfTagsPromise={shelfTagsPromise} />
+    </PantryMotion>
+  );
+}

--- a/src/routes/_protected/bookmarks/new/index.tsx
+++ b/src/routes/_protected/bookmarks/new/index.tsx
@@ -125,7 +125,7 @@ function RouteComponent() {
   return (
     <section className={workbench} aria-label="ブックマーク新規作成">
       <nav className={workbenchNav}>
-        <StyledLink to="/" search={listSearch} visual="accent">
+        <StyledLink to="/bookmarks" search={listSearch} visual="accent">
           <ArrowLeft size={16} aria-hidden /> 一覧へ戻る
         </StyledLink>
       </nav>

--- a/src/routes/_protected/index.stories.tsx
+++ b/src/routes/_protected/index.stories.tsx
@@ -12,7 +12,7 @@ import type { ShelfTag } from "../../features/tags/lib/tag-shelf";
 import { orpc } from "../../rpc/query";
 import preview from "../../storybook/preview";
 import { Route as ProtectedLayoutRoute } from "../_protected";
-import { Route as ListFileRoute } from "./index";
+import { Route as ListFileRoute } from "./bookmarks/index";
 
 const storyQueryClient = new QueryClient({
   defaultOptions: {
@@ -80,7 +80,7 @@ const storyProtectedLayout = createRoute({
 
 const storyListRoute = createRoute({
   getParentRoute: () => storyProtectedLayout as never,
-  path: "/",
+  path: "/bookmarks",
   validateSearch: ListFileRoute.options.validateSearch!,
   loaderDeps: ListFileRoute.options.loaderDeps!,
   loader: ListFileRoute.options.loader!,
@@ -247,7 +247,7 @@ function listQuery(query: Partial<BookmarkSearchSchema>) {
     tanstack: {
       router: {
         route: storyListRoute,
-        path: "/" as const,
+        path: "/bookmarks" as const,
         query,
         context: {
           queryClient: storyQueryClient,
@@ -264,7 +264,7 @@ const meta = preview.meta({
     tanstack: {
       router: {
         route: storyListRoute,
-        path: "/" as const,
+        path: "/bookmarks" as const,
         context: {
           queryClient: storyQueryClient,
         },

--- a/src/routes/_protected/index.tsx
+++ b/src/routes/_protected/index.tsx
@@ -1,44 +1,14 @@
-import type { ErrorComponentProps } from "@tanstack/react-router";
-import {
-  createFileRoute,
-  ErrorComponent,
-  getRouteApi,
-} from "@tanstack/react-router";
-import * as v from "valibot";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
-import { BookmarkList } from "../../features/bookmarks/components/bookmark-list";
-import { bookmarkListQueryOptions } from "../../features/bookmarks/lib/bookmark-list-query-options";
-import { bookmarkSearchSchema } from "../../features/navigation/lib/bookmark-search";
-import { PantryMotion } from "../../shared/components/pantry-motion";
-
-const protectedRouteApi = getRouteApi("/_protected");
+import { validateBookmarkSearch } from "../../features/navigation/lib/bookmark-search";
 
 export const Route = createFileRoute("/_protected/")({
-  validateSearch: (search) => v.parse(bookmarkSearchSchema, search),
-  loaderDeps: ({ search }) => search,
-  loader: async ({ deps, context }) => {
-    // Component が同じ infinite query options を読む。待たずに流すことで streaming を維持する。
-    void context.queryClient.prefetchInfiniteQuery(
-      bookmarkListQueryOptions(deps)
-    );
-
-    return {};
+  validateSearch: validateBookmarkSearch,
+  beforeLoad: ({ search }) => {
+    throw redirect({
+      to: "/bookmarks",
+      search,
+      statusCode: 301,
+    });
   },
-  component: RouteComponent,
-  errorComponent: BookmarkPageFallbackComponent,
 });
-
-function BookmarkPageFallbackComponent({ error }: ErrorComponentProps) {
-  return <ErrorComponent error={error} />;
-}
-
-function RouteComponent() {
-  const search = Route.useSearch();
-  const { shelfTagsPromise } = protectedRouteApi.useLoaderData();
-
-  return (
-    <PantryMotion kind="fade-up">
-      <BookmarkList search={search} shelfTagsPromise={shelfTagsPromise} />
-    </PantryMotion>
-  );
-}

--- a/src/routes/_protected/settings/index.tsx
+++ b/src/routes/_protected/settings/index.tsx
@@ -94,7 +94,11 @@ function RouteComponent() {
         </StyledButton>
       </section>
 
-      <StyledLink to="/" search={defaultBookmarkSearch} visual="accent">
+      <StyledLink
+        to="/bookmarks"
+        search={defaultBookmarkSearch}
+        visual="accent"
+      >
         <ArrowLeft size={16} aria-hidden /> 一覧へ戻る
       </StyledLink>
     </div>

--- a/src/routes/sign-in/index.tsx
+++ b/src/routes/sign-in/index.tsx
@@ -29,7 +29,7 @@ function RouteComponent() {
     const { error } = await authClient.signIn.email({ email, password });
 
     if (error === null) {
-      await router.navigate({ to: redirect ?? "/" });
+      await router.navigate({ to: redirect ?? "/bookmarks" });
       return null;
     }
 

--- a/src/shared/components/styled-link/index.stories.tsx
+++ b/src/shared/components/styled-link/index.stories.tsx
@@ -33,7 +33,7 @@ type Story = StoryObj<typeof meta>;
 export const Default = {
   args: {
     size: "md",
-    to: "/",
+    to: "/bookmarks",
     visual: "plain",
   },
   render: (args) => <StyledLink {...args}>設定</StyledLink>,
@@ -41,7 +41,7 @@ export const Default = {
 
 export const Accent = {
   args: {
-    to: "/",
+    to: "/bookmarks",
     visual: "accent",
   },
   render: (args) => <StyledLink {...args}>戻る</StyledLink>,
@@ -49,7 +49,7 @@ export const Accent = {
 
 export const Muted = {
   args: {
-    to: "/",
+    to: "/bookmarks",
     visual: "muted",
   },
   render: (args) => <StyledLink {...args}>example.com</StyledLink>,
@@ -57,7 +57,7 @@ export const Muted = {
 
 export const Brand = {
   args: {
-    to: "/",
+    to: "/bookmarks",
     visual: "brand",
   },
   render: (args) => <StyledLink {...args}>Pantry</StyledLink>,

--- a/src/shared/components/styled-link/index.tsx
+++ b/src/shared/components/styled-link/index.tsx
@@ -177,7 +177,7 @@ const CreatedLinkComponent = createLink(BasicLinkComponent);
  * ```
  * <StyledLink to="/settings">設定</StyledLink>
  * <StyledLink to="/settings" visual="plain" size="md">設定</StyledLink>
- * <StyledLink to="/" search={defaultBookmarkSearch} visual="brand">Pantry</StyledLink>
+ * <StyledLink to="/bookmarks" search={defaultBookmarkSearch} visual="brand">Pantry</StyledLink>
  * <StyledLink to=".." visual="accent">戻る</StyledLink>
  * <StyledLink to="/bookmarks/$id" params={{ id }} visual="muted">example.com</StyledLink>
  * ```


### PR DESCRIPTION
Closes #273

## 実装方法

ルートの「役割」を入れ替えた。ルートファイルのパスは不変のため `routeTree.gen.ts` に変更はない。

- **`/` (`src/routes/_protected/index.tsx`)**: 一覧コンポーネントを取り除き、`validateSearch`（`bookmarkSearchSchema`）と `beforeLoad` での `redirect({ to: "/bookmarks", search, statusCode: 301 })` のみを持つリダイレクトルートに。既存の `/bookmarks` → `/` リダイレクトと対称な実装。
- **`/bookmarks` (`src/routes/_protected/bookmarks/index.tsx`)**: 従来 `_protected/index.tsx` にあった一覧ルート（`validateSearch` / `loaderDeps` / `loader` / `component` / `errorComponent`）をそのまま移設。一覧のロジック・UI・search parameter 仕様は無変更。
- **認証より先の正規化 (`src/routes/_protected.tsx`)**: TanStack Router は親 `beforeLoad` を先に実行するため、`_protected.beforeLoad` 冒頭で `location.pathname === "/"` を検出したら `redirect({ href: "/bookmarks" + location.searchStr, statusCode: 301 })` を throw する。未認証ユーザーは `/` → `/bookmarks` 正規化 → `/sign-in?redirect=/bookmarks?...` の順になり、ログイン後は `/` を再経由せず `/bookmarks` へ戻る。未ログイン時の戻り先フォールバック既定も `/bookmarks` に変更。
  - `/` 側では search を raw のまま引き継ぎ、未知・不正パラメータの扱い（欠落 / エラー）は移動先の一覧ルートの `validateSearch` に一元化。`/` で再検証すると TanStack の raw search では単一タグが文字列になるなど既存一覧と異なる例外経路になるため。実装中に発見し、計画コメントの案（`_protected` でも `v.parse`）から変更した。
- **導線の一括置換（`to: "/"` → `to: "/bookmarks"`）**: `app-header`（ブランド・検索 commit）、`shelf-sidebar`（ブランド）、`shelf-nav`（すべて / タグ）、`tag-detail` / `tag-table`（タグ → 一覧）、`bookmark-list-results`（条件クリア）、`bookmark-detail-content`（一覧へ戻る・タグチップ）、`bookmark-delete-dialog`（削除後遷移）、`bookmark-list-toolbar`（`useNavigate({ from: "/bookmarks/" })`）、`bookmarks/$id`、`bookmarks/$id/edit`、`bookmarks/new`、`settings`（一覧へ戻る）。
- **ログイン後の既定遷移先**: `sign-in/index.tsx` と `passkey/sign-in.tsx` の `redirect ?? "/"` を `redirect ?? "/bookmarks"` に変更。
- **スクロール復元**: `shouldRestoreRouterScroll` の一覧判定を `pathname !== "/"` → `pathname !== "/bookmarks"` に変更（router.tsx の scrollRestoration は一覧で無効化する意図を維持）。
- **Stories / テスト**: `_protected/index.stories.tsx` の明示ルートツリーを `path: "/bookmarks"` に載せ替え、`query-ownership.test.ts` の参照パスを新ルートファイルへ更新。

## 受け入れ条件の検証

- [x] 認証済み状態で `/` にアクセスすると、search parameter を維持したまま `/bookmarks` へ恒久的にリダイレクトされる
  - 実機確認（dev サーバー、認証済みセッション）: `/?q=react&sort=updated` → 301 → `/bookmarks?q=react&sort=updated&tagMode=and` → 一覧 200
- [x] 未認証状態で `/` にアクセスすると、最初に search parameter を維持した `/bookmarks` へ正規化され、その後 `/sign-in` へ遷移する
  - 実機確認: `/` → 301 `/bookmarks?sort=newest&tagMode=and` → 307 `/sign-in?redirect=%2Fbookmarks%3F...`
- [x] 未認証状態で `/` から認証フローに入ってログインすると、`/` を再経由せず `/bookmarks` に戻る
  - sign-in の戻り先は `/bookmarks?...`（正規化済み URL）であり、ログイン後の navigate が直接 `/bookmarks` を指す
- [x] `/bookmarks` に直接アクセスした場合は `/` へリダイレクトされず、ブックマーク一覧が表示される
  - 実機確認: `/bookmarks` → 200（一覧 HTML を確認）
- [x] 一覧内の検索・タグ選択・並び順などURLで表現される状態は `/bookmarks` 上で維持される
  - toolbar / shelf nav / 検索 commit はすべて `buildListSearch` を `to: "/bookmarks"` で送る
- [x] 一覧へ戻る導線、ブランドリンク、タグから一覧へ移動する導線、削除後遷移、ログイン後の既定遷移先が `/bookmarks` を使用する
  - 上記「導線の一括置換」参照

### エッジケース・制約の確認

- 未知パラメータ（`?junk=1`）: 既存と同様 URL に残存し無視される（canonicalization 307 の挙動は既存の一覧と同一）
- 不正なタグ（`?tags=reading`）: 301 → `/bookmarks?tags=reading` で既存の search validation によりエラー扱い（旧 `/` 上の挙動と整合）
- 末尾スラッシュ `/bookmarks/`: ルーターの 307 正規化で `/bookmarks` と同等に扱われる
- `routeTree.gen.ts` は無変更、search schema・一覧 UI・既存一覧挙動に変更なし

## 検証結果

- `pnpm run typecheck` ✅ / `pnpm run test`（404/404）✅ / `pnpm run check` ✅ / `pnpm run build` ✅ / `pnpm run lint:markup` ✅
- pre-commit（Ultracite・markuplint・typecheck）/ pre-push（betterleaks・knip）フック通過

実装計画: https://github.com/koralle/pantry/issues/273#issuecomment-5606035173